### PR TITLE
[codex] Ignore local Claude state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ __pycache__/
 dist/
 .team/
 .trinity/
+.claude/
 .omx/
 .worktrees/


### PR DESCRIPTION
## What changed

- Added repo-local `.claude/` to `.gitignore`.

## Why

The repo-local `.claude/trinity.json` file is Trinity/Claude session state. Claude Code uses the installed home-directory path `~/.claude/`, so this local project state should not appear as an untracked source file.

## Validation

- `git check-ignore -v .claude/trinity.json` confirms `.gitignore` ignores the local state file.
- Diff is limited to `.gitignore`.
