### PR TITLE
[codex] Add Codex review adapter

### DIFF
--- a/.agents/skills/trinity/SKILL.md
+++ b/.agents/skills/trinity/SKILL.md
@@ -22,11 +22,21 @@ Support the same user-facing command family as the Claude Code adapter:
 
 Also treat `$trinity` as an explicit Codex skill invocation.
 
+For Codex-native code review from the terminal, use the installed wrapper:
+
+```bash
+trinity review --providers glm,gemini,deepseek --scope <path-or-label>
+```
+
+The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
+`.agents/trinity.codex.json`. It calls provider CLIs directly, saves raw outputs,
+and writes a deterministic synthesis markdown under `.trinity/reviews/`.
+
 ## Host Boundary
 
 - The root `SKILL.md` remains the Claude Code adapter and continues to use `~/.claude/` files.
 - This Codex adapter must load successfully without requiring Claude Code worker-agent files.
-- Do not depend on Claude-specific background worker instructions when only checking skill/plugin importability.
+- Do not depend on Claude-specific background worker instructions when checking skill/plugin importability or when running `trinity review`.
 - Preserve existing Trinity provider files and installers unless the user explicitly asks to change Claude behavior.
 
 ## Codex Workflow
@@ -35,7 +45,8 @@ Also treat `$trinity` as an explicit Codex skill invocation.
 2. Inspect the repo first: `README.md`, root `SKILL.md`, `scripts/`, `providers/`, and tests as needed.
 3. For status/help/import questions, answer directly from repo files and the Codex package files.
 4. For implementation work, follow the repo's `af` routing docs and use TDD.
-5. For delegation requests, use Codex-native delegation only when the user explicitly requests background or parallel agent work and the current Codex environment exposes that capability.
+5. For code-review requests from Codex, prefer `trinity review` when the local adapter is installed; it does not require Claude-specific background worker files.
+6. For delegation requests, use Codex-native delegation only when the user explicitly requests background or parallel agent work and the current Codex environment exposes that capability.
 
 ## Verification
 
@@ -43,5 +54,6 @@ For Codex load verification, use these smoke checks after changes are installed 
 
 - Repo-local skill: restart/start Codex in this repository, open `/skills` or invoke `$trinity`, and confirm `trinity` is visible/loadable.
 - Plugin package: restart Codex, open `/plugins`, select the repo marketplace, and confirm the `trinity` plugin appears and exposes its bundled skill.
+- Local wrapper: run `make install-codex`, then `trinity --version` and a mocked or low-risk `trinity review --providers glm,gemini,deepseek --scope <path>`.
 
 For Claude Code regression verification, keep using the existing Claude checks: install Trinity, restart Claude Code, and run `/trinity status`.

--- a/.agents/trinity.codex.json
+++ b/.agents/trinity.codex.json
@@ -1,0 +1,31 @@
+{
+  "providers": {
+    "glm": {
+      "cli": "droid exec --model glm-5",
+      "supports_resume": true,
+      "resume_arg": "-s",
+      "timeout": 360
+    },
+    "gemini": {
+      "cli": "gemini --model gemini-3.1-pro-preview -p",
+      "supports_resume": true,
+      "resume_arg": "-r",
+      "timeout": 360
+    },
+    "deepseek": {
+      "cli": "droid exec --model deepseek-v4-pro[1m]",
+      "supports_resume": true,
+      "resume_arg": "-s",
+      "timeout": 600
+    }
+  },
+  "review": {
+    "default_providers": [
+      "glm",
+      "gemini",
+      "deepseek"
+    ],
+    "output_dir": ".trinity/reviews",
+    "prompt_template": "# Trinity Code Review\n\nScope: {scope}\nRepository: {root}\n\nReview the changes below for correctness, regressions, missing tests, compatibility risk, and unclear implementation choices. Prioritize concrete findings with file/path references. Return PASS only if no blocking issues remain.\n\n## Git Diff\n\n```diff\n{diff}\n```\n\n## Full File Snapshots\n\n{files}\n"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ __pycache__/
 *.egg-info/
 dist/
 .team/
+.trinity/
 .omx/
 .worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Backfilled validator-required sections and change-history tables in older TRN docs (`TRN-1001` through `TRN-1005`, `TRN-2002`, `TRN-2003`), bringing `af validate --root .` to 0 issues.
+- Codex review provider calls now use a short prompt-file handoff instead of passing the full rendered review prompt as argv, avoiding OS argument-length failures on large diffs.
 
 ## [3.0.0] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+- Codex-native review adapter: `.agents/trinity.codex.json`, `scripts/codex.py`, `bin/trinity`, and `make install-codex` install a `trinity review --providers glm,gemini,deepseek` workflow under `~/.codex/` / `~/.local/bin`. The wrapper collects tracked plus untracked git changes, saves raw provider outputs, and writes deterministic review synthesis markdown without using Claude Code worker-agent runtime.
+- `rules/TRN-2010-PRP-Codex-Review-Adapter.md` and `rules/TRN-2011-CHG-Codex-Review-Adapter.md` document the approved design and implementation record. New tests cover Codex config/install/review behavior plus Claude Code compatibility.
+
+### Fixed
+- Backfilled validator-required sections and change-history tables in older TRN docs (`TRN-1001` through `TRN-1005`, `TRN-2002`, `TRN-2003`), bringing `af validate --root .` to 0 issues.
+
 ## [3.0.0] - 2026-04-29
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup build verify-built install-hooks test lint install bump release-prep
+.PHONY: setup build verify-built install-hooks test lint install install-codex bump release-prep
 
 # Read VERSION at make invocation time
 CURRENT_VERSION := $(shell cat VERSION 2>/dev/null || echo "0.0.0")
@@ -62,6 +62,18 @@ install:        ## Install Trinity to ~/.claude/ (TRN-1005)
 		--cli "$(HOME)/.claude/skills/trinity/bin/deepseek -p" \
 		--global-config ~/.claude/trinity.json
 	@echo "Installed Trinity $(CURRENT_VERSION)"
+
+install-codex:  ## Install Trinity Codex adapter to ~/.codex/ and ~/.local/bin
+	@mkdir -p ~/.codex/skills/trinity/scripts
+	@mkdir -p ~/.local/bin
+	cp .agents/skills/trinity/SKILL.md ~/.codex/skills/trinity/SKILL.md
+	cp .agents/trinity.codex.json ~/.codex/skills/trinity/trinity.codex.json
+	cp -r scripts/. ~/.codex/skills/trinity/scripts/
+	cp bin/trinity ~/.local/bin/trinity
+	chmod +x ~/.local/bin/trinity
+	python3 ~/.codex/skills/trinity/scripts/codex.py init-config \
+		--global-config ~/.codex/trinity.json
+	@echo "Installed Trinity Codex adapter $(CURRENT_VERSION)"
 
 bump:           ## Bump version (TRN-1003): make bump VERSION=x.y.z
 	@test -n "$(VERSION)" || (echo "Usage: make bump VERSION=x.y.z"; exit 1)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,39 @@ Edit `~/.claude/trinity.json` to set your preferred heartbeat interval and timeo
 
 Trinity also ships a Codex adapter without changing the Claude Code install path.
 
+**Install the Codex adapter**
+
+From a cloned repo:
+
+```bash
+make install-codex
+```
+
+This installs:
+
+| Location | Contents |
+|----------|----------|
+| `~/.codex/skills/trinity/SKILL.md` | Codex-specific Trinity skill |
+| `~/.codex/skills/trinity/scripts/` | Shared Trinity scripts plus Codex wrapper script |
+| `~/.codex/skills/trinity/trinity.codex.json` | Bundled default Codex config |
+| `~/.codex/trinity.json` | User-level Codex provider config |
+| `~/.local/bin/trinity` | Terminal wrapper for Codex-native commands |
+
+The committed default config lives at `.agents/trinity.codex.json`. It registers
+`glm`, `gemini`, and `deepseek` for direct CLI review calls and records each
+provider's command, resume support flag, timeout, and review prompt template.
+
+**Run a Codex-native review**
+
+```bash
+trinity review --providers glm,gemini,deepseek --scope spikes/hardline
+```
+
+The review wrapper collects tracked and untracked git changes, adds changed file
+snapshots to the prompt, calls each provider CLI directly, stores raw provider
+outputs, and writes a deterministic `synthesis.md` under `.trinity/reviews/`.
+This path does not require Claude Code worker-agent files.
+
 **Codex repo-local skill**
 
 The repo-local Codex skill lives at:

--- a/bin/trinity
+++ b/bin/trinity
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec python3 "${HOME}/.codex/skills/trinity/scripts/codex.py" "$@"

--- a/plugins/trinity/skills/trinity/SKILL.md
+++ b/plugins/trinity/skills/trinity/SKILL.md
@@ -22,11 +22,21 @@ Support the same user-facing command family as the Claude Code adapter:
 
 Also treat `$trinity` as an explicit Codex skill invocation.
 
+For Codex-native code review from the terminal, use the installed wrapper:
+
+```bash
+trinity review --providers glm,gemini,deepseek --scope <path-or-label>
+```
+
+The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
+`.agents/trinity.codex.json`. It calls provider CLIs directly, saves raw outputs,
+and writes a deterministic synthesis markdown under `.trinity/reviews/`.
+
 ## Host Boundary
 
 - The root `SKILL.md` remains the Claude Code adapter and continues to use `~/.claude/` files.
 - This Codex adapter must load successfully without requiring Claude Code worker-agent files.
-- Do not depend on Claude-specific background worker instructions when only checking skill/plugin importability.
+- Do not depend on Claude-specific background worker instructions when checking skill/plugin importability or when running `trinity review`.
 - Preserve existing Trinity provider files and installers unless the user explicitly asks to change Claude behavior.
 
 ## Codex Workflow
@@ -35,7 +45,8 @@ Also treat `$trinity` as an explicit Codex skill invocation.
 2. Inspect the repo first: `README.md`, root `SKILL.md`, `scripts/`, `providers/`, and tests as needed.
 3. For status/help/import questions, answer directly from repo files and the Codex package files.
 4. For implementation work, follow the repo's `af` routing docs and use TDD.
-5. For delegation requests, use Codex-native delegation only when the user explicitly requests background or parallel agent work and the current Codex environment exposes that capability.
+5. For code-review requests from Codex, prefer `trinity review` when the local adapter is installed; it does not require Claude-specific background worker files.
+6. For delegation requests, use Codex-native delegation only when the user explicitly requests background or parallel agent work and the current Codex environment exposes that capability.
 
 ## Verification
 
@@ -43,5 +54,6 @@ For Codex load verification, use these smoke checks after changes are installed 
 
 - Repo-local skill: restart/start Codex in this repository, open `/skills` or invoke `$trinity`, and confirm `trinity` is visible/loadable.
 - Plugin package: restart Codex, open `/plugins`, select the repo marketplace, and confirm the `trinity` plugin appears and exposes its bundled skill.
+- Local wrapper: run `make install-codex`, then `trinity --version` and a mocked or low-risk `trinity review --providers glm,gemini,deepseek --scope <path>`.
 
 For Claude Code regression verification, keep using the existing Claude checks: install Trinity, restart Claude Code, and run `/trinity status`.

--- a/rules/TRN-0000-REF-Document-Index.md
+++ b/rules/TRN-0000-REF-Document-Index.md
@@ -1,8 +1,8 @@
 # REF-0000: Document Index
 
 **Applies to:** TRN project
-**Last updated:** 2026-04-26
-**Last reviewed:** 2026-04-26
+**Last updated:** 2026-05-04
+**Last reviewed:** 2026-05-04
 **Status:** Active
 
 ---
@@ -27,6 +27,8 @@
 | 2007 | CHG | One-click release via workflow_dispatch |
 | 2008 | PRP | Remove Zsh Dependency from Trinity Providers |
 | 2009 | CHG | Remove Zsh Dependency from Trinity Providers |
+| 2010 | PRP | Codex Review Adapter |
+| 2011 | CHG | Codex Review Adapter |
 
 ---
 
@@ -43,3 +45,4 @@
 | 2026-04-26 | Add TRN-2009 | Claude Opus 4.7 |
 | 2026-04-26 | Add TRN-1006 (Provider Model IDs SOP) | Claude Opus 4.7 |
 | 2026-04-26 | Add TRN-1800 + TRN-1801 (Evolution philosophy override + Evolve SOP, mirroring CLD-1800/1801 for trinity) | Claude Opus 4.7 |
+| 2026-05-04 | Add TRN-2010 and TRN-2011 for Codex Review Adapter | Codex |

--- a/rules/TRN-1001-SOP-Test.md
+++ b/rules/TRN-1001-SOP-Test.md
@@ -1,7 +1,8 @@
 # SOP-1001: Test — Trinity
 
 **Applies to:** trinity/ package
-**Last updated:** 2026-03-21
+**Last updated:** 2026-05-04
+**Last reviewed:** 2026-05-04
 **Status:** Active
 
 ---
@@ -9,6 +10,25 @@
 ## What Is It?
 
 Run the full pytest test suite for Trinity.
+
+---
+
+## Why
+
+Trinity changes must preserve provider generation, Python helpers, shell installers, and release workflow checks. A single test target keeps those gates repeatable before release or PR review.
+
+---
+
+## When to Use
+
+- Before opening or updating a PR with code, installer, provider, or workflow changes
+- Before release preparation
+- After changing tests or shared scripts
+
+## When NOT to Use
+
+- For docs-only edits where `af validate --root .` is the relevant gate
+- When running a narrower RED/GREEN TDD loop; use the focused pytest target first, then return to this SOP before completion
 
 ---
 
@@ -23,8 +43,17 @@ Run the full pytest test suite for Trinity.
 
 ---
 
+## Examples
+
+```bash
+make test
+```
+
+---
+
 ## Change History
 
 | Date | Change | By |
 |------|--------|-----|
+| 2026-05-04 | Backfill canonical SOP metadata and sections for `af validate` | Codex |
 | 2026-03-21 | Initial version | Claude Code |

--- a/rules/TRN-1002-SOP-Lint.md
+++ b/rules/TRN-1002-SOP-Lint.md
@@ -1,7 +1,8 @@
 # SOP-1002: Lint — Trinity
 
 **Applies to:** trinity/ package
-**Last updated:** 2026-03-21
+**Last updated:** 2026-05-04
+**Last reviewed:** 2026-05-04
 **Status:** Active
 
 ---
@@ -9,6 +10,25 @@
 ## What Is It?
 
 Run ruff check and format on Trinity source.
+
+---
+
+## Why
+
+Ruff keeps Trinity's Python scripts and tests mechanically consistent. The lint target also enforces formatting so PR diffs stay focused on behavior and docs.
+
+---
+
+## When to Use
+
+- Before opening or updating a PR with Python or test changes
+- After running `ruff format`
+- Before release preparation
+
+## When NOT to Use
+
+- For shell-only changes where the shell tests are the relevant focused gate
+- As a substitute for `make test`; lint checks style, not behavior
 
 ---
 
@@ -23,8 +43,19 @@ Run ruff check and format on Trinity source.
 
 ---
 
+## Examples
+
+```bash
+make lint
+.venv/bin/ruff format scripts/ tests/
+make lint
+```
+
+---
+
 ## Change History
 
 | Date | Change | By |
 |------|--------|-----|
+| 2026-05-04 | Backfill canonical SOP metadata and sections for `af validate` | Codex |
 | 2026-03-21 | Initial version | Claude Code |

--- a/rules/TRN-1003-SOP-Version-Bump.md
+++ b/rules/TRN-1003-SOP-Version-Bump.md
@@ -1,8 +1,8 @@
 # SOP-1003: Version Bump — Trinity
 
 **Applies to:** trinity/ package
-**Last updated:** 2026-04-26
-**Last reviewed:** 2026-04-26
+**Last updated:** 2026-05-04
+**Last reviewed:** 2026-05-04
 **Status:** Active
 
 ---
@@ -10,6 +10,26 @@
 ## What Is It?
 
 Human preparation step before `make release-prep` (TRN-1004). Updates CHANGELOG and bumps version in all files.
+
+---
+
+## Why
+
+Version metadata lives in multiple files (`VERSION`, `scripts/__init__.py`, `SKILL.md`, and `CHANGELOG.md`). This SOP keeps them synchronized before release automation creates the release commit and tag.
+
+---
+
+## When to Use
+
+- Preparing a release after feature or fix work has merged
+- Updating the changelog section for a new version
+- Aligning version pins before `make release-prep`
+
+## When NOT to Use
+
+- During feature implementation before code and tests are committed
+- For draft PRs that are not release preparation
+- To publish a release; use TRN-1004 after this SOP
 
 ---
 
@@ -28,10 +48,21 @@ The release workflow (TRN-2006) still does not call `make bump` — release-time
 
 ---
 
+## Examples
+
+```bash
+git status --short
+make bump VERSION=3.1.0
+git diff -- CHANGELOG.md VERSION scripts/__init__.py SKILL.md
+```
+
+---
+
 ## Change History
 
 | Date | Change | By |
 |------|--------|-----|
+| 2026-05-04 | Backfill Why/When/Examples sections for `af validate` | Codex |
 | 2026-03-21 | Initial version | Claude Code |
 | 2026-04-03 | Strengthen Step 0: explicit commit-first requirement | Claude Code |
 | 2026-04-25 | Note `make build` runs as part of `make bump` (TRN-2004) | Claude Opus 4.7 |

--- a/rules/TRN-1004-SOP-Release.md
+++ b/rules/TRN-1004-SOP-Release.md
@@ -1,8 +1,8 @@
 # SOP-1004: Release — Trinity
 
 **Applies to:** trinity/ package
-**Last updated:** 2026-04-26
-**Last reviewed:** 2026-04-26
+**Last updated:** 2026-05-04
+**Last reviewed:** 2026-05-04
 **Status:** Active
 
 ---
@@ -13,6 +13,26 @@ Cut a GitHub release. The release pipeline lives entirely in `.github/workflows/
 
 ---
 
+## Why
+
+Trinity releases are tag-driven and publish through GitHub Actions. This SOP keeps local preparation, tag creation, CI verification, and publish retry behavior consistent.
+
+---
+
+## When to Use
+
+- Publishing a new version after TRN-1003 is complete
+- Retrying a failed release workflow for an existing tag
+- Choosing between one-click UI release and manual tag push
+
+## When NOT to Use
+
+- Before version metadata and changelog updates are complete
+- For draft PR validation; use TRN-1001 and TRN-1002 instead
+- For emergency local tags that bypass CI
+
+---
+
 ## Prerequisites
 
 - All feature code and tests committed (`git status` clean)
@@ -20,6 +40,12 @@ Cut a GitHub release. The release pipeline lives entirely in `.github/workflows/
 - `providers/*.md` is up-to-date with `*.delta.md` + `_base/` partials (TRN-2004) — `make verify-built` exits 0
 - One-time setup: tag-protection ruleset (see TRN-2007 §D11). Pattern `v[0-9]*.[0-9]*.[0-9]*` (fnmatch — GitHub Rulesets do NOT support regex `+`). Bypass list MUST include **Repository admin** with `Always` mode (covers Path B and the PAT-driven Path A push).
 - One-time setup: `RELEASE_TAG_PAT` repo secret (fine-grained PAT, repo-scoped, `Contents: Read and write`). Required for Path A on personal repos because the GitHub Actions integration cannot be added to a personal-repo ruleset bypass list. See TRN-2007 §D11 for the creation + rotation runbook. Path B and Path C work without this secret.
+
+---
+
+## Steps
+
+Choose exactly one release path below. Path A is preferred for normal releases.
 
 ---
 
@@ -83,10 +109,21 @@ Same pre-flight runs. Workflow fails cleanly with "Release vX.Y.Z already exists
 
 ---
 
+## Examples
+
+```bash
+git fetch origin
+git tag v3.1.0 origin/main
+git push origin v3.1.0
+```
+
+---
+
 ## Change History
 
 | Date | Change | By |
 |------|--------|-----|
+| 2026-05-04 | Backfill Why/When/Steps/Examples sections for `af validate` | Codex |
 | 2026-03-21 | Initial version | Claude Code |
 | 2026-04-03 | Add explicit prerequisite: commit code before release | Claude Code |
 | 2026-04-25 | Add `make verify-built` prerequisite + step (TRN-2004) | Claude Opus 4.7 |

--- a/rules/TRN-1005-SOP-Install.md
+++ b/rules/TRN-1005-SOP-Install.md
@@ -1,8 +1,8 @@
 # SOP-1005: Install — Trinity
 
 **Applies to:** trinity/ package
-**Last updated:** 2026-03-21
-**Last reviewed:** 2026-04-26
+**Last updated:** 2026-05-04
+**Last reviewed:** 2026-05-04
 **Status:** Active
 
 ---
@@ -10,6 +10,25 @@
 ## What Is It?
 
 Install Trinity to `~/.claude/`.
+
+---
+
+## Why
+
+The Claude Code adapter loads from `~/.claude/`, so local and remote installs must put the skill, scripts, providers, wrapper binaries, and provider registry in the expected paths.
+
+---
+
+## When to Use
+
+- Installing Trinity for Claude Code
+- Refreshing an existing local install after a version bump or provider change
+- Verifying install behavior before release
+
+## When NOT to Use
+
+- Installing the Codex-native adapter; use `make install-codex`
+- Testing code without mutating the user's home directory; use a temporary `HOME`
 
 ---
 
@@ -34,5 +53,6 @@ Expected output: the version constant from `scripts/__init__.py` (matches `VERSI
 
 | Date | Change | By |
 |------|--------|-----|
+| 2026-05-04 | Backfill Why/When sections and clarify Codex install is separate | Codex |
 | 2026-03-21 | Add remote install path (TRN-2002) | Claude Code |
 | 2026-03-21 | Initial version | Claude Code |

--- a/rules/TRN-2002-PRP-Remote-Install-Script.md
+++ b/rules/TRN-2002-PRP-Remote-Install-Script.md
@@ -172,3 +172,12 @@ Tests are shell-level (`bash install.sh`) using `TRINITY_BASE_URL` to redirect d
 | Partial install if user Ctrl-C mid-run | Low | Idempotent — re-run overwrites partial files |
 | `install.sh` file list drifts from `make install` | Medium | Both must be updated together when adding files; no automated sync check exists — accepted trade-off for simplicity |
 | Interrupted curl writes truncated file to dest | Low | Idempotent — re-run overwrites; not a silent corruption risk since scripts fail loudly if truncated |
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-04 | Backfill Change History table for `af validate` | Codex |
+| 2026-03-21 | Initial approved proposal for remote install script | Claude Code |

--- a/rules/TRN-2003-CHG-Remote-Install-Script.md
+++ b/rules/TRN-2003-CHG-Remote-Install-Script.md
@@ -32,3 +32,12 @@
 | Update TRN-1005 | ✅ | Added remote install path |
 | Update README.md | ✅ | curl one-liner as primary install method |
 | git commit + push | — | |
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-04 | Backfill Change History table for `af validate` | Codex |
+| 2026-03-21 | Initial change record for remote install script | Claude Code |

--- a/rules/TRN-2010-PRP-Codex-Review-Adapter.md
+++ b/rules/TRN-2010-PRP-Codex-Review-Adapter.md
@@ -1,0 +1,141 @@
+# PRP-2010: Codex Review Adapter
+
+**Applies to:** Trinity project (`frankyxhl/trinity`)
+**Last updated:** 2026-05-04
+**Last reviewed:** 2026-05-04
+**Status:** Approved
+**Reviewed by:** User-approved COR-1202 plan in Codex session; implementation remains subject to tests, lint, `af validate`, and draft PR review.
+**Related:** TRN-1000, TRN-1005, TRN-1006, TRN-2011
+
+---
+
+## What Is It?
+
+Add a Codex-native adapter layer for Trinity that lets Codex use Trinity review flows without Claude Code's background Agent runtime. The adapter installs a Codex skill, writes a Codex-specific provider config, and exposes a local `trinity review` wrapper that calls provider CLIs directly.
+
+---
+
+## Problem
+
+The existing Trinity root skill is a Claude Code adapter. It discovers `~/.claude/trinity.json`, requires `~/.claude/agents/trinity-<provider>.md`, and dispatches work through Claude's Agent tool. Codex can read those files manually, but it cannot use that runtime contract directly.
+
+Trinity already has Codex packaging for skill/plugin importability, but the package lacks the practical local path the user needs:
+
+- `~/.codex/skills/trinity/SKILL.md` installation from the repo-local Codex skill
+- a Codex-owned provider config independent of `~/.claude/trinity.json`
+- a direct CLI wrapper for `glm`, `gemini`, and `deepseek` code reviews
+- regression tests proving Claude Code installation and runtime docs remain compatible
+
+---
+
+## Scope
+
+**In scope (v1):**
+- Add `.agents/trinity.codex.json` as the committed default Codex config.
+- Add `scripts/codex.py` with a `review` subcommand.
+- Add `bin/trinity` and `make install-codex` so this machine gets a `trinity review ...` command.
+- Collect tracked and untracked git changes into a review prompt, including changed file snapshots.
+- Save `prompt.md`, raw provider outputs, metadata, and a deterministic `synthesis.md`.
+- Add TDD tests for Codex config, wrapper behavior, install behavior, and Claude Code compatibility.
+- Document Codex usage and the Claude/Codex host boundary.
+
+**Out of scope (v1):**
+- Replacing Claude Code `/trinity` dispatch.
+- Changing root `SKILL.md` from Claude Agent runtime semantics.
+- Changing `install.sh` remote Claude installer behavior.
+- Running real provider reviews in tests.
+- Adding OpenRouter to the Codex review default set.
+
+---
+
+## Proposed Solution
+
+### Codex Config
+
+Create `.agents/trinity.codex.json`:
+
+```json
+{
+  "providers": {
+    "glm": {
+      "cli": "droid exec --model glm-5",
+      "supports_resume": true,
+      "resume_arg": "-s",
+      "timeout": 360
+    },
+    "gemini": {
+      "cli": "gemini --model gemini-3.1-pro-preview -p",
+      "supports_resume": true,
+      "resume_arg": "-r",
+      "timeout": 360
+    },
+    "deepseek": {
+      "cli": "droid exec --model deepseek-v4-pro[1m]",
+      "supports_resume": true,
+      "resume_arg": "-s",
+      "timeout": 600
+    }
+  },
+  "review": {
+    "default_providers": ["glm", "gemini", "deepseek"],
+    "output_dir": ".trinity/reviews",
+    "prompt_template": "..."
+  }
+}
+```
+
+The bracket suffix in `deepseek-v4-pro[1m]` follows TRN-1006 and must be passed as an argv element, not through an unquoted shell string.
+
+### Wrapper Command
+
+Install `bin/trinity` to `~/.local/bin/trinity`. The wrapper calls:
+
+```bash
+python3 ~/.codex/skills/trinity/scripts/codex.py "$@"
+```
+
+Primary v1 usage:
+
+```bash
+trinity review --providers glm,gemini,deepseek --scope spikes/hardline
+```
+
+### Review Behavior
+
+`scripts/codex.py review`:
+
+1. Resolve repo root.
+2. Load `~/.codex/trinity.json`, with explicit `--config` override for tests.
+3. Collect `git diff HEAD` for tracked changes.
+4. Add synthetic diffs and full snapshots for untracked files.
+5. Include full snapshots for changed text files.
+6. Render the review prompt from the config template.
+7. Invoke each selected provider CLI directly with the prompt as the final argv element.
+8. Write raw outputs under `raw/<provider>.txt`.
+9. Write `synthesis.md` summarizing provider status and linking raw outputs.
+
+No Claude Agent files or `Agent(...)` runtime are required for this path.
+
+---
+
+## Open Questions
+
+1. None blocking for v1. Real provider command tuning can be adjusted after draft PR review if a provider CLI needs a different prompt argument convention.
+
+---
+
+## Implementation Plan
+
+1. Add RED tests for Codex config, wrapper behavior, installation, and Claude compatibility.
+2. Implement `.agents/trinity.codex.json`, `scripts/codex.py`, `bin/trinity`, and `make install-codex`.
+3. Update README and Codex skill documentation.
+4. Run `make test`, `make lint`, `af validate --root .`, and install/smoke checks.
+5. Commit, push a branch, and open a draft PR.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-04 | Initial approved proposal for Codex-native review adapter | Codex |

--- a/rules/TRN-2011-CHG-Codex-Review-Adapter.md
+++ b/rules/TRN-2011-CHG-Codex-Review-Adapter.md
@@ -63,6 +63,7 @@ Expected evidence before marking complete:
 | 2026-05-04 | Implemented Codex config, `scripts/codex.py`, `bin/trinity`, and `make install-codex` | Focused Codex tests pass |
 | 2026-05-04 | Ran full repo verification | `make test`, `make lint`, and `af validate --root .` pass |
 | 2026-05-04 | Installed adapters on this machine | `make install-codex`, `trinity --version`, `make install`, and Claude `session.py --version` pass |
+| 2026-05-04 | Addressed PR #16 review comment about argv length | Provider calls now pass a short prompt-file handoff; large-diff regression test added |
 
 ---
 

--- a/rules/TRN-2011-CHG-Codex-Review-Adapter.md
+++ b/rules/TRN-2011-CHG-Codex-Review-Adapter.md
@@ -1,0 +1,73 @@
+# CHG-2011: Codex Review Adapter
+
+**Applies to:** Trinity project (`frankyxhl/trinity`)
+**Date:** 2026-05-04
+**Last updated:** 2026-05-04
+**Last reviewed:** 2026-05-04
+**Status:** In Progress
+**PRP:** TRN-2010
+**Implementer:** Codex
+
+---
+
+## What
+
+Implement the approved TRN-2010 Codex review adapter: Codex-specific config, `trinity review` CLI wrapper, Codex install target, tests, and documentation.
+
+---
+
+## Why
+
+Codex needs a direct Trinity review path that does not depend on Claude Code's Agent runtime or worker-agent files. The existing Claude Code path must remain unchanged and regression-tested.
+
+---
+
+## Impact Analysis
+
+- **Systems affected:** repo-local Codex skill packaging, local Codex installation under `~/.codex`, `~/.local/bin/trinity`, README, tests, and rules docs.
+- **Systems intentionally preserved:** root Claude Code `SKILL.md`, `install.sh`, `make install`, `~/.claude/agents`, and `~/.claude/trinity.json` behavior.
+- **Downtime required:** No.
+- **Rollback plan:** Remove `bin/trinity`, `scripts/codex.py`, `.agents/trinity.codex.json`, `make install-codex`, and related tests/docs. Locally, remove `~/.local/bin/trinity`, `~/.codex/skills/trinity`, and `~/.codex/trinity.json` if desired.
+
+---
+
+## Implementation Plan
+
+1. RED: add tests for Codex config shape, `review` prompt collection, raw output/synthesis files, `make install-codex`, and Claude compatibility.
+2. GREEN: add Codex config, CLI script, wrapper, install target, and ignore generated review output.
+3. REFACTOR: keep wrapper small, deterministic, and stdlib-only.
+4. Docs: update README and Codex skill with command/config/install notes.
+5. Verification: `make test`, `make lint`, `af validate --root .`, `make install-codex` smoke, and Claude install/version smoke.
+6. Delivery: commit, push feature branch, and open draft PR.
+
+---
+
+## Testing / Verification
+
+Expected evidence before marking complete:
+
+- `.venv/bin/pytest tests/test_codex_adapter.py -q`
+- `make test`
+- `make lint`
+- `af validate --root .`
+- `HOME=<temp> make install-codex` creates only Codex files.
+- `make install` and `python3 ~/.claude/skills/trinity/scripts/session.py --version` still pass.
+
+---
+
+## Execution Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-05-04 | Added RED tests for Codex adapter and Claude compatibility | RED confirmed: missing config, wrapper script, and install target |
+| 2026-05-04 | Implemented Codex config, `scripts/codex.py`, `bin/trinity`, and `make install-codex` | Focused Codex tests pass |
+| 2026-05-04 | Ran full repo verification | `make test`, `make lint`, and `af validate --root .` pass |
+| 2026-05-04 | Installed adapters on this machine | `make install-codex`, `trinity --version`, `make install`, and Claude `session.py --version` pass |
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-04 | Initial change record for TRN-2010 implementation | Codex |

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Codex-native Trinity command wrapper."""
+
+import argparse
+import datetime as dt
+import difflib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import sys
+
+
+DEFAULT_CONFIG = Path("~/.codex/trinity.json").expanduser()
+SCRIPT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG_CANDIDATES = [
+    SCRIPT_ROOT / "trinity.codex.json",
+    SCRIPT_ROOT / ".agents" / "trinity.codex.json",
+]
+
+
+def _load_version():
+    init_file = Path(__file__).resolve().parent / "__init__.py"
+    spec = importlib.util.spec_from_file_location("_scripts_init", str(init_file))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.__version__
+
+
+__version__ = _load_version()
+
+
+def run_git(root, args, allow_error=False):
+    result = subprocess.run(
+        ["git"] + args,
+        cwd=str(root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if result.returncode != 0 and not allow_error:
+        raise RuntimeError(result.stderr.strip() or "git command failed")
+    return result.stdout
+
+
+def resolve_root(root_arg):
+    root = Path(root_arg).expanduser().resolve()
+    try:
+        top = run_git(root, ["rev-parse", "--show-toplevel"]).strip()
+    except RuntimeError:
+        raise SystemExit(f"trinity-codex: not a git repository: {root}")
+    return Path(top).resolve()
+
+
+def load_json(path):
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        raise SystemExit(f"trinity-codex: config not found: {path}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"trinity-codex: invalid JSON in {path}: {exc}")
+
+
+def load_config(path):
+    return load_json(Path(path).expanduser())
+
+
+def write_default_config(path):
+    for candidate in DEFAULT_CONFIG_CANDIDATES:
+        if candidate.exists():
+            source = load_json(candidate)
+            break
+    else:
+        raise SystemExit("trinity-codex: bundled trinity.codex.json not found")
+    target = Path(path).expanduser()
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if target.exists():
+        current = load_json(target)
+    else:
+        current = {}
+
+    current["providers"] = source["providers"]
+    current["review"] = source["review"]
+    target.write_text(json.dumps(current, indent=2, ensure_ascii=False) + "\n")
+    return target
+
+
+def split_providers(value, config):
+    if value:
+        providers = [item.strip() for item in value.split(",") if item.strip()]
+    else:
+        providers = config.get("review", {}).get("default_providers", [])
+    if not providers:
+        raise SystemExit("trinity-codex: no providers selected")
+    return providers
+
+
+def scope_pathspec(root, scope):
+    if not scope or scope == ".":
+        return []
+    candidate = (root / scope).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return []
+    if candidate.exists():
+        return [scope]
+    return []
+
+
+def git_diff(root, pathspec):
+    args = ["diff", "--no-ext-diff", "--binary", "HEAD", "--"]
+    return run_git(root, args + pathspec, allow_error=True)
+
+
+def changed_paths(root, pathspec):
+    args = ["diff", "--name-only", "--diff-filter=ACMRT", "HEAD", "--"]
+    output = run_git(root, args + pathspec, allow_error=True)
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def untracked_paths(root, pathspec):
+    args = ["ls-files", "--others", "--exclude-standard", "--"]
+    output = run_git(root, args + pathspec, allow_error=True)
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def is_text_file(path):
+    try:
+        sample = path.read_bytes()[:4096]
+    except OSError:
+        return False
+    return b"\0" not in sample
+
+
+def read_text_file(path, max_bytes=200000):
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        return f"[unreadable: {exc}]"
+    if b"\0" in data:
+        return "[binary file omitted]"
+    if len(data) > max_bytes:
+        head = data[:max_bytes].decode("utf-8", errors="replace")
+        return head + "\n[truncated: file exceeds max snapshot bytes]\n"
+    return data.decode("utf-8", errors="replace")
+
+
+def synthetic_untracked_diff(root, paths):
+    chunks = []
+    for rel in paths:
+        path = root / rel
+        if not path.is_file() or not is_text_file(path):
+            chunks.append(f"diff --git a/{rel} b/{rel}\nnew file mode 100644\n")
+            chunks.append(
+                "--- /dev/null\n+++ b/{0}\n[binary or unreadable]\n".format(rel)
+            )
+            continue
+        lines = read_text_file(path).splitlines(keepends=True)
+        chunks.extend(
+            difflib.unified_diff(
+                [],
+                lines,
+                fromfile="/dev/null",
+                tofile=f"b/{rel}",
+            )
+        )
+    return "".join(chunks)
+
+
+def file_snapshots(root, paths):
+    if not paths:
+        return "(no changed or untracked file snapshots)\n"
+
+    chunks = []
+    seen = set()
+    for rel in paths:
+        if rel in seen:
+            continue
+        seen.add(rel)
+        path = root / rel
+        chunks.append(f"### {rel}\n\n")
+        if not path.exists():
+            chunks.append("[deleted]\n\n")
+            continue
+        if path.is_dir():
+            chunks.append("[directory omitted]\n\n")
+            continue
+        content = read_text_file(path)
+        chunks.append("```text\n")
+        chunks.append(content)
+        if content and not content.endswith("\n"):
+            chunks.append("\n")
+        chunks.append("```\n\n")
+    return "".join(chunks)
+
+
+def render_prompt(config, root, scope):
+    pathspec = scope_pathspec(root, scope)
+    tracked_diff = git_diff(root, pathspec)
+    untracked = untracked_paths(root, pathspec)
+    untracked_diff = synthetic_untracked_diff(root, untracked)
+    diff = (
+        tracked_diff
+        + ("\n" if tracked_diff and untracked_diff else "")
+        + (untracked_diff)
+    )
+    paths = changed_paths(root, pathspec) + untracked
+    files = file_snapshots(root, paths)
+    template = config.get("review", {}).get("prompt_template", "{diff}\n\n{files}\n")
+    if not diff.strip():
+        diff = "(no tracked or untracked git diff)"
+    return (
+        template.replace("{scope}", scope or ".")
+        .replace("{root}", str(root))
+        .replace("{diff}", diff)
+        .replace("{files}", files)
+    )
+
+
+def slugify(value):
+    value = value.strip() or "review"
+    value = re.sub(r"[^A-Za-z0-9._-]+", "-", value)
+    return value.strip("-") or "review"
+
+
+def make_review_dir(out_dir, scope):
+    stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    base = Path(out_dir).expanduser()
+    slug = slugify(scope)
+    for index in range(100):
+        suffix = f"{stamp}-{slug}" if index == 0 else f"{stamp}-{slug}-{index}"
+        review_dir = base / suffix
+        try:
+            review_dir.mkdir(parents=True, exist_ok=False)
+        except FileExistsError:
+            continue
+        (review_dir / "raw").mkdir()
+        return review_dir
+    raise SystemExit("trinity-codex: unable to create unique review directory")
+
+
+def provider_command(provider, provider_config):
+    cli = provider_config.get("cli")
+    if not cli:
+        raise SystemExit(f"trinity-codex: provider {provider} missing cli")
+    expanded = os.path.expandvars(os.path.expanduser(cli))
+    return shlex.split(expanded)
+
+
+def run_provider(provider, provider_config, prompt, review_dir, root):
+    raw_path = review_dir / "raw" / f"{provider}.txt"
+    cmd = provider_command(provider, provider_config) + [prompt]
+    timeout = int(provider_config.get("timeout", 360))
+    started = dt.datetime.now().isoformat(timespec="seconds")
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(root),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            timeout=timeout,
+        )
+        output = result.stdout
+        if result.stderr:
+            output += "\n[stderr]\n" + result.stderr
+        raw_path.write_text(output)
+        return {
+            "provider": provider,
+            "returncode": result.returncode,
+            "raw": str(raw_path.relative_to(review_dir)),
+            "started_at": started,
+            "finished_at": dt.datetime.now().isoformat(timespec="seconds"),
+        }
+    except FileNotFoundError as exc:
+        raw_path.write_text(f"ERROR: command not found: {exc}\n")
+        return {
+            "provider": provider,
+            "returncode": 127,
+            "raw": str(raw_path.relative_to(review_dir)),
+            "started_at": started,
+            "finished_at": dt.datetime.now().isoformat(timespec="seconds"),
+        }
+    except subprocess.TimeoutExpired as exc:
+        raw_path.write_text(f"ERROR: timeout after {timeout}s\n{exc}\n")
+        return {
+            "provider": provider,
+            "returncode": 124,
+            "raw": str(raw_path.relative_to(review_dir)),
+            "started_at": started,
+            "finished_at": dt.datetime.now().isoformat(timespec="seconds"),
+        }
+
+
+def write_synthesis(review_dir, scope, results):
+    lines = [
+        "# Trinity Review Synthesis",
+        "",
+        f"Scope: {scope or '.'}",
+        "",
+        "## Provider Status",
+        "",
+        "| Provider | Status | Raw Output |",
+        "|----------|--------|------------|",
+    ]
+    for result in results:
+        status = "PASS" if result["returncode"] == 0 else f"FAIL {result['returncode']}"
+        lines.append(f"| {result['provider']} | {status} | `{result['raw']}` |")
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            "This synthesis is deterministic. Inspect raw provider outputs for findings and conflicts.",
+            "",
+        ]
+    )
+    path = review_dir / "synthesis.md"
+    path.write_text("\n".join(lines))
+
+
+def cmd_review(args):
+    root = resolve_root(args.root)
+    config = load_config(args.config)
+    providers = split_providers(args.providers, config)
+    out_base = args.out_dir or config.get("review", {}).get(
+        "output_dir", ".trinity/reviews"
+    )
+    out_base = Path(out_base)
+    if not out_base.is_absolute():
+        out_base = root / out_base
+    review_dir = make_review_dir(out_base, args.scope)
+    prompt = render_prompt(config, root, args.scope)
+    (review_dir / "prompt.md").write_text(prompt)
+
+    results = []
+    provider_configs = config.get("providers", {})
+    for provider in providers:
+        if provider not in provider_configs:
+            raise SystemExit(f"trinity-codex: unknown provider: {provider}")
+        results.append(
+            run_provider(provider, provider_configs[provider], prompt, review_dir, root)
+        )
+    metadata = {
+        "scope": args.scope,
+        "root": str(root),
+        "providers": providers,
+        "results": results,
+    }
+    (review_dir / "metadata.json").write_text(
+        json.dumps(metadata, indent=2, ensure_ascii=False) + "\n"
+    )
+    write_synthesis(review_dir, args.scope, results)
+    print(review_dir)
+    return 0 if all(item["returncode"] == 0 for item in results) else 1
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="trinity")
+    parser.add_argument("--version", action="store_true")
+    subparsers = parser.add_subparsers(dest="command")
+
+    init_config = subparsers.add_parser("init-config")
+    init_config.add_argument("--global-config", default=str(DEFAULT_CONFIG))
+
+    review = subparsers.add_parser("review")
+    review.add_argument("--root", default=".")
+    review.add_argument("--config", default=str(DEFAULT_CONFIG))
+    review.add_argument("--providers")
+    review.add_argument("--scope", default=".")
+    review.add_argument("--out-dir")
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.version:
+        print(__version__)
+        return 0
+    if args.command == "init-config":
+        path = write_default_config(args.global_config)
+        print(path)
+        return 0
+    if args.command == "review":
+        return cmd_review(args)
+    parser.print_help(sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -252,9 +252,19 @@ def provider_command(provider, provider_config):
     return shlex.split(expanded)
 
 
-def run_provider(provider, provider_config, prompt, review_dir, root):
+def build_prompt_handoff(prompt_path):
+    return (
+        "Read the complete Trinity review prompt from the file below, then perform "
+        "the requested code review.\n\n"
+        f"Prompt file: {prompt_path}"
+    )
+
+
+def run_provider(provider, provider_config, prompt_path, review_dir, root):
     raw_path = review_dir / "raw" / f"{provider}.txt"
-    cmd = provider_command(provider, provider_config) + [prompt]
+    cmd = provider_command(provider, provider_config) + [
+        build_prompt_handoff(prompt_path)
+    ]
     timeout = int(provider_config.get("timeout", 360))
     started = dt.datetime.now().isoformat(timespec="seconds")
     try:
@@ -336,7 +346,8 @@ def cmd_review(args):
         out_base = root / out_base
     review_dir = make_review_dir(out_base, args.scope)
     prompt = render_prompt(config, root, args.scope)
-    (review_dir / "prompt.md").write_text(prompt)
+    prompt_path = review_dir / "prompt.md"
+    prompt_path.write_text(prompt)
 
     results = []
     provider_configs = config.get("providers", {})
@@ -344,7 +355,13 @@ def cmd_review(args):
         if provider not in provider_configs:
             raise SystemExit(f"trinity-codex: unknown provider: {provider}")
         results.append(
-            run_provider(provider, provider_configs[provider], prompt, review_dir, root)
+            run_provider(
+                provider,
+                provider_configs[provider],
+                prompt_path,
+                review_dir,
+                root,
+            )
         )
     metadata = {
         "scope": args.scope,

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -91,12 +91,19 @@ def test_codex_review_collects_tracked_and_untracked_changes(tmp_path):
     for provider in ["glm", "gemini", "deepseek"]:
         script = fake_bin / provider
         script.write_text(
-            "#!/bin/sh\n"
-            "prompt=''\n"
-            'for arg in "$@"; do prompt="$arg"; done\n'
-            'printf \'provider=%s\\n\' "$(basename "$0")"\n'
-            "printf '%s' \"$prompt\" | grep -q 'after tracked change' && echo tracked-ok\n"
-            "printf '%s' \"$prompt\" | grep -q 'new untracked evidence' && echo untracked-ok\n"
+            "#!/usr/bin/env python3\n"
+            "import pathlib, re, sys\n"
+            "prompt_arg = sys.argv[-1]\n"
+            "print(f'provider={pathlib.Path(sys.argv[0]).name}')\n"
+            "print(f'argv_len={len(prompt_arg)}')\n"
+            "assert 'after tracked change' not in prompt_arg\n"
+            "match = re.search(r'Prompt file: (.+)', prompt_arg)\n"
+            "assert match, prompt_arg\n"
+            "prompt = pathlib.Path(match.group(1).strip()).read_text()\n"
+            "if 'after tracked change' in prompt:\n"
+            "    print('tracked-ok')\n"
+            "if 'new untracked evidence' in prompt:\n"
+            "    print('untracked-ok')\n"
         )
         script.chmod(0o755)
 
@@ -146,6 +153,69 @@ def test_codex_review_collects_tracked_and_untracked_changes(tmp_path):
     synthesis = (review_dir / "synthesis.md").read_text()
     assert "Trinity Review Synthesis" in synthesis
     assert "raw/glm.txt" in synthesis
+
+
+def test_codex_review_uses_short_prompt_file_handoff_for_large_diffs(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    tracked = repo / "large.txt"
+    tracked.write_text("before\n")
+    subprocess.run(["git", "add", "large.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True)
+    tracked.write_text("large-change\n" + ("x" * 70000) + "\n")
+
+    fake = tmp_path / "provider"
+    fake.write_text(
+        "#!/usr/bin/env python3\n"
+        "import pathlib, re, sys\n"
+        "prompt_arg = sys.argv[-1]\n"
+        "print(f'argv_len={len(prompt_arg)}')\n"
+        "assert len(prompt_arg) < 500\n"
+        "assert 'large-change' not in prompt_arg\n"
+        "match = re.search(r'Prompt file: (.+)', prompt_arg)\n"
+        "assert match, prompt_arg\n"
+        "prompt = pathlib.Path(match.group(1).strip()).read_text()\n"
+        "assert 'large-change' in prompt\n"
+        "print('large-prompt-file-ok')\n"
+    )
+    fake.chmod(0o755)
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {"glm": {"cli": str(fake), "timeout": 10}},
+                "review": {
+                    "prompt_template": "{diff}\n\n{files}\n",
+                    "default_providers": ["glm"],
+                },
+            }
+        )
+    )
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--providers",
+            "glm",
+            "--scope",
+            ".",
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert rc == 0, err
+    raw = (Path(out) / "raw" / "glm.txt").read_text()
+    assert "large-prompt-file-ok" in raw
 
 
 def test_install_codex_installs_skill_config_and_wrapper_without_claude(tmp_path):

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -1,0 +1,177 @@
+"""Tests for the Codex-native Trinity adapter."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent.parent
+CODEX_CONFIG = ROOT / ".agents" / "trinity.codex.json"
+CODEX_SCRIPT = ROOT / "scripts" / "codex.py"
+CODEX_BIN = ROOT / "bin" / "trinity"
+CODEX_SKILL = ROOT / ".agents" / "skills" / "trinity" / "SKILL.md"
+CLAUDE_SKILL = ROOT / "SKILL.md"
+MAKEFILE = ROOT / "Makefile"
+INSTALL_SH = ROOT / "install.sh"
+
+
+def run_codex(args, cwd=None, env=None):
+    result = subprocess.run(
+        [sys.executable, str(CODEX_SCRIPT)] + args,
+        cwd=cwd or ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def test_codex_default_config_has_direct_review_providers():
+    data = json.loads(CODEX_CONFIG.read_text())
+
+    assert data["providers"]["glm"] == {
+        "cli": "droid exec --model glm-5",
+        "supports_resume": True,
+        "resume_arg": "-s",
+        "timeout": 360,
+    }
+    assert data["providers"]["gemini"] == {
+        "cli": "gemini --model gemini-3.1-pro-preview -p",
+        "supports_resume": True,
+        "resume_arg": "-r",
+        "timeout": 360,
+    }
+    assert data["providers"]["deepseek"] == {
+        "cli": "droid exec --model deepseek-v4-pro[1m]",
+        "supports_resume": True,
+        "resume_arg": "-s",
+        "timeout": 600,
+    }
+    assert data["review"]["default_providers"] == ["glm", "gemini", "deepseek"]
+    assert "{diff}" in data["review"]["prompt_template"]
+    assert "{files}" in data["review"]["prompt_template"]
+
+
+def test_claude_code_install_path_remains_unchanged():
+    makefile = MAKEFILE.read_text()
+    install_sh = INSTALL_SH.read_text()
+    root_skill = CLAUDE_SKILL.read_text()
+
+    assert "install:        ## Install Trinity to ~/.claude/" in makefile
+    assert "cp SKILL.md ~/.claude/skills/trinity/SKILL.md" in makefile
+    assert "--global-config ~/.claude/trinity.json" in makefile
+    assert "${HOME}/.claude/skills/trinity/SKILL.md" in install_sh
+    assert "${HOME}/.claude/trinity.json" in install_sh
+
+    assert "background sub-agents" in root_skill
+    assert ".claude/trinity.json" in root_skill
+    assert "Agent(" in root_skill
+    assert CODEX_SKILL.read_text() != root_skill
+
+
+def test_codex_review_collects_tracked_and_untracked_changes(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    tracked = repo / "tracked.txt"
+    tracked.write_text("before\n")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True)
+    tracked.write_text("before\nafter tracked change\n")
+    (repo / "untracked.txt").write_text("new untracked evidence\n")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for provider in ["glm", "gemini", "deepseek"]:
+        script = fake_bin / provider
+        script.write_text(
+            "#!/bin/sh\n"
+            "prompt=''\n"
+            'for arg in "$@"; do prompt="$arg"; done\n'
+            'printf \'provider=%s\\n\' "$(basename "$0")"\n'
+            "printf '%s' \"$prompt\" | grep -q 'after tracked change' && echo tracked-ok\n"
+            "printf '%s' \"$prompt\" | grep -q 'new untracked evidence' && echo untracked-ok\n"
+        )
+        script.chmod(0o755)
+
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "glm": {"cli": str(fake_bin / "glm"), "timeout": 10},
+                    "gemini": {"cli": str(fake_bin / "gemini"), "timeout": 10},
+                    "deepseek": {"cli": str(fake_bin / "deepseek"), "timeout": 10},
+                },
+                "review": {
+                    "prompt_template": "Scope: {scope}\n\n{diff}\n\n{files}\n",
+                    "default_providers": ["glm", "gemini", "deepseek"],
+                },
+            }
+        )
+    )
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--providers",
+            "glm,gemini,deepseek",
+            "--scope",
+            ".",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 0, err
+    review_dir = Path(out)
+    assert review_dir.is_dir()
+    assert (review_dir / "prompt.md").read_text().count("after tracked change") >= 1
+    assert "new untracked evidence" in (review_dir / "prompt.md").read_text()
+    for provider in ["glm", "gemini", "deepseek"]:
+        raw = (review_dir / "raw" / f"{provider}.txt").read_text()
+        assert "tracked-ok" in raw
+        assert "untracked-ok" in raw
+    synthesis = (review_dir / "synthesis.md").read_text()
+    assert "Trinity Review Synthesis" in synthesis
+    assert "raw/glm.txt" in synthesis
+
+
+def test_install_codex_installs_skill_config_and_wrapper_without_claude(tmp_path):
+    home = tmp_path / "home"
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PATH"] = os.environ["PATH"]
+
+    result = subprocess.run(
+        ["make", "install-codex"],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (home / ".codex" / "skills" / "trinity" / "SKILL.md").read_text() == (
+        CODEX_SKILL.read_text()
+    )
+    installed_config = json.loads((home / ".codex" / "trinity.json").read_text())
+    assert installed_config["providers"]["glm"]["cli"] == "droid exec --model glm-5"
+    assert installed_config["providers"]["deepseek"]["cli"] == (
+        "droid exec --model deepseek-v4-pro[1m]"
+    )
+    assert (home / ".codex" / "skills" / "trinity" / "scripts" / "codex.py").exists()
+    assert (home / ".local" / "bin" / "trinity").read_text() == CODEX_BIN.read_text()
+    assert os.access(home / ".local" / "bin" / "trinity", os.X_OK)
+    assert not (home / ".claude").exists()

--- a/tests/test_codex_compat.py
+++ b/tests/test_codex_compat.py
@@ -37,6 +37,9 @@ def test_repo_local_codex_skill_is_importable_and_codex_specific():
     assert "Agent(" not in text
     assert "Claude Code" in text
     assert "Codex" in text
+    assert "trinity review" in text
+    assert ".agents/trinity.codex.json" in text
+    assert "Claude-specific background worker" in text
 
 
 def test_plugin_manifest_points_to_bundled_skill():
@@ -78,3 +81,6 @@ def test_readme_documents_claude_and_codex_load_smoke_checks():
     assert "/plugins" in text
     assert "/trinity status" in text
     assert "Claude Code" in text
+    assert "make install-codex" in text
+    assert "trinity review --providers glm,gemini,deepseek" in text
+    assert ".agents/trinity.codex.json" in text


### PR DESCRIPTION
## What changed

- Added a Codex-native Trinity review adapter: `.agents/trinity.codex.json`, `scripts/codex.py`, `bin/trinity`, and `make install-codex`.
- `trinity review --providers glm,gemini,deepseek --scope <path>` now collects tracked and untracked git changes, includes changed file snapshots, calls provider CLIs directly, saves raw outputs, and writes `synthesis.md`.
- Installed/packaged Codex docs now describe the wrapper and config path while preserving the existing Claude Code root `SKILL.md` and `make install` path.
- Added TRN-2010 PRP and TRN-2011 CHG, plus validator backfills for older TRN docs so `af validate --root .` is clean.

## Why

Codex could load the Trinity skill/plugin package, but it still lacked a practical local review path because the Claude adapter depends on Claude Code worker-agent files and the Agent runtime. This adds the missing Codex-side CLI path without changing Claude Code dispatch semantics.

## Validation

- RED confirmed first: `tests/test_codex_adapter.py` initially failed for missing config, script, and install target.
- `.venv/bin/pytest tests/test_codex_adapter.py tests/test_codex_compat.py -q` -> 8 passed.
- `make test` -> pytest 71/71 plus shell suites passed.
- `make lint` -> ruff check and format check passed.
- `af validate --root .` -> 74 documents checked, 0 issues.
- `HOME=$(mktemp -d) make install-codex` -> installed Codex adapter without creating `.claude`.
- `make install && python3 ~/.claude/skills/trinity/scripts/session.py --version` -> 3.0.0.
- Real local install smoke: `make install-codex && ~/.local/bin/trinity --version` -> 3.0.0.
- Installed wrapper smoke used mocked provider CLIs and verified tracked/untracked prompt content reached raw outputs.

## Notes

- Real provider review calls were not run to avoid consuming provider quota during PR creation; tests and smoke checks use fake provider CLIs.
- `origin` push was denied for the current GitHub account, so this draft PR is opened from `ryosaeba1985:codex/codex-review-adapter` into `frankyxhl/trinity:main`.
