### PR TITLE
TRN-2009: remove zsh dependency from trinity providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ lint:           ## Check and format code (TRN-1002)
 
 install:        ## Install Trinity to ~/.claude/ (TRN-1005)
 	@mkdir -p ~/.claude/skills/trinity/scripts
+	@mkdir -p ~/.claude/skills/trinity/bin
 	@mkdir -p ~/.claude/agents
 	cp SKILL.md ~/.claude/skills/trinity/SKILL.md
 	cp -r scripts/. ~/.claude/skills/trinity/scripts/
@@ -41,6 +42,9 @@ install:        ## Install Trinity to ~/.claude/ (TRN-1005)
 	cp providers/gemini.md ~/.claude/agents/trinity-gemini.md
 	cp providers/openrouter.md ~/.claude/agents/trinity-openrouter.md
 	cp providers/deepseek.md ~/.claude/agents/trinity-deepseek.md
+	cp providers/bin/deepseek ~/.claude/skills/trinity/bin/deepseek
+	cp providers/bin/openrouter ~/.claude/skills/trinity/bin/openrouter
+	chmod +x ~/.claude/skills/trinity/bin/deepseek ~/.claude/skills/trinity/bin/openrouter
 	python3 ~/.claude/skills/trinity/scripts/install.py register glm \
 		--cli "droid exec --model glm-5" \
 		--global-config ~/.claude/trinity.json
@@ -51,10 +55,10 @@ install:        ## Install Trinity to ~/.claude/ (TRN-1005)
 		--cli "gemini -p" \
 		--global-config ~/.claude/trinity.json
 	python3 ~/.claude/skills/trinity/scripts/install.py register openrouter \
-		--cli "openrouter_cy -p" \
+		--cli "$(HOME)/.claude/skills/trinity/bin/openrouter -p" \
 		--global-config ~/.claude/trinity.json
 	python3 ~/.claude/skills/trinity/scripts/install.py register deepseek \
-		--cli "deepseek_cy -p" \
+		--cli "$(HOME)/.claude/skills/trinity/bin/deepseek -p" \
 		--global-config ~/.claude/trinity.json
 	@echo "Installed Trinity $(CURRENT_VERSION)"
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,21 @@ Each install command:
 5. Runs a smoke test to verify everything works
 6. Rolls back atomically if any step fails
 
-**Wrapper-based providers** (`openrouter`, `deepseek`) don't have a package install path — they use the `claude` binary pointed at an Anthropic-compatible endpoint. They ship with `make install` / `install.sh`; see **Or install manually** below if you need to configure them independently.
+**Wrapper-based providers** (`openrouter`, `deepseek`) don't have a package install path — they use the `claude` binary pointed at an Anthropic-compatible endpoint via small POSIX shell wrappers shipped in `providers/bin/` and installed to `~/.claude/skills/trinity/bin/`. `install.sh` and `make install` set them up automatically; no `~/.zshrc` edits required.
+
+Each wrapper expects an API key, in this order of precedence:
+1. **Environment variable** — `DEEPSEEK_API_KEY` / `OPENROUTER_API_KEY`
+2. **Key file** — `~/.secrets/<provider>_api_key` with mode `600` (or `400`); the wrapper refuses anything more permissive
+
+```bash
+# Either set an env var in your shell rc:
+export DEEPSEEK_API_KEY=sk-...
+
+# Or write the key to a file (safer for unattended use):
+mkdir -p ~/.secrets
+echo "sk-..." > ~/.secrets/deepseek_api_key
+chmod 600 ~/.secrets/deepseek_api_key
+```
 
 **Or install manually:**
 
@@ -153,8 +167,8 @@ Then create `~/.claude/trinity.json`:
     "codex":      { "cli": "codex exec --skip-git-repo-check", "installed": true },
     "gemini":     { "cli": "gemini -p",                        "installed": true },
     "glm":        { "cli": "droid exec --model glm-5",         "installed": true },
-    "openrouter": { "cli": "openrouter_cy -p",                 "installed": true },
-    "deepseek":   { "cli": "deepseek_cy -p",                   "installed": true }
+    "openrouter": { "cli": "/Users/<you>/.claude/skills/trinity/bin/openrouter -p", "installed": true },
+    "deepseek":   { "cli": "/Users/<you>/.claude/skills/trinity/bin/deepseek -p",   "installed": true }
   },
   "defaults": {
     "heartbeat_interval": 120,

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,7 @@ fi
 
 # Create destination directories
 mkdir -p "${HOME}/.claude/skills/trinity/scripts"
+mkdir -p "${HOME}/.claude/skills/trinity/bin"
 mkdir -p "${HOME}/.claude/agents"
 
 # Download each file
@@ -46,6 +47,10 @@ _download "providers/codex.md"        "${HOME}/.claude/agents/trinity-codex.md"
 _download "providers/gemini.md"       "${HOME}/.claude/agents/trinity-gemini.md"
 _download "providers/openrouter.md"   "${HOME}/.claude/agents/trinity-openrouter.md"
 _download "providers/deepseek.md"     "${HOME}/.claude/agents/trinity-deepseek.md"
+_download "providers/bin/deepseek"    "${HOME}/.claude/skills/trinity/bin/deepseek"
+_download "providers/bin/openrouter"  "${HOME}/.claude/skills/trinity/bin/openrouter"
+chmod +x "${HOME}/.claude/skills/trinity/bin/deepseek" \
+         "${HOME}/.claude/skills/trinity/bin/openrouter"
 
 CURRENT_FILE=""
 
@@ -60,10 +65,10 @@ python3 "${HOME}/.claude/skills/trinity/scripts/install.py" register gemini \
     --cli "gemini -p" \
     --global-config "${HOME}/.claude/trinity.json"
 python3 "${HOME}/.claude/skills/trinity/scripts/install.py" register openrouter \
-    --cli "openrouter_cy -p" \
+    --cli "${HOME}/.claude/skills/trinity/bin/openrouter -p" \
     --global-config "${HOME}/.claude/trinity.json"
 python3 "${HOME}/.claude/skills/trinity/scripts/install.py" register deepseek \
-    --cli "deepseek_cy -p" \
+    --cli "${HOME}/.claude/skills/trinity/bin/deepseek -p" \
     --global-config "${HOME}/.claude/trinity.json"
 
 # Print success with version

--- a/providers/bin/deepseek
+++ b/providers/bin/deepseek
@@ -1,0 +1,44 @@
+#!/bin/sh
+# providers/bin/deepseek — Anthropic-compat wrapper for DeepSeek V4.
+# Loads API key from $DEEPSEEK_API_KEY (preferred) or ~/.secrets/deepseek_api_key
+# (mode 600 or 400; anything else is refused). Then exec's claude --dangerously-
+# skip-permissions with DeepSeek's Anthropic-compatible endpoint env vars.
+#
+# Pattern: trinity Anthropic-compat wrapper (see PRP TRN-2008, CHG TRN-2009).
+set -eu
+
+KEY="${DEEPSEEK_API_KEY:-}"
+KEY_FILE="${HOME}/.secrets/deepseek_api_key"
+
+if [ -z "$KEY" ] && [ -f "$KEY_FILE" ]; then
+    # BSD stat (macOS, FreeBSD): -f '%Lp'; GNU stat (Linux): -c '%a'.
+    # `|| echo unknown` keeps `set -e` from aborting silently on exotic FS.
+    PERM=$(stat -f '%Lp' "$KEY_FILE" 2>/dev/null \
+        || stat -c '%a' "$KEY_FILE" 2>/dev/null \
+        || echo unknown)
+    case "$PERM" in
+        600|400) ;;
+        unknown)
+            echo "trinity-deepseek: cannot stat $KEY_FILE — refusing to read for safety." >&2
+            exit 1 ;;
+        *)
+            echo "trinity-deepseek: refuse to read $KEY_FILE (perm $PERM, expected 600 or 400). Run: chmod 600 $KEY_FILE" >&2
+            exit 1 ;;
+    esac
+    KEY=$(cat "$KEY_FILE")
+fi
+
+if [ -z "$KEY" ]; then
+    echo "trinity-deepseek: no API key. Set \$DEEPSEEK_API_KEY or write ~/.secrets/deepseek_api_key (mode 600)." >&2
+    exit 1
+fi
+
+CLAUDE_CONFIG_DIR="${HOME}/.claude-deepseek" \
+ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic" \
+ANTHROPIC_AUTH_TOKEN="$KEY" \
+ANTHROPIC_API_KEY="$KEY" \
+ANTHROPIC_MODEL="deepseek-v4-pro" \
+ANTHROPIC_SMALL_FAST_MODEL="deepseek-v4-flash" \
+API_TIMEOUT_MS="600000" \
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1" \
+exec claude --dangerously-skip-permissions "$@"

--- a/providers/bin/openrouter
+++ b/providers/bin/openrouter
@@ -1,0 +1,40 @@
+#!/bin/sh
+# providers/bin/openrouter — Anthropic-compat wrapper for OpenRouter.
+# Loads API key from $OPENROUTER_API_KEY (preferred) or ~/.secrets/openrouter_api_key
+# (mode 600 or 400; anything else is refused). Then exec's claude --dangerously-
+# skip-permissions with OpenRouter's Anthropic-compatible endpoint env vars.
+#
+# Pattern: trinity Anthropic-compat wrapper (see PRP TRN-2008, CHG TRN-2009).
+set -eu
+
+KEY="${OPENROUTER_API_KEY:-}"
+KEY_FILE="${HOME}/.secrets/openrouter_api_key"
+
+if [ -z "$KEY" ] && [ -f "$KEY_FILE" ]; then
+    PERM=$(stat -f '%Lp' "$KEY_FILE" 2>/dev/null \
+        || stat -c '%a' "$KEY_FILE" 2>/dev/null \
+        || echo unknown)
+    case "$PERM" in
+        600|400) ;;
+        unknown)
+            echo "trinity-openrouter: cannot stat $KEY_FILE — refusing to read for safety." >&2
+            exit 1 ;;
+        *)
+            echo "trinity-openrouter: refuse to read $KEY_FILE (perm $PERM, expected 600 or 400). Run: chmod 600 $KEY_FILE" >&2
+            exit 1 ;;
+    esac
+    KEY=$(cat "$KEY_FILE")
+fi
+
+if [ -z "$KEY" ]; then
+    echo "trinity-openrouter: no API key. Set \$OPENROUTER_API_KEY or write ~/.secrets/openrouter_api_key (mode 600)." >&2
+    exit 1
+fi
+
+CLAUDE_CONFIG_DIR="${HOME}/.claude-openrouter" \
+ANTHROPIC_BASE_URL="https://openrouter.ai/api" \
+ANTHROPIC_AUTH_TOKEN="$KEY" \
+ANTHROPIC_API_KEY="$KEY" \
+ANTHROPIC_MODEL="qwen/qwen3.6-plus:free" \
+ANTHROPIC_SMALL_FAST_MODEL="qwen/qwen3.6-plus:free" \
+exec claude --dangerously-skip-permissions "$@"

--- a/providers/deepseek.delta.md
+++ b/providers/deepseek.delta.md
@@ -1,8 +1,10 @@
 ---
 name: trinity-deepseek
 description: |
-  Worker agent for DeepSeek V4 (via anthropic_cli wrapper).
-  Uses deepseek_cy (claude --dangerously-skip-permissions with DeepSeek backend).
+  Worker agent for DeepSeek V4. Wraps `claude --dangerously-skip-permissions`
+  with DeepSeek's Anthropic-compatible endpoint via the bin script installed
+  by trinity (providers/bin/deepseek). API key from $DEEPSEEK_API_KEY or
+  ~/.secrets/deepseek_api_key (mode 600 or 400).
   Default model: deepseek-v4-pro. Supports session resume via --resume.
 
   Invoked via Agent tool with subagent_type="general-purpose".
@@ -23,30 +25,15 @@ You are a worker agent that executes tasks using DeepSeek V4 via the `claude` CL
 
 ### Setup (run once before new or resume)
 
-Define the CLI function and session directory:
+Define the CLI entry function and session directory. `run_deepseek` calls the
+wrapper script installed by `install.sh` / `make install` (repo source:
+`providers/bin/deepseek`). The wrapper handles env injection, key-file loading
+from `~/.secrets/deepseek_api_key` (mode 600 or 400), and precedence
+(`DEEPSEEK_API_KEY` env var wins over file).
+
 ```bash
-# CLI function — uses wrapper if available, otherwise portable env approach
 run_deepseek() {
-  if command -v deepseek_cy >/dev/null 2>&1; then
-    deepseek_cy "$@"
-  else
-    local key
-    key="$(cat ~/.secrets/deepseek_api_key 2>/dev/null)"
-    if [ -z "$key" ]; then key="${DEEPSEEK_API_KEY:-}"; fi
-    if [ -z "$key" ]; then
-      echo "ERROR: no DeepSeek API key found. Set DEEPSEEK_API_KEY or create ~/.secrets/deepseek_api_key" >&2
-      return 1
-    fi
-    CLAUDE_CONFIG_DIR="$HOME/.claude-deepseek" \
-    ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic" \
-    ANTHROPIC_AUTH_TOKEN="$key" \
-    ANTHROPIC_API_KEY="$key" \
-    ANTHROPIC_MODEL="deepseek-v4-pro" \
-    ANTHROPIC_SMALL_FAST_MODEL="deepseek-v4-flash" \
-    API_TIMEOUT_MS="600000" \
-    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1" \
-    claude --dangerously-skip-permissions "$@"
-  fi
+  "$HOME/.claude/skills/trinity/bin/deepseek" "$@"
 }
 
 # Session directory (scoped to project)

--- a/providers/deepseek.md
+++ b/providers/deepseek.md
@@ -1,8 +1,10 @@
 ---
 name: trinity-deepseek
 description: |
-  Worker agent for DeepSeek V4 (via anthropic_cli wrapper).
-  Uses deepseek_cy (claude --dangerously-skip-permissions with DeepSeek backend).
+  Worker agent for DeepSeek V4. Wraps `claude --dangerously-skip-permissions`
+  with DeepSeek's Anthropic-compatible endpoint via the bin script installed
+  by trinity (providers/bin/deepseek). API key from $DEEPSEEK_API_KEY or
+  ~/.secrets/deepseek_api_key (mode 600 or 400).
   Default model: deepseek-v4-pro. Supports session resume via --resume.
 
   Invoked via Agent tool with subagent_type="general-purpose".
@@ -37,30 +39,15 @@ python3 ~/.claude/skills/trinity/scripts/session.py write "$PROJECT_DIR" "$INSTA
 
 ### Setup (run once before new or resume)
 
-Define the CLI function and session directory:
+Define the CLI entry function and session directory. `run_deepseek` calls the
+wrapper script installed by `install.sh` / `make install` (repo source:
+`providers/bin/deepseek`). The wrapper handles env injection, key-file loading
+from `~/.secrets/deepseek_api_key` (mode 600 or 400), and precedence
+(`DEEPSEEK_API_KEY` env var wins over file).
+
 ```bash
-# CLI function — uses wrapper if available, otherwise portable env approach
 run_deepseek() {
-  if command -v deepseek_cy >/dev/null 2>&1; then
-    deepseek_cy "$@"
-  else
-    local key
-    key="$(cat ~/.secrets/deepseek_api_key 2>/dev/null)"
-    if [ -z "$key" ]; then key="${DEEPSEEK_API_KEY:-}"; fi
-    if [ -z "$key" ]; then
-      echo "ERROR: no DeepSeek API key found. Set DEEPSEEK_API_KEY or create ~/.secrets/deepseek_api_key" >&2
-      return 1
-    fi
-    CLAUDE_CONFIG_DIR="$HOME/.claude-deepseek" \
-    ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic" \
-    ANTHROPIC_AUTH_TOKEN="$key" \
-    ANTHROPIC_API_KEY="$key" \
-    ANTHROPIC_MODEL="deepseek-v4-pro" \
-    ANTHROPIC_SMALL_FAST_MODEL="deepseek-v4-flash" \
-    API_TIMEOUT_MS="600000" \
-    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1" \
-    claude --dangerously-skip-permissions "$@"
-  fi
+  "$HOME/.claude/skills/trinity/bin/deepseek" "$@"
 }
 
 # Session directory (scoped to project)

--- a/providers/openrouter.delta.md
+++ b/providers/openrouter.delta.md
@@ -1,8 +1,10 @@
 ---
 name: trinity-openrouter
 description: |
-  Worker agent for OpenRouter (via anthropic_cli wrapper).
-  Uses openrouter_cy (claude --dangerously-skip-permissions with OpenRouter backend).
+  Worker agent for OpenRouter. Wraps `claude --dangerously-skip-permissions`
+  with OpenRouter's Anthropic-compatible endpoint via the bin script installed
+  by trinity (providers/bin/openrouter). API key from $OPENROUTER_API_KEY or
+  ~/.secrets/openrouter_api_key (mode 600 or 400).
   Default model: qwen/qwen3.6-plus:free. Supports session resume via --resume.
 
   Invoked via Agent tool with subagent_type="general-purpose".
@@ -23,28 +25,15 @@ You are a worker agent that executes tasks using OpenRouter via the `claude` CLI
 
 ### Setup (run once before new or resume)
 
-Define the CLI function and session directory:
+Define the CLI entry function and session directory. `run_openrouter` calls the
+wrapper script installed by `install.sh` / `make install` (repo source:
+`providers/bin/openrouter`). The wrapper handles env injection, key-file loading
+from `~/.secrets/openrouter_api_key` (mode 600 or 400), and precedence
+(`OPENROUTER_API_KEY` env var wins over file).
+
 ```bash
-# CLI function — uses wrapper if available, otherwise portable env approach
 run_openrouter() {
-  if command -v openrouter_cy >/dev/null 2>&1; then
-    openrouter_cy "$@"
-  else
-    local key
-    key="$(cat ~/.secrets/openrouter_api_key 2>/dev/null)"
-    if [ -z "$key" ]; then key="${OPENROUTER_API_KEY:-}"; fi
-    if [ -z "$key" ]; then
-      echo "ERROR: no OpenRouter API key found. Set OPENROUTER_API_KEY or create ~/.secrets/openrouter_api_key" >&2
-      return 1
-    fi
-    CLAUDE_CONFIG_DIR="$HOME/.claude-openrouter" \
-    ANTHROPIC_BASE_URL="https://openrouter.ai/api" \
-    ANTHROPIC_AUTH_TOKEN="$key" \
-    ANTHROPIC_API_KEY="$key" \
-    ANTHROPIC_MODEL="qwen/qwen3.6-plus:free" \
-    ANTHROPIC_SMALL_FAST_MODEL="qwen/qwen3.6-plus:free" \
-    claude --dangerously-skip-permissions "$@"
-  fi
+  "$HOME/.claude/skills/trinity/bin/openrouter" "$@"
 }
 
 # Session directory (scoped to project)

--- a/providers/openrouter.md
+++ b/providers/openrouter.md
@@ -1,8 +1,10 @@
 ---
 name: trinity-openrouter
 description: |
-  Worker agent for OpenRouter (via anthropic_cli wrapper).
-  Uses openrouter_cy (claude --dangerously-skip-permissions with OpenRouter backend).
+  Worker agent for OpenRouter. Wraps `claude --dangerously-skip-permissions`
+  with OpenRouter's Anthropic-compatible endpoint via the bin script installed
+  by trinity (providers/bin/openrouter). API key from $OPENROUTER_API_KEY or
+  ~/.secrets/openrouter_api_key (mode 600 or 400).
   Default model: qwen/qwen3.6-plus:free. Supports session resume via --resume.
 
   Invoked via Agent tool with subagent_type="general-purpose".
@@ -37,28 +39,15 @@ python3 ~/.claude/skills/trinity/scripts/session.py write "$PROJECT_DIR" "$INSTA
 
 ### Setup (run once before new or resume)
 
-Define the CLI function and session directory:
+Define the CLI entry function and session directory. `run_openrouter` calls the
+wrapper script installed by `install.sh` / `make install` (repo source:
+`providers/bin/openrouter`). The wrapper handles env injection, key-file loading
+from `~/.secrets/openrouter_api_key` (mode 600 or 400), and precedence
+(`OPENROUTER_API_KEY` env var wins over file).
+
 ```bash
-# CLI function — uses wrapper if available, otherwise portable env approach
 run_openrouter() {
-  if command -v openrouter_cy >/dev/null 2>&1; then
-    openrouter_cy "$@"
-  else
-    local key
-    key="$(cat ~/.secrets/openrouter_api_key 2>/dev/null)"
-    if [ -z "$key" ]; then key="${OPENROUTER_API_KEY:-}"; fi
-    if [ -z "$key" ]; then
-      echo "ERROR: no OpenRouter API key found. Set OPENROUTER_API_KEY or create ~/.secrets/openrouter_api_key" >&2
-      return 1
-    fi
-    CLAUDE_CONFIG_DIR="$HOME/.claude-openrouter" \
-    ANTHROPIC_BASE_URL="https://openrouter.ai/api" \
-    ANTHROPIC_AUTH_TOKEN="$key" \
-    ANTHROPIC_API_KEY="$key" \
-    ANTHROPIC_MODEL="qwen/qwen3.6-plus:free" \
-    ANTHROPIC_SMALL_FAST_MODEL="qwen/qwen3.6-plus:free" \
-    claude --dangerously-skip-permissions "$@"
-  fi
+  "$HOME/.claude/skills/trinity/bin/openrouter" "$@"
 }
 
 # Session directory (scoped to project)

--- a/rules/TRN-0000-REF-Document-Index.md
+++ b/rules/TRN-0000-REF-Document-Index.md
@@ -22,6 +22,8 @@
 | 2005 | CHG | Pin trinity-codex to gpt-5.5 |
 | 2006 | CHG | Release-on-tag GitHub Action |
 | 2007 | CHG | One-click release via workflow_dispatch |
+| 2008 | PRP | Remove Zsh Dependency from Trinity Providers |
+| 2009 | CHG | Remove Zsh Dependency from Trinity Providers |
 
 ---
 
@@ -34,3 +36,5 @@
 | 2026-04-26 | Add TRN-2005 | Claude Opus 4.7 |
 | 2026-04-26 | Add TRN-2006 | Claude Opus 4.7 |
 | 2026-04-26 | Add TRN-2007 | Claude Opus 4.7 |
+| 2026-04-26 | Add TRN-2008 | Claude Opus 4.7 |
+| 2026-04-26 | Add TRN-2009 | Claude Opus 4.7 |

--- a/rules/TRN-2008-PRP-Remove-Zsh-Dependency.md
+++ b/rules/TRN-2008-PRP-Remove-Zsh-Dependency.md
@@ -1,0 +1,358 @@
+# PRP-2008: Remove Zsh Dependency from Trinity Providers
+
+**Applies to:** trinity/ package (`frankyxhl/trinity`)
+**Last updated:** 2026-04-26
+**Last reviewed:** 2026-04-26
+**Status:** Approved
+**Reviewed by:**
+- Round 1 (2026-04-26): Codex 7.6/10 FIX, Gemini 8.6/10 FIX, GLM 7.4/10 FIX, DeepSeek 6.8/10 FIX. Convergent blockers: (1) generated `.md` vs `.delta.md`, (2) missing `mkdir -p .../bin/`, (3) `run_<provider>` callers preservation, (4) stat portability + empty-`$PERM` handling, (5) error-message wording, (6) test-stub `exec` semantics, (7) `--resume` argv ordering test, (8) legacy-migration test.
+- Round 2 (2026-04-26): Codex 8.9/10 PASS, Gemini 9.8/10 PASS, GLM 8.8/10 PASS, DeepSeek 10/10 PASS. All blockers verified resolved; no new blocking issues.
+**Related:** TRN-2002 (Remote Install Script), TRN-2004 (Provider Files Refactor), TRN-1005 (SOP Install)
+
+---
+
+## What Is It?
+
+Replace the two `.zshrc`-defined wrapper functions (`deepseek_cy`, `openrouter_cy`) — which today register as the `cli` for the `deepseek` and `openrouter` providers — with portable POSIX shell scripts shipped inside the trinity repo.
+
+After this change, a fresh user can install trinity (`install.sh`) and use every registered provider with **no shell-rc edits** of any kind.
+
+---
+
+## Problem
+
+1. **Sharing trinity is broken for two of five providers.** `~/.claude/trinity.json` registers `deepseek_cy -p` and `openrouter_cy -p` as the dispatch `cli`. These names resolve only inside the maintainer's `~/.zshrc`. A new user who follows `install.sh` ends up with two providers that fail at first dispatch with `command not found`.
+
+2. **Dead-code fallback in agent .md.** `providers/deepseek.md` and `providers/openrouter.md` carry a `Setup` block with a `command -v <name>_cy` check and an inline `claude --dangerously-skip-permissions` fallback. Per Trinity's actual dispatch contract (`SKILL.md` §Dispatch), the worker reads its agent .md for protocol instructions but the **`cli` field in `trinity.json` is what gets executed verbatim**. The fallback never runs. It misleads readers into thinking it does.
+
+3. **Two near-identical wrappers, copy-paste-ready for growth.** Both functions perform the same five steps: load API key from `~/.secrets/<provider>_api_key` (env-var override), set `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` / `CLAUDE_CONFIG_DIR`, exec `claude --dangerously-skip-permissions "$@"`. Any future Anthropic-API-compatible endpoint (Z.ai, Moonshot, Kimi, etc.) will be tempted to copy a third one into `.zshrc`.
+
+---
+
+## Decision Drivers
+
+This PRP follows a four-model consultation (Codex high-effort, Gemini, GLM, DeepSeek) on three candidate approaches. All four converged on the **thin path** below.
+
+Convergent findings:
+
+- The `cli` field is the actual execution surface; the agent `.md` Setup block is read-but-not-used for dispatch routing. Any redesign must touch the surface that actually runs.
+- A schema rethink (`shape: native | anthropic-compat | openai-compat`) is the wrong altitude: per-provider quirks (Codex `model_reasoning_effort`, Codex `resume` subcommand, Gemini `-r <index>` resume, DeepSeek 600 s timeout, JSONL trace-marker session lookup) do not factor into a 3-element enum. The redesign would either bloat into `adapter / resume_strategy / session_strategy / effort_strategy` discriminators, or push those quirks back into the agent `.md` and re-fragment the contract.
+- A new `trinity-exec` Python dispatcher replacing `cli` strings is a ~200-LoC change to remove ~12 lines of zsh and one `cli` field — net-negative compression.
+- The thin path (POSIX scripts in repo + install rewrites `cli` → absolute path) eliminates the zsh dependency with zero schema change, zero new abstraction, zero migration path, and is independent of any future architectural cleanup (e.g. moving provider config into agent `.md` frontmatter — explicitly deferred).
+
+---
+
+## Considered Alternatives
+
+| # | Approach | Status | Reason |
+|---|----------|--------|--------|
+| A | Document the zsh dependency; ship a `trinity-shell-init` snippet users source | Rejected | Doesn't fix the problem; blesses it. |
+| B | New Python dispatcher `trinity-exec <provider>` with `shape` discriminator in `trinity.json` | Rejected | 4-of-4 reviewer consensus: wrong altitude, leaky abstraction, breaking migration, premature `openai-compat`, doesn't address the actual dispatch surface (.md Setup). |
+| C | Thin POSIX scripts in `providers/bin/`; `install.sh` writes absolute paths into `trinity.json` | **Accepted** | Smallest change that fixes the share story. Independent of future architectural rethink. |
+| D | Eliminate `trinity.json` providers map; move shape into agent `.md` frontmatter as single source of truth | Deferred | Coherent design but breaks the `Config Overlay` global/project merge story (SKILL.md §Config Overlay). Out of scope for this PRP — track separately if pursued. |
+
+---
+
+## Proposed Solution
+
+### 1. New scripts in repo: `providers/bin/`
+
+Two POSIX `sh` scripts (no bashisms, no zshisms), checked into the repo:
+
+- `providers/bin/deepseek` — wraps `claude --dangerously-skip-permissions` with DeepSeek env vars
+- `providers/bin/openrouter` — wraps `claude --dangerously-skip-permissions` with OpenRouter env vars
+
+Final shape of `providers/bin/deepseek`:
+
+```sh
+#!/bin/sh
+# providers/bin/deepseek — Anthropic-compat wrapper for DeepSeek V4.
+# Loads API key from $DEEPSEEK_API_KEY (preferred) or ~/.secrets/deepseek_api_key.
+# Refuses to read key files with perm > 0600.
+set -eu
+
+KEY="${DEEPSEEK_API_KEY:-}"
+KEY_FILE="${HOME}/.secrets/deepseek_api_key"
+
+if [ -z "$KEY" ] && [ -f "$KEY_FILE" ]; then
+    # Determine mode in three-octal form; tolerate exotic filesystems.
+    # BSD stat (macOS, FreeBSD): -f '%Lp'; GNU stat (Linux): -c '%a'.
+    PERM=$(stat -f '%Lp' "$KEY_FILE" 2>/dev/null \
+        || stat -c '%a' "$KEY_FILE" 2>/dev/null \
+        || echo unknown)
+    case "$PERM" in
+        600|400) ;;
+        unknown)
+            echo "trinity-deepseek: cannot stat $KEY_FILE — refusing to read for safety." >&2
+            exit 1 ;;
+        *)
+            echo "trinity-deepseek: refuse to read $KEY_FILE (perm $PERM, expected 600 or 400). Run: chmod 600 $KEY_FILE" >&2
+            exit 1 ;;
+    esac
+    KEY=$(cat "$KEY_FILE")
+fi
+
+if [ -z "$KEY" ]; then
+    echo "trinity-deepseek: no API key. Set \$DEEPSEEK_API_KEY or write ~/.secrets/deepseek_api_key (mode 600)." >&2
+    exit 1
+fi
+
+CLAUDE_CONFIG_DIR="${HOME}/.claude-deepseek" \
+ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic" \
+ANTHROPIC_AUTH_TOKEN="$KEY" \
+ANTHROPIC_API_KEY="$KEY" \
+ANTHROPIC_MODEL="deepseek-v4-pro" \
+ANTHROPIC_SMALL_FAST_MODEL="deepseek-v4-flash" \
+API_TIMEOUT_MS="600000" \
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1" \
+exec claude --dangerously-skip-permissions "$@"
+```
+
+`providers/bin/openrouter` is structurally identical with OpenRouter's `BASE_URL`, model defaults, and key-file path.
+
+**Key precedence (declared explicitly):** environment variable `<PROVIDER>_API_KEY` wins over `~/.secrets/<provider>_api_key`. 12-factor convention; lets ad-hoc invocations (`DEEPSEEK_API_KEY=xxx providers/bin/deepseek …`) override the file.
+
+**Key-file permission check:** the script `stat`s the file and refuses any mode > 0400 unless it's exactly `0600`. Hard error — reading a world-readable secret silently is a footgun. The `|| echo unknown` terminator ensures the `case` runs even if both `stat` invocations fail (exotic filesystems, NFS, sshfs); `unknown` falls through to a refuse-with-message branch instead of a silent `set -e` abort.
+
+**Why `exec`:** wrapper replaces itself with `claude` so signals propagate and `ps` stays clean.
+
+**Why no bashisms:** `/bin/sh` is everywhere; minimal containers may lack bash.
+
+**Stat portability matrix:**
+
+| OS | Tool | Format flag |
+|----|------|-------------|
+| macOS (Darwin) | BSD `stat` | `-f '%Lp'` (✓ verified outputs `600`/`400`/`644`) |
+| FreeBSD | BSD `stat` | `-f '%Lp'` (same) |
+| Linux (glibc/musl) | GNU `stat` | `-c '%a'` |
+| anything else | n/a | `echo unknown` → refuse |
+
+### 2. `install.sh` changes
+
+Concrete diff:
+
+```diff
+@@ install.sh: directory creation block @@
+ mkdir -p "${HOME}/.claude/skills/trinity/scripts"
++mkdir -p "${HOME}/.claude/skills/trinity/bin"
+ mkdir -p "${HOME}/.claude/agents"
+
+@@ install.sh: download block @@
+ _download "providers/openrouter.md"   "${HOME}/.claude/agents/trinity-openrouter.md"
+ _download "providers/deepseek.md"     "${HOME}/.claude/agents/trinity-deepseek.md"
++_download "providers/bin/deepseek"    "${HOME}/.claude/skills/trinity/bin/deepseek"
++_download "providers/bin/openrouter"  "${HOME}/.claude/skills/trinity/bin/openrouter"
++chmod +x "${HOME}/.claude/skills/trinity/bin/deepseek" \
++         "${HOME}/.claude/skills/trinity/bin/openrouter"
+
+@@ install.sh: provider registration block @@
+ python3 "${HOME}/.claude/skills/trinity/scripts/install.py" register openrouter \
+-    --cli "openrouter_cy -p" \
++    --cli "${HOME}/.claude/skills/trinity/bin/openrouter -p" \
+     --global-config "${HOME}/.claude/trinity.json"
+ python3 "${HOME}/.claude/skills/trinity/scripts/install.py" register deepseek \
+-    --cli "deepseek_cy -p" \
++    --cli "${HOME}/.claude/skills/trinity/bin/deepseek -p" \
+     --global-config "${HOME}/.claude/trinity.json"
+```
+
+Notes:
+- `glm`, `codex`, `gemini` registrations unchanged — already PATH binaries with no zsh dependency.
+- `-p` is kept in the registered `cli` because the agent worker invokes the wrapper as `run_<provider> -p "$MARKED_PROMPT"`. The `cli` field is the canonical "first form" shown in `/trinity status` (matches today's `gemini -p` registration shape).
+- `install.py` already uses `fcntl.flock` for atomic JSON updates (`scripts/install.py:55-78`); concurrent installs are safe.
+
+### 3. `Makefile` `install` target
+
+Mirror the same wiring locally. The `install` target must also create the `bin/` dir, copy the two scripts, set `+x`, and re-register the two providers with absolute paths. (TRN-2002 documented this drift risk; we accept it again with explicit symmetry.)
+
+### 4. Agent template (`.delta.md`) edits — NOT generated `.md`
+
+`providers/deepseek.md` and `providers/openrouter.md` are **generated files** produced by `scripts/build_providers.sh` from `providers/<name>.delta.md` + `providers/_base/*.md` partials. `make verify-built` (run inside `make test` and `release-prep`) hashes the generated output against the source — direct edits to the generated `.md` will fail CI.
+
+All template edits land in the `.delta.md` files; `make build` regenerates the `.md`.
+
+**`providers/deepseek.delta.md` Setup block — before/after:**
+
+```diff
+ ### Setup (run once before new or resume)
+
+-Define the CLI function and session directory:
++Define the CLI entry function and session directory.
++`run_deepseek` calls the wrapper script installed by install.sh / make install
++(repo source: providers/bin/deepseek). The wrapper handles env injection,
++key-file loading from ~/.secrets/deepseek_api_key (mode 600), and
++precedence (DEEPSEEK_API_KEY env var wins over file).
++
+ ```bash
+-# CLI function — uses wrapper if available, otherwise portable env approach
+ run_deepseek() {
+-  if command -v deepseek_cy >/dev/null 2>&1; then
+-    deepseek_cy "$@"
+-  else
+-    local key
+-    key="$(cat ~/.secrets/deepseek_api_key 2>/dev/null)"
+-    if [ -z "$key" ]; then key="${DEEPSEEK_API_KEY:-}"; fi
+-    if [ -z "$key" ]; then
+-      echo "ERROR: no DeepSeek API key found. Set DEEPSEEK_API_KEY or create ~/.secrets/deepseek_api_key" >&2
+-      return 1
+-    fi
+-    CLAUDE_CONFIG_DIR="$HOME/.claude-deepseek" \
+-    ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic" \
+-    ANTHROPIC_AUTH_TOKEN="$key" \
+-    ANTHROPIC_API_KEY="$key" \
+-    ANTHROPIC_MODEL="deepseek-v4-pro" \
+-    ANTHROPIC_SMALL_FAST_MODEL="deepseek-v4-flash" \
+-    API_TIMEOUT_MS="600000" \
+-    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1" \
+-    claude --dangerously-skip-permissions "$@"
+-  fi
++  "$HOME/.claude/skills/trinity/bin/deepseek" "$@"
+ }
+
+ # Session directory (scoped to project)
+ PROJECT_SLUG=$(echo "$PROJECT_DIR" | sed 's|/|-|g; s|^-||')
+ SESSION_DIR="$HOME/.claude-deepseek/projects/${PROJECT_SLUG}"
+ ```
+```
+
+**Frontmatter `description` cleanup** — drop the `deepseek_cy` reference:
+
+```diff
+ description: |
+-  Worker agent for DeepSeek V4 (via anthropic_cli wrapper).
+-  Uses deepseek_cy (claude --dangerously-skip-permissions with DeepSeek backend).
++  Worker agent for DeepSeek V4. Wraps `claude --dangerously-skip-permissions`
++  with DeepSeek's Anthropic-compatible endpoint. API key from
++  $DEEPSEEK_API_KEY or ~/.secrets/deepseek_api_key (mode 600).
+   Default model: deepseek-v4-pro. Supports session resume via --resume.
+```
+
+**`providers/openrouter.delta.md`** — structurally identical change, with OpenRouter env values.
+
+**Caller sections (`### New session`, `### Resume session`, common-tail rules)** — unchanged. They keep calling `run_deepseek -p` / `run_deepseek --resume <id> -p`; the function signature is preserved.
+
+After both `.delta.md` edits: `make build` (regenerates `providers/<name>.md`) → `make verify-built` (must pass).
+
+### 5. README / SKILL.md docs
+
+- Add a short note to `README.md` Quick Start: "DeepSeek and OpenRouter providers expect `~/.secrets/<provider>_api_key` (mode 600) or `<PROVIDER>_API_KEY` env var."
+- `SKILL.md` `## Config Overlay` example — no changes (doesn't show deepseek/openrouter today).
+
+---
+
+## Scope
+
+**In scope:**
+
+- New `providers/bin/deepseek` and `providers/bin/openrouter` (POSIX sh, ~30 lines each)
+- `install.sh` — download bin scripts, `chmod +x`, register absolute path as `cli`
+- `Makefile` `install` target — same wiring locally
+- `providers/deepseek.md` and `providers/openrouter.md` — cleanup `Setup` block
+- `README.md` — Quick Start key-file note
+- `tests/` — new test file `tests/test_anthropic_compat_wrappers.py` covering: missing-key error, env-overrides-file precedence, perm-check refusal, exec-replaces-shell behavior (smoke), `install.sh` registers absolute paths
+- `rules/TRN-0000-REF-Document-Index.md` — add TRN-2008 row, TRN-2009 row
+- `rules/TRN-2009-CHG-Remove-Zsh-Dependency.md` — implementation CHG (separate doc, drafted in Phase 5)
+
+**Out of scope:**
+
+- Python `trinity-exec` dispatcher (alternative B, rejected)
+- `shape` discriminator in `trinity.json` schema
+- `openai-compat` shape — no current consumer
+- Moving provider config into agent `.md` frontmatter (alternative D, deferred)
+- Changing `glm`, `codex`, `gemini` registrations (no zsh dependency)
+- Migrating Codex `--reasoning-effort`, Gemini `-r`, DeepSeek timeout into config — those stay in the worker .md per current contract
+- Uninstall script
+- Windows support
+
+---
+
+## Design Decisions
+
+**DD-1 — POSIX `sh` not bash.**
+The wrappers use `/bin/sh` with no bash-only syntax (no `[[`, no arrays, no `$'…'` ANSI-C quoting). Justification: portability to minimal containers; the wrappers are simple enough that bash buys nothing.
+
+**DD-2 — `exec claude` not `claude` + `wait`.**
+Replacing the shell with the `claude` process avoids a stranded parent shell, propagates signals cleanly, and removes one entry from `ps` output.
+
+**DD-3 — Permission check is a hard refuse; accept `0600` and `0400`.**
+Mode > 0600 on a key file is a real footgun. Failing closed is the safer default. Both `0600` (rw owner) and `0400` (read-only owner) are accepted — `0400` is strictly safer than `0600`. Anything else (including unreadable / unstattable files) is refused with a stderr message.
+
+**DD-4 — Env wins over file.**
+Standard 12-factor precedence. Lets ad-hoc overrides without editing the file.
+
+**DD-5 — Keep `run_<provider>` function in the agent template; simplify it to call the bin script.**
+Don't change the dispatcher contract. The worker calls `run_deepseek -p "$MARKED_PROMPT"` and `run_deepseek --resume <id> -p "<prompt>"`; that signature stays. The function body collapses from ~25 lines to one line: `"$HOME/.claude/skills/trinity/bin/deepseek" "$@"`. This isolates env handling in the bin script (testable, portable) without touching call sites.
+
+**DD-6 — Keep `-p` baked into the registered `cli`.**
+The `cli` field in `trinity.json` is the canonical "first form" shown in `/trinity status`. Today gemini/openrouter/deepseek all register `<wrapper> -p`; preserving the shape prevents UX drift and matches what the worker actually invokes (`run_<provider> -p ...`). Resume safety is unaffected because the dispatcher calls through `run_<provider>`, not by templating `<cli>` itself.
+
+**DD-7 — Keep the `cli` schema as-is.**
+Don't touch `trinity.json`'s shape. Only the *values* of two `cli` strings change (zshrc-function-name → absolute path). All existing readers (`discover.py`, `install.py`, dispatcher) keep working with no migration code.
+
+**DD-8 — Don't delete `~/.claude/trinity.json`'s `installed: true` field.**
+Existing flag is harmless; keep writing it for compatibility with any reader that keys off it.
+
+---
+
+## Test Cases
+
+All new tests live in `tests/test_anthropic_compat_wrappers.py`. Tests run the wrapper scripts directly with a `claude` stub injected via PATH-prepend (no real network calls).
+
+**Stub mechanism (concrete):**
+
+A small Python script written to `tmp_path/bin/claude` records `sys.argv[1:]` and selected `os.environ` keys to a file (e.g. `tmp_path/claude.invoked.json`), then exits `0`. The test prepends `tmp_path/bin` to `PATH` before exec'ing the wrapper. Because the wrapper does `exec claude …`, the stub becomes the leaf process and the recording file is the source of truth for assertions. This pattern handles the `exec`-replaces-shell semantics correctly (no fork; the stub IS the process).
+
+| # | Test | Expected |
+|---|------|----------|
+| T1 | Run `providers/bin/deepseek arg1 arg2` with `DEEPSEEK_API_KEY=xxx` set | Stub `claude` records argv `['--dangerously-skip-permissions', 'arg1', 'arg2']`; env has `ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic`, `ANTHROPIC_AUTH_TOKEN=xxx`, `ANTHROPIC_MODEL=deepseek-v4-pro`, `ANTHROPIC_SMALL_FAST_MODEL=deepseek-v4-flash`, `API_TIMEOUT_MS=600000`, `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`, `CLAUDE_CONFIG_DIR` ends in `.claude-deepseek`; exit 0 |
+| T2 | No env, `~/.secrets/deepseek_api_key` exists with mode 600 and content `from-file` | Stub recorded with `ANTHROPIC_AUTH_TOKEN=from-file`; exit 0 |
+| T3 | Env `from-env`, file `from-file` (mode 600) | Stub recorded with `ANTHROPIC_AUTH_TOKEN=from-env` (env wins); exit 0 |
+| T4 | No env, no file | Exit 1; stderr matches `no API key` |
+| T5 | No env, file mode 644 | Exit 1; stderr matches `refuse to read .* perm 644 .* expected 600 or 400` |
+| T6 | No env, file mode 600 but empty | Exit 1; stderr matches `no API key` |
+| T6b | No env, file mode 400 (read-only owner) | Stub recorded with token from file; exit 0 (DD-3 accepts 400) |
+| T7 | Same T1–T6b for `providers/bin/openrouter` (different base URL, model, key file path) | Same expected outcomes; OpenRouter env: `BASE_URL=https://openrouter.ai/api`, `MODEL=qwen/qwen3.6-plus:free` |
+| T8 | Wrapper invoked as `<bin>/deepseek --resume sess123 -p "hello"` (simulating worker resume) | Stub argv = `['--dangerously-skip-permissions', '--resume', 'sess123', '-p', 'hello']` (correct argv ordering, `-p` after `--resume`, no double-`-p`) |
+| T9 | `install.sh` against local server (TRINITY_BASE_URL) | `~/.claude/trinity.json` `providers.deepseek.cli` == `${HOME}/.claude/skills/trinity/bin/deepseek -p`; same shape for openrouter; both bin scripts present and `os.access(.., os.X_OK)` true |
+| T10 | `install.sh` run twice (idempotent) | Second run produces byte-identical `trinity.json` for these two providers; bin scripts still executable |
+| T11 | Pre-existing `~/.claude/trinity.json` with legacy `"cli": "deepseek_cy -p"`, then `install.sh` runs | Post-install `cli` == absolute-path form; legacy value overwritten; other providers untouched (regression: legacy → new migration) |
+| T12 | `make install` (local path) — same outcome as T9 + T11 | Pass |
+| T13 | Wrapper run with `KEY_FILE` on a path where `stat -f` AND `stat -c` both fail (simulated by replacing `stat` on PATH with a stub returning exit 1) | Exit 1; stderr matches `cannot stat .* refusing to read for safety` (covers the `unknown` case in PERM resolution) |
+| T14 | `make build` after editing `providers/deepseek.delta.md` and `providers/openrouter.delta.md` | `make verify-built` passes; generated `providers/deepseek.md` and `providers/openrouter.md` contain `"$HOME/.claude/skills/trinity/bin/deepseek" "$@"` and no `command -v deepseek_cy` line |
+
+Tests are pytest with `tmp_path` for `HOME` redirection. Pattern follows `tests/test_install.py` (existing precedent for `tmp_path` + `--global-config` injection).
+
+---
+
+## Risk
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `stat -f` (BSD) vs `stat -c` (GNU) split | Medium (Linux users) | Try BSD first, fall back to GNU, then `|| echo unknown` terminator; T13 covers the `unknown` branch |
+| `set -eu` trips on unset `HOME` | Very low | If `HOME` is unset the rest of trinity is broken anyway — fail loudly is correct |
+| Concurrent installs corrupt `trinity.json` | Very low | `install.py atomic_update` uses `fcntl.flock` (`scripts/install.py:55-78`) — already exercised by `test_concurrent_register_no_corruption` |
+| User has the old zsh function defined AND the new script registered | Low | New `cli` is an absolute path — PATH/function lookup never happens. Old function silently unused; user can delete `.zshrc` lines at leisure |
+| Migration: existing `trinity.json` has `deepseek_cy -p` | Medium | Re-running `install.sh` / `make install` overwrites the registration. T11 covers it. Documented in CHG TRN-2009. Not auto-rewritten on first dispatch (would surprise users) |
+| `chmod +x` failure in `install.sh` (e.g., noexec mount) | Very low | `set -eE` aborts; trap reports the failing file |
+| Editing generated `providers/<name>.md` directly bypasses `make verify-built` | Medium | §4 explicitly directs edits at `.delta.md`; T14 asserts `make verify-built` passes after `.delta.md` edits |
+| Future Anthropic-compat provider author copies an old `_cy` function from history | Low | CHG TRN-2009 + this PRP serve as the canonical pattern; bin script header comment names the pattern |
+| User has key file at non-default path (e.g., `~/keys/deepseek.txt`) | Low | Out of scope today — env var (`DEEPSEEK_API_KEY`) is the documented escape hatch. Future enhancement could read `DEEPSEEK_API_KEY_FILE` |
+
+---
+
+## Open Questions
+
+All resolved in Round 1 review (Codex / Gemini / GLM / DeepSeek unanimous):
+
+- ~~OQ-1~~ — **Resolved (No)**: wrappers are transparent passthroughs; `claude --help` is what users actually need.
+- ~~OQ-2~~ — **Resolved (Yes)**: accept mode `0400` in addition to `0600`. Folded into DD-3.
+- ~~OQ-3~~ — **Resolved (No)**: out of scope; existing `install.py unregister` covers user-driven removal. CHG TRN-2009 will document the command.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-04-26 | Initial draft | Claude Opus 4.7 |
+| 2026-04-26 | Round 2 revision per 4-model strict review: §1 stat handling + portability matrix + accept 400; §2 concrete diff incl. mkdir -p bin/; §3 Makefile parity explicit; §4 edits target .delta.md (NOT generated .md), keep `run_<provider>` function; DD-3 widened to 600 OR 400; DD-5/6/7/8 split for clarity; tests T6b/T8/T11/T13/T14 added; risks expanded; OQs resolved | Claude Opus 4.7 |

--- a/rules/TRN-2009-CHG-Remove-Zsh-Dependency.md
+++ b/rules/TRN-2009-CHG-Remove-Zsh-Dependency.md
@@ -1,0 +1,124 @@
+# CHG-2009: Remove Zsh Dependency from Trinity Providers
+
+**Applies to:** trinity/ package (`frankyxhl/trinity`)
+**Date:** 2026-04-26
+**Status:** In Progress
+**PRP:** TRN-2008 (Approved — Round 2: Codex 8.9/PASS, Gemini 9.8/PASS, GLM 8.8/PASS, DeepSeek 10/PASS)
+**Implementer:** Claude Opus 4.7
+
+---
+
+## Summary
+
+Replace the two `.zshrc`-defined wrapper functions (`deepseek_cy`, `openrouter_cy`) — registered today as the dispatch CLI for `deepseek` and `openrouter` providers — with portable POSIX shell scripts shipped in the trinity repo. After this change, a fresh user can install trinity (`install.sh` or `make install`) and use every registered provider with **no shell-rc edits**.
+
+See PRP TRN-2008 for full design rationale, alternatives considered, and 4-model strict-review resolution.
+
+---
+
+## Deliverables
+
+| File | Action |
+|------|--------|
+| `providers/bin/deepseek` | New — POSIX sh wrapper (~50 lines) |
+| `providers/bin/openrouter` | New — POSIX sh wrapper (~45 lines) |
+| `providers/deepseek.delta.md` | Edit — simplify `run_deepseek` Setup to 1-line wrapper call; clean frontmatter description |
+| `providers/openrouter.delta.md` | Edit — same shape for openrouter |
+| `providers/deepseek.md` | Regenerate via `make build` (do NOT edit directly) |
+| `providers/openrouter.md` | Regenerate via `make build` (do NOT edit directly) |
+| `install.sh` | Edit — `mkdir -p .../bin/`; download + `chmod +x` both bin scripts; register absolute paths |
+| `Makefile` | Edit — `install` target mirrors install.sh wiring |
+| `tests/test_anthropic_compat_wrappers.py` | New — pytest suite covering T1–T14 from PRP |
+| `README.md` | Edit — note `~/.secrets/<provider>_api_key` (mode 600) or `<PROVIDER>_API_KEY` env var |
+| `rules/TRN-0000-REF-Document-Index.md` | Update — add TRN-2008 (PRP) and TRN-2009 (CHG) rows |
+
+**No changes to:** `glm`, `codex`, `gemini` provider registrations; `trinity.json` schema; `discover.py`; `install.py`; `session.py`; `SKILL.md`.
+
+---
+
+## Migration
+
+**For existing users with `~/.claude/trinity.json` containing `"cli": "deepseek_cy -p"` or `"cli": "openrouter_cy -p"`:**
+
+Re-run the installer:
+
+```bash
+# remote
+curl -fsSL https://raw.githubusercontent.com/frankyxhl/trinity/main/install.sh | bash
+
+# or local
+cd <trinity-clone> && make install
+```
+
+The installer's `register` calls (`scripts/install.py`) overwrite the two `cli` strings to absolute-path form. Other providers (glm/codex/gemini) and any project-scoped configs are untouched.
+
+**To remove the now-dead zsh functions** (optional cleanup): delete the `deepseek_cy` and `openrouter_cy` definitions from `~/.zshrc` (or whichever shell-rc holds them). They are no longer reached.
+
+**To remove a provider entirely** (out of scope for this CHG, but documented for completeness):
+
+```bash
+python3 ~/.claude/skills/trinity/scripts/install.py unregister deepseek
+```
+
+---
+
+## Execution Log
+
+Workflow: TDD per COR-1500 — write failing tests first, then implement until green.
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Phase 6.1 — Write `tests/test_anthropic_compat_wrappers.py` (17 tests, all failing initially) | ✅ | RED confirmed — 17/17 fail with FileNotFoundError before bin scripts exist |
+| Phase 6.2 — Write `providers/bin/deepseek` and `providers/bin/openrouter` (POSIX sh) | ✅ | GREEN — 17/17 pytest pass; both files +x, `#!/bin/sh` shebang |
+| Phase 6.3 — Edit `providers/deepseek.delta.md` and `providers/openrouter.delta.md` | ✅ | `run_<provider>` simplified to 1-line wrapper call; frontmatter description cleaned |
+| Phase 6.4 — Run `make build` to regenerate `providers/<name>.md`; verify `make verify-built` passes | ✅ | Both regenerated; verify-built OK; no `command -v _cy` lines remain |
+| Phase 6.5 — Edit `install.sh` (mkdir + download + chmod + register absolute paths) | ✅ | T9 + T11 in `tests/test_install_sh.sh` cover the new behavior; both pass |
+| Phase 6.6 — Edit `Makefile` `install` target for parity | ✅ | Same wiring (`mkdir -p .../bin`, copy + chmod, register absolute paths via `$(HOME)`) |
+| Phase 6.7 — Edit `README.md` (key file note in Quick Start) | ✅ | Step 2 expanded with env-var / key-file precedence + perm requirement; legacy `*_cy` snippet replaced with absolute-path example |
+| Phase 7 — `make test` green | ✅ | pytest 63/63 + shell 10/10 + release-workflow 53/53; verify-built OK |
+| Phase 8 — `make lint` clean | ✅ | ruff check + ruff format --check both clean |
+| Pause — report to user before mutating `~/.claude/trinity.json` or pushing | in_progress | |
+| User confirmation — proceed with commit + push + PR | blocked on user | |
+| `git commit` + `git push` + `gh pr create` | pending | |
+
+---
+
+## Test Strategy
+
+Per PRP TRN-2008 §Test Cases, T1–T14:
+
+- **T1–T7**: wrapper scripts behavior (env precedence, perm check, missing-key, exec semantics) — pytest with PATH-injected Python `claude` stub recording argv+env to a temp file.
+- **T8**: `--resume <id> -p <prompt>` argv ordering (verifies the worker's resume contract still produces correct argv).
+- **T9–T12**: `install.sh` and `make install` register absolute paths; idempotent; legacy `deepseek_cy -p` migration overwrites correctly.
+- **T13**: stat-fails-on-exotic-fs (both BSD and GNU `stat` return non-zero) → `unknown` branch refuses with stderr.
+- **T14**: `make build` from edited `.delta.md` produces `.md` that passes `make verify-built` and contains the new 1-line wrapper.
+
+---
+
+## Risk Realized / Mitigations Applied
+
+| Risk (from PRP) | Realized? | How handled |
+|-----------------|-----------|-------------|
+| Generated `.md` edits would fail `make verify-built` | (TBD during impl) | §4 of PRP and Step 6.3 explicitly direct edits at `.delta.md` source |
+| `stat -f` (BSD) vs `-c` (GNU) split | (TBD during impl) | Wrapper script tries both, then `\|\| echo unknown` terminator with explicit case branch |
+| Concurrent install corrupts `trinity.json` | Already mitigated | `install.py` uses `fcntl.flock` (existing test `test_concurrent_register_no_corruption`) |
+
+---
+
+## Out of Scope
+
+- Python `trinity-exec` dispatcher (rejected alternative B in PRP)
+- `shape` discriminator in `trinity.json` schema
+- `openai-compat` shape
+- Moving provider config into agent .md frontmatter (deferred alternative D)
+- Changes to `glm`, `codex`, `gemini` registrations
+- Windows support
+- `DEEPSEEK_API_KEY_FILE` / non-default key path support
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-04-26 | Initial draft after PRP TRN-2008 approval (Round 2 PASS from all four reviewers) | Claude Opus 4.7 |

--- a/tests/test_anthropic_compat_wrappers.py
+++ b/tests/test_anthropic_compat_wrappers.py
@@ -1,0 +1,289 @@
+"""
+Tests for providers/bin/deepseek and providers/bin/openrouter (TRN-2008/TRN-2009).
+
+The wrapper scripts run `exec claude --dangerously-skip-permissions "$@"` after
+loading an API key (env DEEPSEEK_API_KEY / OPENROUTER_API_KEY wins; falls back
+to ~/.secrets/<provider>_api_key with mode 600 or 400) and injecting
+ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_MODEL etc.
+
+Strategy: prepend a Python `claude` stub onto PATH that records argv + selected
+env vars to a JSON file before exit(0). Because the wrapper does `exec`, the
+stub IS the leaf process — the JSON file is the source of truth for assertions.
+
+Test grid covers PRP TRN-2008 §Test Cases (T1-T8, T13) for both wrappers.
+T9-T12 (install.sh integration) live in tests/test_install_sh.sh.
+T14 (make verify-built after .delta.md edit) is enforced by `make test` itself.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+DEEPSEEK_BIN = REPO_ROOT / "providers" / "bin" / "deepseek"
+OPENROUTER_BIN = REPO_ROOT / "providers" / "bin" / "openrouter"
+
+CAPTURED_ENV_KEYS = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL",
+    "API_TIMEOUT_MS",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+    "CLAUDE_CONFIG_DIR",
+)
+
+
+# --- fixtures ---
+
+
+@pytest.fixture
+def stub_env(tmp_path):
+    """
+    Return a callable: stub_env(env_extra=None) -> (env, record_path).
+
+    Sets up tmp_path/bin/claude as a Python script that records argv+env to JSON
+    and exits 0. PATH is rebuilt to put the stub first; HOME is set to tmp_path.
+    Wrapper scripts inherit this env when invoked via subprocess.
+    """
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    record_path = tmp_path / "claude.invoked.json"
+    stub = bin_dir / "claude"
+    stub.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "captured_env = {k: os.environ.get(k) for k in (\n"
+        + ",\n".join(f"    {k!r}" for k in CAPTURED_ENV_KEYS)
+        + ",\n)}\n"
+        f"open({str(record_path)!r}, 'w').write(json.dumps({{\n"
+        "    'argv': sys.argv[1:],\n"
+        "    'env': captured_env,\n"
+        "}))\n"
+        "sys.exit(0)\n"
+    )
+    stub.chmod(0o755)
+
+    secrets_dir = tmp_path / ".secrets"
+    secrets_dir.mkdir()
+
+    def make_env(env_extra=None):
+        env = {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "HOME": str(tmp_path),
+        }
+        if env_extra:
+            env.update(env_extra)
+        return env, record_path
+
+    return make_env
+
+
+def _run(wrapper, args, env):
+    return subprocess.run(
+        [str(wrapper), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_key_file(home, provider, content, mode=0o600):
+    p = Path(home) / ".secrets" / f"{provider}_api_key"
+    p.write_text(content)
+    p.chmod(mode)
+    return p
+
+
+# --- DeepSeek wrapper tests (T1-T6, T6b, T8) ---
+
+
+def test_t1_deepseek_env_key_sets_anthropic_env_and_passes_argv(stub_env):
+    env, rec = stub_env({"DEEPSEEK_API_KEY": "from-env-xxx"})
+    res = _run(DEEPSEEK_BIN, ["arg1", "arg2"], env)
+    assert res.returncode == 0, res.stderr
+    rec_data = json.loads(rec.read_text())
+    assert rec_data["argv"] == ["--dangerously-skip-permissions", "arg1", "arg2"]
+    e = rec_data["env"]
+    assert e["ANTHROPIC_BASE_URL"] == "https://api.deepseek.com/anthropic"
+    assert e["ANTHROPIC_AUTH_TOKEN"] == "from-env-xxx"
+    assert e["ANTHROPIC_API_KEY"] == "from-env-xxx"
+    assert e["ANTHROPIC_MODEL"] == "deepseek-v4-pro"
+    assert e["ANTHROPIC_SMALL_FAST_MODEL"] == "deepseek-v4-flash"
+    assert e["API_TIMEOUT_MS"] == "600000"
+    assert e["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+    assert e["CLAUDE_CONFIG_DIR"].endswith(".claude-deepseek")
+
+
+def test_t2_deepseek_no_env_reads_key_file_mode_600(stub_env):
+    env, rec = stub_env()
+    _write_key_file(env["HOME"], "deepseek", "from-file-yyy", mode=0o600)
+    res = _run(DEEPSEEK_BIN, [], env)
+    assert res.returncode == 0, res.stderr
+    assert json.loads(rec.read_text())["env"]["ANTHROPIC_AUTH_TOKEN"] == "from-file-yyy"
+
+
+def test_t3_deepseek_env_wins_over_file(stub_env):
+    env, rec = stub_env({"DEEPSEEK_API_KEY": "from-env"})
+    _write_key_file(env["HOME"], "deepseek", "from-file", mode=0o600)
+    res = _run(DEEPSEEK_BIN, [], env)
+    assert res.returncode == 0
+    assert json.loads(rec.read_text())["env"]["ANTHROPIC_AUTH_TOKEN"] == "from-env"
+
+
+def test_t4_deepseek_no_key_anywhere_exits_1(stub_env):
+    env, rec = stub_env()
+    res = _run(DEEPSEEK_BIN, [], env)
+    assert res.returncode == 1
+    assert "no API key" in res.stderr
+    assert not rec.exists(), "claude stub should not have been invoked"
+
+
+def test_t5_deepseek_refuses_world_readable_key_file(stub_env):
+    env, rec = stub_env()
+    _write_key_file(env["HOME"], "deepseek", "secret", mode=0o644)
+    res = _run(DEEPSEEK_BIN, [], env)
+    assert res.returncode == 1
+    assert "refuse to read" in res.stderr
+    assert "perm 644" in res.stderr
+    assert "expected 600 or 400" in res.stderr
+    assert not rec.exists()
+
+
+def test_t6_deepseek_empty_key_file_treated_as_missing(stub_env):
+    env, rec = stub_env()
+    _write_key_file(env["HOME"], "deepseek", "", mode=0o600)
+    res = _run(DEEPSEEK_BIN, [], env)
+    assert res.returncode == 1
+    assert "no API key" in res.stderr
+
+
+def test_t6b_deepseek_accepts_key_file_mode_400(stub_env):
+    env, rec = stub_env()
+    _write_key_file(env["HOME"], "deepseek", "ro-key", mode=0o400)
+    res = _run(DEEPSEEK_BIN, [], env)
+    assert res.returncode == 0, res.stderr
+    assert json.loads(rec.read_text())["env"]["ANTHROPIC_AUTH_TOKEN"] == "ro-key"
+
+
+def test_t8_deepseek_resume_argv_ordering(stub_env):
+    """Worker invokes resume as: <wrapper> --resume <id> -p "<prompt>".
+    Wrapper must produce: claude --dangerously-skip-permissions --resume <id> -p "<prompt>"
+    (no double -p, --resume placed correctly)."""
+    env, rec = stub_env({"DEEPSEEK_API_KEY": "k"})
+    res = _run(DEEPSEEK_BIN, ["--resume", "sess123", "-p", "hello world"], env)
+    assert res.returncode == 0, res.stderr
+    assert json.loads(rec.read_text())["argv"] == [
+        "--dangerously-skip-permissions",
+        "--resume",
+        "sess123",
+        "-p",
+        "hello world",
+    ]
+
+
+# --- OpenRouter wrapper tests (T7 = T1-T6/T8 mirrored) ---
+
+
+def test_t7_openrouter_env_key_sets_anthropic_env(stub_env):
+    env, rec = stub_env({"OPENROUTER_API_KEY": "or-env"})
+    res = _run(OPENROUTER_BIN, ["arg"], env)
+    assert res.returncode == 0, res.stderr
+    rec_data = json.loads(rec.read_text())
+    assert rec_data["argv"] == ["--dangerously-skip-permissions", "arg"]
+    e = rec_data["env"]
+    assert e["ANTHROPIC_BASE_URL"] == "https://openrouter.ai/api"
+    assert e["ANTHROPIC_AUTH_TOKEN"] == "or-env"
+    assert e["ANTHROPIC_MODEL"] == "qwen/qwen3.6-plus:free"
+    assert e["CLAUDE_CONFIG_DIR"].endswith(".claude-openrouter")
+
+
+def test_t7_openrouter_reads_key_file(stub_env):
+    env, rec = stub_env()
+    _write_key_file(env["HOME"], "openrouter", "from-file", mode=0o600)
+    res = _run(OPENROUTER_BIN, [], env)
+    assert res.returncode == 0, res.stderr
+    assert json.loads(rec.read_text())["env"]["ANTHROPIC_AUTH_TOKEN"] == "from-file"
+
+
+def test_t7_openrouter_env_wins_over_file(stub_env):
+    env, rec = stub_env({"OPENROUTER_API_KEY": "from-env"})
+    _write_key_file(env["HOME"], "openrouter", "from-file", mode=0o600)
+    res = _run(OPENROUTER_BIN, [], env)
+    assert res.returncode == 0
+    assert json.loads(rec.read_text())["env"]["ANTHROPIC_AUTH_TOKEN"] == "from-env"
+
+
+def test_t7_openrouter_no_key_anywhere_exits_1(stub_env):
+    env, rec = stub_env()
+    res = _run(OPENROUTER_BIN, [], env)
+    assert res.returncode == 1
+    assert "no API key" in res.stderr
+
+
+def test_t7_openrouter_refuses_world_readable(stub_env):
+    env, rec = stub_env()
+    _write_key_file(env["HOME"], "openrouter", "secret", mode=0o644)
+    res = _run(OPENROUTER_BIN, [], env)
+    assert res.returncode == 1
+    assert "refuse to read" in res.stderr
+
+
+def test_t7_openrouter_resume_argv(stub_env):
+    env, rec = stub_env({"OPENROUTER_API_KEY": "k"})
+    res = _run(OPENROUTER_BIN, ["--resume", "or-sess", "-p", "x"], env)
+    assert res.returncode == 0
+    assert json.loads(rec.read_text())["argv"] == [
+        "--dangerously-skip-permissions",
+        "--resume",
+        "or-sess",
+        "-p",
+        "x",
+    ]
+
+
+# --- Stat-failure portability test (T13) ---
+
+
+def test_t13_deepseek_unknown_perm_when_stat_fails(stub_env, tmp_path):
+    """If both `stat -f` and `stat -c` fail (exotic FS / sshfs / etc.), the
+    wrapper must refuse via the explicit `unknown` branch — never silently
+    abort under `set -e`."""
+    bin_dir = tmp_path / "bin"
+    # Replace `stat` on PATH with a stub that always exits 1 — simulates both
+    # BSD and GNU stat failing on the key file.
+    stat_stub = bin_dir / "stat"
+    stat_stub.write_text("#!/bin/sh\nexit 1\n")
+    stat_stub.chmod(0o755)
+
+    env, rec = stub_env()
+    _write_key_file(env["HOME"], "deepseek", "secret", mode=0o600)
+
+    res = _run(DEEPSEEK_BIN, [], env)
+    assert res.returncode == 1
+    assert "cannot stat" in res.stderr
+    assert "refusing to read for safety" in res.stderr
+    assert not rec.exists()
+
+
+# --- Sanity check on installed bits (these are the obvious RED indicators) ---
+
+
+def test_wrapper_scripts_exist_and_executable():
+    assert DEEPSEEK_BIN.is_file(), f"{DEEPSEEK_BIN} missing"
+    assert OPENROUTER_BIN.is_file(), f"{OPENROUTER_BIN} missing"
+    assert os.access(DEEPSEEK_BIN, os.X_OK), f"{DEEPSEEK_BIN} not executable"
+    assert os.access(OPENROUTER_BIN, os.X_OK), f"{OPENROUTER_BIN} not executable"
+
+
+def test_wrappers_use_posix_sh_shebang():
+    for p in (DEEPSEEK_BIN, OPENROUTER_BIN):
+        first_line = p.read_text().splitlines()[0]
+        assert first_line == "#!/bin/sh", (
+            f"{p}: expected POSIX sh shebang, got {first_line!r}"
+        )

--- a/tests/test_install_sh.sh
+++ b/tests/test_install_sh.sh
@@ -200,6 +200,96 @@ t7_success_output_version() {
     rm -rf "${FAKE_HOME}"
 }
 
+# T9 (TRN-2008/2009): bin scripts present + executable; deepseek/openrouter
+# registered with absolute-path cli (no _cy reference).
+t9_bin_scripts_and_absolute_cli() {
+    FAKE_HOME=$(mktemp -d)
+    _start_server "${REPO_DIR}"
+    HOME="${FAKE_HOME}" TRINITY_BASE_URL="http://localhost:${SERVER_PORT}" \
+        bash "${INSTALL_SCRIPT}" >/dev/null
+    _stop_server
+
+    BIN_DIR="${FAKE_HOME}/.claude/skills/trinity/bin"
+    for w in deepseek openrouter; do
+        if [ ! -x "${BIN_DIR}/${w}" ]; then
+            _fail "T9: ${BIN_DIR}/${w} missing or not executable"
+            rm -rf "${FAKE_HOME}"; return
+        fi
+    done
+
+    TRINITY_JSON="${FAKE_HOME}/.claude/trinity.json"
+    EXPECTED_DS="${BIN_DIR}/deepseek -p"
+    EXPECTED_OR="${BIN_DIR}/openrouter -p"
+    ACTUAL_DS=$(python3 -c "import json; print(json.load(open('${TRINITY_JSON}'))['providers']['deepseek']['cli'])")
+    ACTUAL_OR=$(python3 -c "import json; print(json.load(open('${TRINITY_JSON}'))['providers']['openrouter']['cli'])")
+
+    if [ "${ACTUAL_DS}" != "${EXPECTED_DS}" ]; then
+        _fail "T9: deepseek cli mismatch: got '${ACTUAL_DS}' expected '${EXPECTED_DS}'"
+        rm -rf "${FAKE_HOME}"; return
+    fi
+    if [ "${ACTUAL_OR}" != "${EXPECTED_OR}" ]; then
+        _fail "T9: openrouter cli mismatch: got '${ACTUAL_OR}' expected '${EXPECTED_OR}'"
+        rm -rf "${FAKE_HOME}"; return
+    fi
+
+    # Sanity: no legacy _cy reference anywhere in trinity.json.
+    if grep -q "_cy" "${TRINITY_JSON}"; then
+        _fail "T9: trinity.json still contains _cy reference"
+        rm -rf "${FAKE_HOME}"; return
+    fi
+
+    _pass "T9: bin scripts installed + executable; deepseek/openrouter cli use absolute paths"
+    rm -rf "${FAKE_HOME}"
+}
+
+# T11 (TRN-2008/2009): legacy `deepseek_cy -p` cli is overwritten by re-install.
+t11_legacy_cli_migration() {
+    FAKE_HOME=$(mktemp -d)
+    mkdir -p "${FAKE_HOME}/.claude"
+    # Simulate an existing user with the legacy zsh-wrapper registration.
+    cat > "${FAKE_HOME}/.claude/trinity.json" <<EOF
+{
+  "providers": {
+    "deepseek":   {"cli": "deepseek_cy -p",  "installed": true},
+    "openrouter": {"cli": "openrouter_cy -p", "installed": true},
+    "glm":        {"cli": "droid exec --model glm-5", "installed": true}
+  }
+}
+EOF
+
+    _start_server "${REPO_DIR}"
+    HOME="${FAKE_HOME}" TRINITY_BASE_URL="http://localhost:${SERVER_PORT}" \
+        bash "${INSTALL_SCRIPT}" >/dev/null
+    _stop_server
+
+    TRINITY_JSON="${FAKE_HOME}/.claude/trinity.json"
+    BIN_DIR="${FAKE_HOME}/.claude/skills/trinity/bin"
+
+    # Legacy cli must have been overwritten.
+    if grep -q "_cy" "${TRINITY_JSON}"; then
+        _fail "T11: legacy _cy entries not overwritten"
+        rm -rf "${FAKE_HOME}"; return
+    fi
+
+    # New absolute-path cli must be present.
+    EXPECTED_DS="${BIN_DIR}/deepseek -p"
+    ACTUAL_DS=$(python3 -c "import json; print(json.load(open('${TRINITY_JSON}'))['providers']['deepseek']['cli'])")
+    if [ "${ACTUAL_DS}" != "${EXPECTED_DS}" ]; then
+        _fail "T11: deepseek cli not migrated: got '${ACTUAL_DS}'"
+        rm -rf "${FAKE_HOME}"; return
+    fi
+
+    # Other providers untouched (glm was pre-existing).
+    ACTUAL_GLM=$(python3 -c "import json; print(json.load(open('${TRINITY_JSON}'))['providers']['glm']['cli'])")
+    if [ "${ACTUAL_GLM}" != "droid exec --model glm-5" ]; then
+        _fail "T11: glm registration mutated unexpectedly: '${ACTUAL_GLM}'"
+        rm -rf "${FAKE_HOME}"; return
+    fi
+
+    _pass "T11: legacy deepseek_cy/openrouter_cy cli overwritten with absolute paths; other providers untouched"
+    rm -rf "${FAKE_HOME}"
+}
+
 # Run all tests
 t1_happy_path
 t2_idempotent
@@ -209,6 +299,8 @@ t4_leading_v_stripped
 t5_dirs_created
 t6_404_exits_nonzero
 t7_success_output_version
+t9_bin_scripts_and_absolute_cli
+t11_legacy_cli_migration
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"


### PR DESCRIPTION
## Summary

DeepSeek and OpenRouter providers no longer require user-side `.zshrc` shell functions (`deepseek_cy`, `openrouter_cy`). They now ship as portable POSIX `sh` wrappers in `providers/bin/`, installed to `~/.claude/skills/trinity/bin/` by `install.sh` and `make install`.

After this PR, a fresh user can install trinity and use every registered provider with **no shell-rc edits**.

## Approval trail (4-model strict review per COR-1602)

PRP `rules/TRN-2008-PRP-Remove-Zsh-Dependency.md` — converged in 2 iterations:

| Reviewer | Round 1 | Round 2 |
|----------|---------|---------|
| Codex (high effort) | 7.6 FIX | **8.9 PASS** |
| Gemini | 8.6 FIX | **9.8 PASS** |
| GLM | 7.4 FIX | **8.8 PASS** |
| DeepSeek | 6.8 FIX | **10.0 PASS** |

Implementation review (GLM, post-code): **SHIP** — verified §1–§4 + DD-1..DD-8 + T1–T14 all match approved PRP.

CHG `rules/TRN-2009-CHG-Remove-Zsh-Dependency.md` carries the execution log.

## How it works

- `providers/bin/<provider>` — POSIX `sh`, ~50 lines each
  - Loads API key from `$<PROVIDER>_API_KEY` (preferred) or `~/.secrets/<provider>_api_key`
  - Hard-refuses key files with mode > 0600 (accepts 600 or 400)
  - BSD/GNU `stat` fallback with `|| echo unknown` so `set -e` never silently aborts
  - `exec claude --dangerously-skip-permissions \"\$@\"` so signals propagate cleanly
- `install.sh` / `Makefile install` — `mkdir -p .../bin/`, download + `chmod +x`, register absolute path as the `cli` value
- `providers/<provider>.delta.md` — `run_<provider>` collapses from 25 lines to 1: `\"\$HOME/.claude/skills/trinity/bin/<provider>\" \"\$@\"`

## Migration

Existing users with `\"cli\": \"deepseek_cy -p\"` or `\"cli\": \"openrouter_cy -p\"` in `~/.claude/trinity.json`: re-run the installer — `cli` is overwritten to absolute-path form. Other providers (`glm`, `codex`, `gemini`) untouched. Then delete the now-dead zsh functions at leisure. Test T11 verifies this migration explicitly.

## Test plan

- [x] `pytest tests/` — 63/63 (46 existing + 17 new in `test_anthropic_compat_wrappers.py`)
- [x] `tests/test_install_sh.sh` — 10/10 (8 existing + T9 absolute-path cli + T11 legacy migration)
- [x] `tests/test_release_workflow.sh` — 53/53 (untouched)
- [x] `make verify-built` — generated `.md` matches `.delta.md` source
- [x] `make lint` — `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)