### PR TITLE
evolve(trn): cycle 1 — Makefile cross-platform fix + SOP/metadata cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+- `Makefile` `bump` target: replace BSD-only `sed -i ''` with portable `perl -i -pe` for both `__version__` (in `scripts/__init__.py`) and `REQUIRED_VERSION` (in `SKILL.md`) rewrites. The prior form failed on Linux because GNU sed treats `''` as the input file path — a Linux maintainer running `make bump` would have hit the same trap class as the v2.0.0 stat-order incident. Found by the first run of the TRN-1801 evolve cycle (signal: cross-platform shell trap grep). Pre-existing version pins were already in sync (VERSION=2.0.3 / `__version__=2.0.3` / `REQUIRED_VERSION=2.0.3`), so this is preventive, not a fix-after-incident. New `tests/test_make_bump.sh` adds two regression cases — T1 verifies `perl -i -pe` rewrites both pin files and preserves unrelated lines; T2 is a static guard that fails if anyone re-introduces `sed -i ''` in the bump target. Wired into `make test`.
+- `rules/TRN-1006-SOP-Provider-Model-IDs.md`: backfill canonical SOP structure — add `Last reviewed` metadata, `## When to Use`, `## When NOT to Use`, and rename `## Steps — Updating a Model ID` to `## Steps` with a one-line preamble (the suffix tripped `af validate`'s exact-match section check). Brings the SOP added in v2.0.3 to the same shape as TRN-1801 / TRN-1000.
+- Metadata backfill across 8 PRJ docs flagged by `af validate`: `TRN-1004-SOP-Release.md` and `TRN-1005-SOP-Install.md` now carry `Last reviewed: 2026-04-26`; `TRN-2003/2004/2005/2006/2007/2009-CHG-*.md` now carry both `Last updated` (matching their original `Date`) and `Last reviewed: 2026-04-26`. Drops `af validate` issue count from 43 → 25.
+- `rules/TRN-1003-SOP-Version-Bump.md` line 24: replace stale "BSD `sed -i ''` syntax" note with the new portable `perl -i -pe` form and a pointer to `tests/test_make_bump.sh`. Caught by Codex in the §5 Reviewer A gate on the diff — active-SOP drift would have left a future contributor reading "never invoke `make bump` from CI" while the actual implementation was already cross-platform. Added `Last reviewed` while touching the metadata.
+
+### Notes
+- This is the first run of the TRN-1801 evolve cycle. Two-reviewer gate met (Codex + DeepSeek; both reviewed the candidate slate against TRN-1800 weights and converged on Option 2 constrained: C2 + C4 + C1-with-regression-test). Skipped C3 (TRN-1001/1002/1003/1004 structural-section retrofit) — atomicity rule splits it into 16 sub-candidates, deferred for a future cycle.
+
 ## [2.0.3] - 2026-04-26
 ### Added
 - `rules/TRN-1800-REF-Evolution-Philosophy.md` — PRJ-layer override of COR-1800 for the trinity repo. Defines trinity-specific behaviour baseline (the union of `make test` / `make verify-built` / `make lint` / `install.sh` share-readiness against tmp HOME / Linux CI parity / dispatch sample), and overrides COR-1800's code-evolution and document-evolution weight tables plus the signal-source table with trinity-specific axes (cross-platform parity, generated-vs-source build via `_base/`, `Makefile`↔`install.sh` provider-parity, model-ID drift vs vendor docs).

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ test:           ## Run all tests (TRN-1001 + TRN-2004 build tests + TRN-2006 rel
 	.venv/bin/pytest tests/ -v
 	bash tests/test_build_providers.sh
 	bash tests/test_release_workflow.sh
+	bash tests/test_make_bump.sh
 
 lint:           ## Check and format code (TRN-1002)
 	.venv/bin/ruff check scripts/ tests/
@@ -68,8 +69,8 @@ bump:           ## Bump version (TRN-1003): make bump VERSION=x.y.z
 		(echo "Invalid semver: $(VERSION)"; exit 1)
 	$(MAKE) build
 	@echo "$(VERSION)" > VERSION
-	@sed -i '' 's/__version__ = ".*"/__version__ = "$(VERSION)"/' scripts/__init__.py
-	@sed -i '' 's/REQUIRED_VERSION=".*"/REQUIRED_VERSION="$(VERSION)"/' SKILL.md
+	@perl -i -pe 's/__version__ = ".*"/__version__ = "$(VERSION)"/' scripts/__init__.py
+	@perl -i -pe 's/REQUIRED_VERSION=".*"/REQUIRED_VERSION="$(VERSION)"/' SKILL.md
 	@echo "Bumped to $(VERSION)"
 
 release-prep:   ## Stage release-metadata commit + local tag (TRN-1004): no push, CI publishes

--- a/rules/TRN-1003-SOP-Version-Bump.md
+++ b/rules/TRN-1003-SOP-Version-Bump.md
@@ -2,6 +2,7 @@
 
 **Applies to:** trinity/ package
 **Last updated:** 2026-04-26
+**Last reviewed:** 2026-04-26
 **Status:** Active
 
 ---
@@ -21,7 +22,9 @@ Human preparation step before `make release-prep` (TRN-1004). Updates CHANGELOG 
 4. Do not commit the metadata files — `make release-prep` (TRN-1004) stages and commits all 4 files together as `Release vX.Y.Z` and creates the local tag
 5. Worktree will be dirty (CHANGELOG.md + VERSION + __init__.py + SKILL.md modified, all unstaged) — expected. Proceed to TRN-1004.
 
-**Local-only:** `make bump` uses BSD `sed -i ''` syntax which fails on Linux. Never invoke `make bump` from CI. The release workflow (TRN-2006) explicitly avoids it.
+**Portable in-place rewrite:** `make bump` uses `perl -i -pe` (cross-platform: macOS BSD + Linux GNU) to rewrite `__version__` in `scripts/__init__.py` and `REQUIRED_VERSION` in `SKILL.md`. The prior BSD-only `sed -i ''` form would fail on Linux because GNU sed treats `''` as the input file path. Regression test: `tests/test_make_bump.sh` (T1 = portable rewrite semantics; T2 = static guard against re-introducing the BSD-only form). Wired into `make test`.
+
+The release workflow (TRN-2006) still does not call `make bump` — release-time version edits are made before pushing the tag, not from inside CI — but the portability fix removes a contributor-side trap on Linux dev machines.
 
 ---
 
@@ -32,4 +35,5 @@ Human preparation step before `make release-prep` (TRN-1004). Updates CHANGELOG 
 | 2026-03-21 | Initial version | Claude Code |
 | 2026-04-03 | Strengthen Step 0: explicit commit-first requirement | Claude Code |
 | 2026-04-25 | Note `make build` runs as part of `make bump` (TRN-2004) | Claude Opus 4.7 |
+| 2026-04-26 | TRN-1801 evolve cycle 1: replace stale `sed -i ''` note with `perl -i -pe` (matches C1 Makefile fix) + reference `tests/test_make_bump.sh`. Add `Last reviewed`. | Claude Opus 4.7 |
 | 2026-04-26 | Step 4: `make release` → `make release-prep` (TRN-2006); add BSD-sed warning | Claude Opus 4.7 |

--- a/rules/TRN-1004-SOP-Release.md
+++ b/rules/TRN-1004-SOP-Release.md
@@ -2,6 +2,7 @@
 
 **Applies to:** trinity/ package
 **Last updated:** 2026-04-26
+**Last reviewed:** 2026-04-26
 **Status:** Active
 
 ---

--- a/rules/TRN-1005-SOP-Install.md
+++ b/rules/TRN-1005-SOP-Install.md
@@ -2,6 +2,7 @@
 
 **Applies to:** trinity/ package
 **Last updated:** 2026-03-21
+**Last reviewed:** 2026-04-26
 **Status:** Active
 
 ---

--- a/rules/TRN-1006-SOP-Provider-Model-IDs.md
+++ b/rules/TRN-1006-SOP-Provider-Model-IDs.md
@@ -2,6 +2,7 @@
 
 **Applies to:** Trinity project (`frankyxhl/trinity`)
 **Last updated:** 2026-04-26
+**Last reviewed:** 2026-04-26
 **Status:** Active
 **Related:** TRN-2005 (CHG: Pin trinity-codex to gpt-5.5), TRN-2009 (CHG: Remove zsh dependency)
 
@@ -25,6 +26,20 @@ Each provider exposes multiple model variants:
 | Date/snapshot | `claude-opus-4-7`, `claude-opus-4-7[1m]` |
 
 If Trinity defers to the user's CLI default (`~/.codex/config.toml`, `~/.deepseek/config`, etc.), behaviour is non-deterministic across machines and across user reconfigurations — the same `/trinity codex "x"` could pick `gpt-5.4` on one box and `gpt-5.5-mini` on another. We pin explicitly to make `make install` produce the same provider behaviour everywhere.
+
+---
+
+## When to Use
+
+- Bumping a provider's model ID after vendor announces a new tier or snapshot (e.g., DeepSeek announces 1M-context, Codex pins move from GPT-5.4 → GPT-5.5).
+- Pinning a previously-unpinned provider for the first time, when CLI-default drift starts producing surprises across machines.
+- Reviewing whether existing pins still match current vendor docs (cadence: per evolve cycle, signal in TRN-1800).
+
+## When NOT to Use
+
+- Cosmetic edits to a model name (e.g., adding a snapshot date that the provider treats as a synonym) — bump VERSION instead, no SOP required.
+- Provider behaviour change that lives entirely in the agent `.delta.md` prompt (system message, session resume flag) — that's a doc-only change.
+- Trying to *unpin* a provider (revert to CLI default) — re-run the routing decision from TRN-1000; pinning vs unpinning is a different question than which value to pin to.
 
 ---
 
@@ -78,7 +93,9 @@ Single source of truth per provider:
 
 ---
 
-## Steps — Updating a Model ID
+## Steps
+
+The exact procedure depends on which pin location the provider uses. Section A covers native-CLI providers (codex, glm, gemini); Section B covers Anthropic-compat wrappers (deepseek, openrouter); Section C covers verification after `make install`.
 
 ### A. Native-CLI providers (codex, glm)
 

--- a/rules/TRN-2003-CHG-Remote-Install-Script.md
+++ b/rules/TRN-2003-CHG-Remote-Install-Script.md
@@ -2,6 +2,8 @@
 
 **Applies to:** trinity/ package (`frankyxhl/trinity`)
 **Date:** 2026-03-21
+**Last updated:** 2026-03-21
+**Last reviewed:** 2026-04-26
 **Status:** In Progress
 **PRP:** TRN-2002 (Approved, Codex 9.2/PASS, Gemini 9.8/PASS)
 **Implementer:** Claude Sonnet 4.6

--- a/rules/TRN-2004-CHG-Provider-Files-Refactor.md
+++ b/rules/TRN-2004-CHG-Provider-Files-Refactor.md
@@ -2,6 +2,8 @@
 
 **Applies to:** trinity/ package (`frankyxhl/trinity`)
 **Date:** 2026-04-25
+**Last updated:** 2026-04-25
+**Last reviewed:** 2026-04-26
 **Requested by:** Frank
 **Status:** Approved
 **Priority:** Medium

--- a/rules/TRN-2005-CHG-Codex-GPT-5.5-Pin.md
+++ b/rules/TRN-2005-CHG-Codex-GPT-5.5-Pin.md
@@ -2,6 +2,8 @@
 
 **Applies to:** trinity/ package (`frankyxhl/trinity`)
 **Date:** 2026-04-26
+**Last updated:** 2026-04-26
+**Last reviewed:** 2026-04-26
 **Status:** In Progress
 **Requested by:** Frank
 **Priority:** Low

--- a/rules/TRN-2006-CHG-Release-On-Tag-Workflow.md
+++ b/rules/TRN-2006-CHG-Release-On-Tag-Workflow.md
@@ -2,6 +2,8 @@
 
 **Applies to:** trinity/ package (`frankyxhl/trinity`)
 **Date:** 2026-04-26
+**Last updated:** 2026-04-26
+**Last reviewed:** 2026-04-26
 **Status:** In Progress
 **Requested by:** Frank
 **Priority:** Medium

--- a/rules/TRN-2007-CHG-One-Click-Release.md
+++ b/rules/TRN-2007-CHG-One-Click-Release.md
@@ -2,6 +2,8 @@
 
 **Applies to:** trinity/ package (`frankyxhl/trinity`)
 **Date:** 2026-04-26
+**Last updated:** 2026-04-26
+**Last reviewed:** 2026-04-26
 **Status:** In Progress
 **Requested by:** Frank
 **Priority:** Low

--- a/rules/TRN-2009-CHG-Remove-Zsh-Dependency.md
+++ b/rules/TRN-2009-CHG-Remove-Zsh-Dependency.md
@@ -2,6 +2,8 @@
 
 **Applies to:** trinity/ package (`frankyxhl/trinity`)
 **Date:** 2026-04-26
+**Last updated:** 2026-04-26
+**Last reviewed:** 2026-04-26
 **Status:** In Progress
 **PRP:** TRN-2008 (Approved — Round 2: Codex 8.9/PASS, Gemini 9.8/PASS, GLM 8.8/PASS, DeepSeek 10/PASS)
 **Implementer:** Claude Opus 4.7

--- a/tests/test_make_bump.sh
+++ b/tests/test_make_bump.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# tests/test_make_bump.sh — Regression test for cross-platform `make bump` (TRN-1801 cycle 1, evolve C1)
+#
+# The `bump` target rewrites __version__ in scripts/__init__.py and REQUIRED_VERSION
+# in SKILL.md. Prior to this test, the target used `sed -i ''` which is BSD-only —
+# on Linux, `''` is interpreted as the input file and the command fails. The fix is
+# `perl -i -pe`, which is portable across macOS (BSD) and Linux (GNU).
+#
+# This test guards against silent regression to the BSD-only form, and verifies the
+# substitution semantics on a fixture file.
+#
+# Usage: bash tests/test_make_bump.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# T1: portable in-place rewrite of __version__ and REQUIRED_VERSION succeeds and
+# preserves unrelated lines, on whichever OS the test runs.
+t1_portable_in_place_rewrite() {
+    TMP=$(mktemp -d)
+    cat > "${TMP}/init.py" <<'EOF'
+__version__ = "0.0.0"
+keep_me = True
+EOF
+    cat > "${TMP}/skill.md" <<'EOF'
+prefix
+REQUIRED_VERSION="0.0.0"
+suffix
+EOF
+
+    perl -i -pe 's/__version__ = ".*"/__version__ = "9.9.9"/' "${TMP}/init.py"
+    perl -i -pe 's/REQUIRED_VERSION=".*"/REQUIRED_VERSION="9.9.9"/' "${TMP}/skill.md"
+
+    grep -qx '__version__ = "9.9.9"' "${TMP}/init.py" \
+        || { _fail "T1: __version__ not rewritten"; rm -rf "${TMP}"; return; }
+    grep -qx 'keep_me = True' "${TMP}/init.py" \
+        || { _fail "T1: unrelated line in init.py lost"; rm -rf "${TMP}"; return; }
+    grep -qx 'REQUIRED_VERSION="9.9.9"' "${TMP}/skill.md" \
+        || { _fail "T1: REQUIRED_VERSION not rewritten"; rm -rf "${TMP}"; return; }
+    grep -qx 'prefix' "${TMP}/skill.md" && grep -qx 'suffix' "${TMP}/skill.md" \
+        || { _fail "T1: surrounding lines in skill.md lost"; rm -rf "${TMP}"; return; }
+
+    _pass "T1: perl -i -pe rewrites both pins and preserves unrelated lines"
+    rm -rf "${TMP}"
+}
+
+# T2: static guard against silent revert to the BSD-only `sed -i ''` form.
+# If a future change reintroduces `sed -i ''` in the bump target, this fails.
+t2_makefile_uses_portable_form() {
+    if grep -nE "^\s*@?sed -i ''" "${REPO_DIR}/Makefile" >/dev/null 2>&1; then
+        _fail "T2: Makefile contains BSD-only \`sed -i ''\` — Linux \`make bump\` will break"
+        return
+    fi
+    if ! grep -qE '^\s*@?perl -i -pe' "${REPO_DIR}/Makefile"; then
+        _fail "T2: Makefile bump target no longer uses \`perl -i -pe\` — verify portable rewrite"
+        return
+    fi
+    _pass "T2: Makefile uses portable \`perl -i -pe\` (no BSD-only \`sed -i ''\`)"
+}
+
+t1_portable_in_place_rewrite
+t2_makefile_uses_portable_form
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ ${FAIL} -eq 0 ]


### PR DESCRIPTION
## Summary

First run of the **TRN-1801 evolve loop** on the trinity repo. Three candidates ship; one (C5) was added during the §5 review gate after Codex caught active-SOP drift.

- **C1**: `Makefile` `bump` target — replace BSD-only `sed -i ''` with portable `perl -i -pe`. Same trap class as the v2.0.0 stat-order incident TRN-1801 was written to prevent. Pre-existing version pins were already in sync, so this is preventive, not a fix-after-incident. New `tests/test_make_bump.sh` (T1 = portable rewrite semantics on fixtures; T2 = static guard against re-introducing `sed -i ''`). Wired into `make test`.
- **C2**: `rules/TRN-1006-SOP-Provider-Model-IDs.md` — added `Last reviewed`, `## When to Use`, `## When NOT to Use`; renamed `## Steps — Updating a Model ID` to `## Steps` for `af validate` exact-match. Brings the SOP added in v2.0.3 to canonical structure.
- **C4**: 8 PRJ docs metadata backfill — `TRN-1004` / `TRN-1005` (SOPs: `Last reviewed`) and `TRN-2003` / `TRN-2004` / `TRN-2005` / `TRN-2006` / `TRN-2007` / `TRN-2009` (CHGs: `Last updated` + `Last reviewed`).
- **C5** (added during §5 review): `rules/TRN-1003-SOP-Version-Bump.md` line 24 — replaced stale "BSD `sed -i ''` syntax" warning with the new portable-perl note + reference to `tests/test_make_bump.sh` + Change History row. Caught by Codex Reviewer A (would have left a contributor reading "never invoke `make bump` from CI" while the implementation was already cross-platform).

## Candidate scores (TRN-1800 weights)

| ID | Surface | Composite |
|----|---------|-----------|
| C1 | Makefile + new test | 7.8 |
| C2 | TRN-1006 backfill | 7.2 |
| C4 | 8-doc metadata | 7.3 |
| C5 | TRN-1003:24 fix | (added during gate, post-evaluation) |

Threshold: 7.0 (per TRN-1800).

## Four-reviewer gate (TRN-1801 §5, threshold ≥9.0)

| Reviewer | Score | Verdict |
|----------|-------|---------|
| Codex (Reviewer A) | **9.1** | PASS (initial 8.4/FAIL caught TRN-1003:24 drift, resolved by C5; re-gated to 9.1) |
| DeepSeek (Reviewer B) | **9.5** | PASS (independent byte-level `cmp` verification of `perl -i -pe` vs `sed -i ''` equivalence) |
| GLM | **9.2** | PASS (implementer's view — perl is the right form; T1+T2 sufficient) |
| Gemini | **9.3** | PASS (fresh-eyes audit; CHANGELOG well-formed, no anchor breakage) |

**Mean: 9.275 / 10.** All four converge.

## Compression delta

- 12 files changed, 122 insertions, 4 deletions
- Net positive: justified by new test (75 lines) + necessary doc additions
- `af validate` issue count: 43 → 24 (−19)

## Test plan

- [x] `make test` — 103 pytest cases + all shell tests including new T1/T2 pass
- [x] `make lint` — ruff clean
- [x] `make verify-built` — providers match generated
- [x] `af validate --root .` — 43 → 24 issues (remaining are deferred C3 + 2 missing Change History tables, out of cycle scope)
- [ ] **Linux CI** — `release.yml` on `ubuntu-latest` runs `make test` (incl. `tests/test_make_bump.sh`) when the v2.0.4 tag is pushed. TRN-2007 verify/publish split guards against publishing if Linux verify fails.

## Skipped this cycle

- **C3** — TRN-1001/1002/1003/1004 structural-section retrofit (`## Why` / `## When to Use` / `## When NOT to Use` / `## Examples`). Atomicity rule splits this into 16 sub-candidates; deferred to a future cycle.

## Notes

This is the first run of the TRN-1801 evolve cycle. Its execution validated the SOP itself (signal sources fired correctly; the §5 reviewer gate caught a real blocker that lead orchestrator missed; cycle ended with measurable parity improvements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)