### PR TITLE
fix(ci): skip duplicate tag-push trigger after Path A run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,9 +218,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.verify.outputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            # Designed exit: when Path A pushes a tag via RELEASE_TAG_PAT,
+            # the PAT-driven push triggers this same workflow again via
+            # `on.push.tags`. The duplicate run reaches here, finds the
+            # release already published by the original Path A run, and
+            # exits cleanly instead of failing — keeps the Actions tab
+            # clear of "false-positive" red checks.
+            if [ "$EVENT_NAME" = "push" ]; then
+              echo "Release $TAG already exists. Tag-push trigger is the duplicate from a Path A run that already published. Skipping cleanly."
+              exit 0
+            fi
             echo "::error::Release $TAG already exists. Delete it manually if you intend to recreate."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,14 +222,23 @@ jobs:
         run: |
           set -euo pipefail
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            # Designed exit: when Path A pushes a tag via RELEASE_TAG_PAT,
-            # the PAT-driven push triggers this same workflow again via
-            # `on.push.tags`. The duplicate run reaches here, finds the
-            # release already published by the original Path A run, and
-            # exits cleanly instead of failing — keeps the Actions tab
-            # clear of "false-positive" red checks.
+            # When the trigger is `push.tags` and a release already exists for
+            # this tag, exit cleanly. Two scenarios reach here legitimately:
+            #   1. The duplicate run from a Path A workflow_dispatch that
+            #      already published (RELEASE_TAG_PAT push re-triggers
+            #      `on.push.tags`).
+            #   2. A maintainer Path B re-run where the release was already
+            #      created out-of-band.
+            # Trade-off: if a maintainer force-pushes a tag (overwriting an
+            # earlier tag whose release still exists), this exit-0 silently
+            # skips publishing — but the tag-protection ruleset's "Restrict
+            # updates" rule already prevents force-push for non-bypass actors,
+            # narrowing the risk window to admin-bypass force-push (a clearly
+            # intentional and rare action).
+            # `workflow_dispatch` retry path keeps fail-loud (the operator
+            # explicitly asked to re-publish; tell them it's already done).
             if [ "$EVENT_NAME" = "push" ]; then
-              echo "Release $TAG already exists. Tag-push trigger is the duplicate from a Path A run that already published. Skipping cleanly."
+              echo "Release $TAG already exists; tag-push event with prior release — exiting cleanly."
               exit 0
             fi
             echo "::error::Release $TAG already exists. Delete it manually if you intend to recreate."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
-- `.github/workflows/release.yml` `Publish GitHub Release` step: when Path A's PAT-pushed tag re-triggers the same workflow via `on.push.tags`, the duplicate run now exits cleanly (exit 0) instead of failing with "Release already exists". Surfaced on the v1.8.0 end-to-end run (PAT-pushed tags fire workflows; GITHUB_TOKEN-pushed ones don't — TRN-2007 D11 PAT path introduced this corner case that the original Codex review didn't cover). The `workflow_dispatch` retry path still fails on existing release (intentional — that path explicitly addresses an existing tag and should warn if release was already published). +3 T11 assertions.
+- `.github/workflows/release.yml` `Publish GitHub Release` step: when a `push.tags` event finds a release already published (Path A duplicate-trigger or Path B re-run), the step exits cleanly (exit 0) instead of failing with "Release already exists". Surfaced on the v1.8.0 end-to-end run — TRN-2007 D11's PAT path re-triggers the workflow on every Path A push (PAT-pushed tags fire workflows; GITHUB_TOKEN-pushed ones don't, which the original review missed). The `workflow_dispatch` retry path still fails loud on existing release (operator explicitly asked to re-publish; tell them it's already done). Trade-off documented inline: a maintainer admin-bypass force-push to a tag with a stale release will silently skip publish — the tag-protection ruleset's "Restrict updates" rule narrows the risk window. Multi-model review on the initial fix (Codex PASS / Gemini FAIL on force-push concern) → log message neutralized + 5 T11 assertions covering control-flow placement, not just string presence.
 
 ## [1.8.0] - 2026-04-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- `.github/workflows/release.yml` `Publish GitHub Release` step: when Path A's PAT-pushed tag re-triggers the same workflow via `on.push.tags`, the duplicate run now exits cleanly (exit 0) instead of failing with "Release already exists". Surfaced on the v1.8.0 end-to-end run (PAT-pushed tags fire workflows; GITHUB_TOKEN-pushed ones don't — TRN-2007 D11 PAT path introduced this corner case that the original Codex review didn't cover). The `workflow_dispatch` retry path still fails on existing release (intentional — that path explicitly addresses an existing tag and should warn if release was already published). +3 T11 assertions.
 
 ## [1.8.0] - 2026-04-26
 ### Added

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -250,8 +250,12 @@ check "publish: PAT-checkout gated to one-click"  bash -c "grep -A1 'Checkout ma
 # Duplicate-trigger skip in tag-push path (D13 — PAT-pushed tag re-triggers workflow).
 # When release exists AND event_name == 'push', exit 0 (clean) instead of fail.
 check "publish: EVENT_NAME env in publish step"   bash -c "awk '/Publish GitHub Release/{f=1; next} f && /env:/{e=1; next} e && /EVENT_NAME:/{print; exit}' '$WORKFLOW' | grep -q 'EVENT_NAME:'"
-check "publish: tag-push duplicate skip branch"   grep -qF 'Tag-push trigger is the duplicate' "$WORKFLOW"
+check "publish: literal EVENT_NAME == push check"  grep -qF '[ "$EVENT_NAME" = "push" ]' "$WORKFLOW"
 check "publish: workflow_dispatch retry still fails on existing release"  grep -qF 'Delete it manually if you intend to recreate' "$WORKFLOW"
+# Verify exit 0 (clean skip) lives INSIDE the EVENT_NAME == push branch (not at top level of run script).
+check "publish: exit 0 inside EVENT_NAME push branch"  bash -c "awk '/\\[ \"\\\$EVENT_NAME\" = \"push\" \\]/{f=1; next} f && /^[[:space:]]*fi[[:space:]]*\$/{exit} f && /exit 0/{print; found=1; exit} END{exit !found}' '$WORKFLOW'"
+# Verify the EVENT_NAME branch is itself nested inside the `gh release view` existing-release block.
+check "publish: EVENT_NAME branch nested under gh release view"  bash -c "awk '/gh release view.*GITHUB_REPOSITORY/{f=1; next} f && /\\[ \"\\\$EVENT_NAME\" = \"push\" \\]/{print; exit}' '$WORKFLOW' | grep -q 'EVENT_NAME'"
 
 echo "-- T10: one-click release path"
 # tag_name's required attribute must be false (was true in TRN-2006).

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -247,6 +247,12 @@ check "publish: PAT preflight uses secret"    bash -c "grep -A3 'Verify RELEASE_
 check "publish: checkout uses PAT token"      bash -c "awk '/Checkout main HEAD with PAT/{f=1} f && /token:/{print;exit}' '$WORKFLOW' | grep -qF 'secrets.RELEASE_TAG_PAT'"
 check "publish: PAT-checkout gated to one-click"  bash -c "grep -A1 'Checkout main HEAD with PAT' '$WORKFLOW' | grep -qF \"needs.verify.outputs.one_click == '1'\""
 
+# Duplicate-trigger skip in tag-push path (D13 — PAT-pushed tag re-triggers workflow).
+# When release exists AND event_name == 'push', exit 0 (clean) instead of fail.
+check "publish: EVENT_NAME env in publish step"   bash -c "awk '/Publish GitHub Release/{f=1; next} f && /env:/{e=1; next} e && /EVENT_NAME:/{print; exit}' '$WORKFLOW' | grep -q 'EVENT_NAME:'"
+check "publish: tag-push duplicate skip branch"   grep -qF 'Tag-push trigger is the duplicate' "$WORKFLOW"
+check "publish: workflow_dispatch retry still fails on existing release"  grep -qF 'Delete it manually if you intend to recreate' "$WORKFLOW"
+
 echo "-- T10: one-click release path"
 # tag_name's required attribute must be false (was true in TRN-2006).
 awk '/tag_name:/{f=1; next} f && /required:/{print; exit}' "$WORKFLOW" | grep -q 'required: false' \


### PR DESCRIPTION
## Summary

When Path A (one-click release) pushes a tag via `RELEASE_TAG_PAT`, the PAT-driven push triggers the same `release.yml` again via `on.push.tags`. The duplicate run reaches `Publish GitHub Release`, finds the release already published by the original Path A run, and currently fails with "Release vX.Y.Z already exists" — correct behavior, but leaves an ugly red ❌ in the Actions tab after every successful release.

This PR makes the Publish step exit cleanly (exit 0) in that specific scenario: **release exists AND `event_name == 'push'`**.

## Why now

Surfaced on the v1.8.0 end-to-end Path A validation run:
- ✅ https://github.com/frankyxhl/trinity/actions/runs/24950764858 (workflow_dispatch, success — actual publish)
- ❌ https://github.com/frankyxhl/trinity/actions/runs/24950771720 (push, "duplicate" failure)

The original Codex review on TRN-2007 said "GITHUB_TOKEN-driven tag push will NOT re-trigger the workflow — no recursion concern". True — but TRN-2007 D11 later switched to PAT-driven tag push for ruleset-bypass, and **PAT-pushed events DO trigger workflows**. The corner case wasn't covered.

## Fix

```diff
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.verify.outputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if [ "$EVENT_NAME" = "push" ]; then
+              echo "Release $TAG already exists. Tag-push trigger is the duplicate from a Path A run that already published. Skipping cleanly."
+              exit 0
+            fi
             echo "::error::Release $TAG already exists. Delete it manually if you intend to recreate."
             exit 1
           fi
```

## What's NOT changed

- **`workflow_dispatch` retry path** still fails on existing release — that path explicitly addresses an existing tag and should warn if release was already published (intentional; you don't want to "successfully" retry a release that's already out there)
- **One-click path** (the original publish) — unchanged
- **Manual `git push origin <tag>` by maintainer (Path B)** — same behavior; if release was somehow already created, exits cleanly. Acceptable: prevents spurious failures on idempotent retries

## Verification

- `make verify-built` ✅
- `make test` ✅ — **90/90** (+3 T11 assertions: EVENT_NAME env present, duplicate-skip branch, retry-still-fails branch preserved)
- `make lint` ✅
- End-to-end: next release will validate (no failed run after success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)