### PR TITLE
chore(ci): bump release workflow actions to Node 24 majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout (full history for ancestor check)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag_name || github.ref }}
@@ -53,7 +53,7 @@ jobs:
           echo "Tag $TAG is on main"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
 
@@ -95,7 +95,7 @@ jobs:
           echo "Extracted $(wc -l < release-notes.md) lines from CHANGELOG"
 
       - name: Upload release notes artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-notes-${{ steps.tag.outputs.tag }}
           path: release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- `.github/workflows/release.yml`: bump action pins to Node 24 majors — `actions/checkout@v4`→`@v6`, `actions/upload-artifact@v4`→`@v5`, `astral-sh/setup-uv@v5`→`@v6`. Resolves Node 20 deprecation annotation surfaced on the v1.7.0 release run. setup-uv@v8 was skipped because it removed floating major tags (`@v8` no longer resolves) — staying on `@v6` keeps the workflow low-maintenance. `tests/test_release_workflow.sh` assertions updated.
 
 ## [1.7.0] - 2026-04-26
 ### Added

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -131,8 +131,9 @@ done
 echo "-- T5: no third-party publish actions"
 check_neg "no softprops/action-gh-release" grep -q 'softprops/action-gh-release' "$WORKFLOW"
 check     "uses gh release create"         grep -q 'gh release create' "$WORKFLOW"
-check     "checkout pinned to v4"          grep -q 'actions/checkout@v4' "$WORKFLOW"
-check     "setup-uv pinned to v5"          grep -q 'astral-sh/setup-uv@v5' "$WORKFLOW"
+check     "checkout pinned to v6"          grep -q 'actions/checkout@v6' "$WORKFLOW"
+check     "upload-artifact pinned to v5"   grep -q 'actions/upload-artifact@v5' "$WORKFLOW"
+check     "setup-uv pinned to v6"          grep -q 'astral-sh/setup-uv@v6' "$WORKFLOW"
 
 echo "-- T6: semver regex acceptance"
 check "accepts v1.2.3"        valid_semver_tag "v1.2.3"


### PR DESCRIPTION
## Summary

Bump GitHub Actions pins in `.github/workflows/release.yml` to majors that ship Node 24:

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v5` |
| `astral-sh/setup-uv` | `@v5` | `@v6` |

Resolves the Node 20 deprecation annotation that surfaced on the v1.7.0 release run (https://github.com/frankyxhl/trinity/actions/runs/24948191000):

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/upload-artifact@v4, astral-sh/setup-uv@v5. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Why these specific majors

- **`actions/checkout@v6`**: v5 added Node 24 (only change). v6 added a credentials-persistence improvement. No API breaks for our usage.
- **`actions/upload-artifact@v5`**: v5 added Node 24. v6/v7 are also available but bring additional changes worth not bundling — going one major at a time. We can re-evaluate later.
- **`astral-sh/setup-uv@v6`**: v6 added Node 24 + a `cache-dependency-glob` default change (covers `pyproject.toml` now). **Skipped v8** because v8 removed floating major tags entirely (`@v8` no longer resolves — they only publish immutable per-version tags now as supply-chain hardening). Pinning to specific `v8.x.x` would mean manual bumps per release; staying on `@v6` keeps things low-maintenance.

## Verification

- `make verify-built` ✅
- `make test` ✅ — 53/53 (was 52, +1 for the newly-asserted upload-artifact pin)
- `make lint` ✅
- End-to-end CI validation happens on next tag push (no easy dry-run path; if anything breaks, `workflow_dispatch` retry is available)

## Related

- Surfaced on v1.7.0 release run (TRN-2006 first end-to-end validation)
- Sibling PR for the cache annotation: see `chore/fix-uv-cache-key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)