### PR TITLE
chore(ci): pin uv cache-dependency-glob to Makefile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+          cache-dependency-glob: 'Makefile'
 
       - name: Install dev dependencies (uv → pip fallback)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Changed
 - `.github/workflows/release.yml`: bump action pins to Node 24 majors — `actions/checkout@v4`→`@v6`, `actions/upload-artifact@v4`→`@v5`, `astral-sh/setup-uv@v5`→`@v6`. Resolves Node 20 deprecation annotation surfaced on the v1.7.0 release run. setup-uv@v8 was skipped because it removed floating major tags (`@v8` no longer resolves) — staying on `@v6` keeps the workflow low-maintenance. `tests/test_release_workflow.sh` assertions updated.
 
+### Fixed
+- `.github/workflows/release.yml`: add `cache-dependency-glob: 'Makefile'` to the `setup-uv` step. Resolves the "No file matched to [**/uv.lock,**/requirements*.txt]. The cache will never get invalidated." annotation surfaced on the v1.7.0 release run. Trinity has neither `uv.lock` nor `requirements*.txt`; deps live in `Makefile` (`uv pip install pytest ruff`), so that file is the right cache key.
+
 ## [1.7.0] - 2026-04-26
 ### Added
 - `.github/workflows/release.yml`: tag-push triggers automated GitHub Release publish (TRN-2006). Strict semver glob `v[0-9]+.[0-9]+.[0-9]+` for trigger; `workflow_dispatch` with `tag_name` input for manual retry. Defense-in-depth tag/VERSION validation, tag-must-be-on-main check, CHANGELOG section extraction (fail on empty), least-privilege permissions (global `contents: read`, only the publish job gets `contents: write`). No third-party publish actions — direct `gh release create` only.


### PR DESCRIPTION
## Summary

Add `cache-dependency-glob: 'Makefile'` to the `setup-uv` step in `.github/workflows/release.yml` so the uv cache invalidates on the right signal.

## Why

Annotation on the v1.7.0 release run (https://github.com/frankyxhl/trinity/actions/runs/24948191000):

> No file matched to [**/uv.lock,**/requirements*.txt]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.

Trinity has neither `uv.lock` nor `requirements*.txt`. Dev deps are declared in `Makefile`:

```makefile
setup:
	uv venv && uv pip install pytest ruff
```

Pinning the glob to `Makefile` makes the cache invalidate only when we actually change the deps list — which is the right semantics. Without this, the cache never invalidates and accumulates stale stuff (or, equivalently, never warms up across runs depending on how the action handles the empty-glob case).

## Verification

- `make verify-built` ✅
- `make test` ✅ — 52/52 (no test changes; this PR only touches the workflow yaml + CHANGELOG)
- `make lint` ✅
- End-to-end CI validation happens on next tag push

## Related

- Surfaced on v1.7.0 release run (TRN-2006 first end-to-end validation)
- Sibling PR for the Node 20 deprecation: #6 (`chore/bump-actions-node24`)
- Independent of #6 — touches different lines under the same `setup-uv` step. Whichever lands second gets a clean fast-forward (no conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)