### PR TITLE
chore: ignore .omx/ local tooling dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.egg-info/
 dist/
 .team/
+.omx/


### PR DESCRIPTION
## Summary

One-line addition to `.gitignore` so the `.omx/` local tooling directory stops showing up as untracked.

## Why

`.omx/` is generated by local tooling and shouldn't be committed. Discovered while running `git status` and seeing the dir as untracked.

## Verification

- `git status` clean after the change (no untracked `.omx/` shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)