### PR TITLE
[codex] Add Codex provider health checks

### DIFF
--- a/.agents/skills/trinity/SKILL.md
+++ b/.agents/skills/trinity/SKILL.md
@@ -25,12 +25,16 @@ Also treat `$trinity` as an explicit Codex skill invocation.
 For Codex-native code review from the terminal, use the installed wrapper:
 
 ```bash
+trinity doctor --providers glm,gemini,deepseek
 trinity review --providers glm,gemini,deepseek --scope <path-or-label>
 ```
 
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
 `.agents/trinity.codex.json`. It calls provider CLIs directly, saves raw outputs,
 and writes a deterministic synthesis markdown under `.trinity/reviews/`.
+`trinity doctor` and `trinity review --check-providers` validate provider config,
+command lookup, executable permissions, and timeout values without making network
+calls.
 
 ## Host Boundary
 
@@ -54,6 +58,8 @@ For Codex load verification, use these smoke checks after changes are installed 
 
 - Repo-local skill: restart/start Codex in this repository, open `/skills` or invoke `$trinity`, and confirm `trinity` is visible/loadable.
 - Plugin package: restart Codex, open `/plugins`, select the repo marketplace, and confirm the `trinity` plugin appears and exposes its bundled skill.
-- Local wrapper: run `make install-codex`, then `trinity --version` and a mocked or low-risk `trinity review --providers glm,gemini,deepseek --scope <path>`.
+- Local wrapper: run `make install-codex`, then `trinity --version`,
+  `trinity doctor --providers glm,gemini,deepseek`, and a mocked or low-risk
+  `trinity review --providers glm,gemini,deepseek --scope <path>`.
 
 For Claude Code regression verification, keep using the existing Claude checks: install Trinity, restart Claude Code, and run `/trinity status`.

--- a/.agents/trinity.codex.json
+++ b/.agents/trinity.codex.json
@@ -13,9 +13,9 @@
       "timeout": 360
     },
     "deepseek": {
-      "cli": "droid exec --model deepseek-v4-pro[1m]",
+      "cli": "~/.codex/skills/trinity/bin/deepseek -p",
       "supports_resume": true,
-      "resume_arg": "-s",
+      "resume_arg": "-r",
       "timeout": 600
     }
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### Added
 - Codex-native review adapter: `.agents/trinity.codex.json`, `scripts/codex.py`, `bin/trinity`, and `make install-codex` install a `trinity review --providers glm,gemini,deepseek` workflow under `~/.codex/` / `~/.local/bin`. The wrapper collects tracked plus untracked git changes, saves raw provider outputs, and writes deterministic review synthesis markdown without using Claude Code worker-agent runtime.
 - `rules/TRN-2010-PRP-Codex-Review-Adapter.md` and `rules/TRN-2011-CHG-Codex-Review-Adapter.md` document the approved design and implementation record. New tests cover Codex config/install/review behavior plus Claude Code compatibility.
+- `trinity doctor` and `trinity review --check-providers` preflight Codex review providers for config shape, command lookup, executable permissions, and timeout values before review dispatch.
 
 ### Fixed
 - Backfilled validator-required sections and change-history tables in older TRN docs (`TRN-1001` through `TRN-1005`, `TRN-2002`, `TRN-2003`), bringing `af validate --root .` to 0 issues.
 - Codex review provider calls now use a short prompt-file handoff instead of passing the full rendered review prompt as argv, avoiding OS argument-length failures on large diffs.
+- Codex DeepSeek review config now uses the installed `~/.codex/skills/trinity/bin/deepseek -p` wrapper instead of the locally rejected `droid exec --model deepseek-v4-pro[1m]` alias.
 
 ## [3.0.0] - 2026-04-29
 

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,14 @@ install:        ## Install Trinity to ~/.claude/ (TRN-1005)
 
 install-codex:  ## Install Trinity Codex adapter to ~/.codex/ and ~/.local/bin
 	@mkdir -p ~/.codex/skills/trinity/scripts
+	@mkdir -p ~/.codex/skills/trinity/bin
 	@mkdir -p ~/.local/bin
 	cp .agents/skills/trinity/SKILL.md ~/.codex/skills/trinity/SKILL.md
 	cp .agents/trinity.codex.json ~/.codex/skills/trinity/trinity.codex.json
 	cp -r scripts/. ~/.codex/skills/trinity/scripts/
+	cp providers/bin/deepseek ~/.codex/skills/trinity/bin/deepseek
 	cp bin/trinity ~/.local/bin/trinity
-	chmod +x ~/.local/bin/trinity
+	chmod +x ~/.codex/skills/trinity/bin/deepseek ~/.local/bin/trinity
 	python3 ~/.codex/skills/trinity/scripts/codex.py init-config \
 		--global-config ~/.codex/trinity.json
 	@echo "Installed Trinity Codex adapter $(CURRENT_VERSION)"

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ This installs:
 |----------|----------|
 | `~/.codex/skills/trinity/SKILL.md` | Codex-specific Trinity skill |
 | `~/.codex/skills/trinity/scripts/` | Shared Trinity scripts plus Codex wrapper script |
+| `~/.codex/skills/trinity/bin/deepseek` | Codex DeepSeek Anthropic-compatible wrapper |
 | `~/.codex/skills/trinity/trinity.codex.json` | Bundled default Codex config |
 | `~/.codex/trinity.json` | User-level Codex provider config |
 | `~/.local/bin/trinity` | Terminal wrapper for Codex-native commands |
@@ -217,6 +218,21 @@ This installs:
 The committed default config lives at `.agents/trinity.codex.json`. It registers
 `glm`, `gemini`, and `deepseek` for direct CLI review calls and records each
 provider's command, resume support flag, timeout, and review prompt template.
+The Codex DeepSeek entry uses the installed
+`~/.codex/skills/trinity/bin/deepseek -p` wrapper so it does not depend on a
+locally accepted `droid` model alias.
+
+**Check provider health**
+
+```bash
+trinity doctor --providers glm,gemini,deepseek
+trinity review --check-providers --providers glm,gemini,deepseek
+```
+
+Health checks validate the selected provider config, command lookup,
+executable permissions, and timeout values before a review run starts. They do
+not call the provider or require a network request, so API-key or quota failures
+can still occur during the actual review.
 
 **Run a Codex-native review**
 
@@ -227,7 +243,8 @@ trinity review --providers glm,gemini,deepseek --scope spikes/hardline
 The review wrapper collects tracked and untracked git changes, adds changed file
 snapshots to the prompt, calls each provider CLI directly, stores raw provider
 outputs, and writes a deterministic `synthesis.md` under `.trinity/reviews/`.
-This path does not require Claude Code worker-agent files.
+Selected providers are preflighted before output directories are created. This
+path does not require Claude Code worker-agent files.
 
 **Codex repo-local skill**
 

--- a/plugins/trinity/skills/trinity/SKILL.md
+++ b/plugins/trinity/skills/trinity/SKILL.md
@@ -25,12 +25,16 @@ Also treat `$trinity` as an explicit Codex skill invocation.
 For Codex-native code review from the terminal, use the installed wrapper:
 
 ```bash
+trinity doctor --providers glm,gemini,deepseek
 trinity review --providers glm,gemini,deepseek --scope <path-or-label>
 ```
 
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
 `.agents/trinity.codex.json`. It calls provider CLIs directly, saves raw outputs,
 and writes a deterministic synthesis markdown under `.trinity/reviews/`.
+`trinity doctor` and `trinity review --check-providers` validate provider config,
+command lookup, executable permissions, and timeout values without making network
+calls.
 
 ## Host Boundary
 
@@ -54,6 +58,8 @@ For Codex load verification, use these smoke checks after changes are installed 
 
 - Repo-local skill: restart/start Codex in this repository, open `/skills` or invoke `$trinity`, and confirm `trinity` is visible/loadable.
 - Plugin package: restart Codex, open `/plugins`, select the repo marketplace, and confirm the `trinity` plugin appears and exposes its bundled skill.
-- Local wrapper: run `make install-codex`, then `trinity --version` and a mocked or low-risk `trinity review --providers glm,gemini,deepseek --scope <path>`.
+- Local wrapper: run `make install-codex`, then `trinity --version`,
+  `trinity doctor --providers glm,gemini,deepseek`, and a mocked or low-risk
+  `trinity review --providers glm,gemini,deepseek --scope <path>`.
 
 For Claude Code regression verification, keep using the existing Claude checks: install Trinity, restart Claude Code, and run `/trinity status`.

--- a/rules/TRN-0000-REF-Document-Index.md
+++ b/rules/TRN-0000-REF-Document-Index.md
@@ -31,6 +31,7 @@
 | 2011 | CHG | Codex Review Adapter |
 | 2012 | CHG | Claude Code Provider |
 | 2013 | CHG | Trinity Review Presets |
+| 2014 | CHG | Provider Health Checks and DeepSeek Review Config |
 
 ---
 
@@ -50,3 +51,4 @@
 | 2026-05-04 | Add TRN-2010 and TRN-2011 for Codex Review Adapter | Codex |
 | 2026-05-04 | Add TRN-2012 for Claude Code Provider | Codex |
 | 2026-05-04 | Add TRN-2013 for Trinity Review Presets | Codex |
+| 2026-05-04 | Add TRN-2014 Provider Health Checks and DeepSeek Review Config | Codex |

--- a/rules/TRN-2014-CHG-Provider-Health-Checks-and-DeepSeek-Review-Config.md
+++ b/rules/TRN-2014-CHG-Provider-Health-Checks-and-DeepSeek-Review-Config.md
@@ -1,0 +1,108 @@
+# CHG-2014: Provider Health Checks and DeepSeek Review Config
+
+**Applies to:** Trinity project (`frankyxhl/trinity`)
+**Last updated:** 2026-05-04
+**Last reviewed:** 2026-05-04
+**Status:** In Progress
+**Date:** 2026-05-04
+**Requested by:** Frank
+**Implementer:** Codex
+**Priority:** High
+**Change Type:** Normal
+**Related:** TRN-1200, TRN-2011, TRN-2013
+
+---
+
+## What
+
+Add provider health checks for Codex-native `trinity review`, and fix the
+DeepSeek review path so it uses a locally valid Trinity wrapper or a validated
+model command.
+
+---
+
+## Why
+
+During TRN-2013 review, DeepSeek failed through the Codex config path because
+`droid exec --model deepseek-v4-pro[1m]` was not accepted by the local `droid`
+CLI. The installed Trinity DeepSeek wrapper worked. Review orchestration should
+surface this before a long review run, not after partial reviewer output.
+
+---
+
+## Impact Analysis
+
+- **Systems affected:** `.agents/trinity.codex.json`, `scripts/codex.py`,
+  `make install-codex`, README, Codex adapter tests, and local
+  `~/.codex/trinity.json` after install.
+- **Systems intentionally preserved:** Claude Code provider agents,
+  `make install`, existing `trinity review --providers ...` syntax, raw output
+  and synthesis file layout.
+- **Downtime required:** No.
+- **Rollback plan:** restore prior DeepSeek CLI config and remove provider
+  health-check code/tests/docs. Existing review calls continue to run providers
+  directly.
+
+---
+
+## Implementation Plan
+
+1. RED: add tests for provider health validation with fake CLIs:
+   missing command, empty `cli`, non-executable wrapper, invalid timeout, and
+   healthy provider.
+2. RED: add regression test proving configured DeepSeek review path is locally
+   valid without requiring a real DeepSeek network call.
+3. GREEN: add a health-check function in `scripts/codex.py` that validates
+   command existence, config shape, timeout, and optional smoke metadata before
+   dispatch.
+4. GREEN: update Codex default DeepSeek config to use the installed Trinity
+   wrapper path when available, or a droid model ID accepted by local/provider
+   health checks.
+5. GREEN: add `trinity doctor` or `trinity review --check-providers` if the
+   implementation needs an explicit health-only command.
+6. REFACTOR: keep health validation independent from review execution so tests
+   do not need real provider calls.
+7. Docs: document provider health checks, expected failures, and repair steps.
+
+---
+
+## Testing / Verification
+
+Expected evidence before marking complete:
+
+- `.venv/bin/pytest tests/test_codex_adapter.py -q`
+- focused fake-provider health tests
+- `make test`
+- `make lint`
+- `af validate --root .`
+- `make install-codex`
+- `trinity review --providers glm,deepseek --scope <small-file>` with mocked or
+  low-risk provider calls
+
+---
+
+## Execution Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-05-04 | Added RED tests for provider health failures, healthy providers, review preflight, and Codex DeepSeek wrapper install | RED confirmed against prior adapter |
+| 2026-05-04 | Implemented `trinity doctor`, `trinity review --check-providers`, and pre-dispatch health validation | Focused Codex adapter tests pass |
+| 2026-05-04 | Updated Codex DeepSeek default to `~/.codex/skills/trinity/bin/deepseek -p` and install target to copy the wrapper | Installed config can be health-checked without network calls |
+| 2026-05-04 | Addressed Trinity review note by aligning `doctor` relative CLI resolution with git-root review semantics while preserving non-git health checks | Added regression coverage and reran full verification |
+
+---
+
+## Triage Evidence
+
+Trinity improvement triage on 2026-05-04:
+
+- GLM: CREATE_CHG
+- DeepSeek: CREATE_CHG, highest score among candidates
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-04 | Initial CHG for provider health checks and DeepSeek review config | Codex |

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 
@@ -55,6 +56,15 @@ def resolve_root(root_arg):
     return Path(top).resolve()
 
 
+def resolve_health_root(root_arg):
+    root = Path(root_arg).expanduser().resolve()
+    try:
+        top = run_git(root, ["rev-parse", "--show-toplevel"]).strip()
+    except (OSError, RuntimeError):
+        return root
+    return Path(top).resolve()
+
+
 def load_json(path):
     try:
         return json.loads(path.read_text())
@@ -97,6 +107,140 @@ def split_providers(value, config):
     if not providers:
         raise SystemExit("trinity-codex: no providers selected")
     return providers
+
+
+def parse_provider_command(provider, provider_config):
+    if not isinstance(provider_config, dict):
+        raise ValueError("provider config must be an object")
+    cli = provider_config.get("cli")
+    if not isinstance(cli, str) or not cli.strip():
+        raise ValueError("missing cli")
+    expanded = os.path.expandvars(os.path.expanduser(cli))
+    try:
+        command = shlex.split(expanded)
+    except ValueError as exc:
+        raise ValueError(f"invalid cli: {exc}") from exc
+    if not command:
+        raise ValueError("missing cli")
+    return command
+
+
+def provider_timeout(provider, provider_config):
+    raw_timeout = provider_config.get("timeout", 360)
+    if isinstance(raw_timeout, bool):
+        raise ValueError(f"invalid timeout: {raw_timeout}")
+    try:
+        timeout = int(raw_timeout)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid timeout: {raw_timeout}") from exc
+    if timeout <= 0:
+        raise ValueError(f"invalid timeout: {raw_timeout}")
+    return timeout
+
+
+def command_has_path(command):
+    return os.path.sep in command or (
+        os.path.altsep is not None and os.path.altsep in command
+    )
+
+
+def executable_health(command, root):
+    executable = command[0]
+    if command_has_path(executable):
+        executable_path = Path(executable)
+        if not executable_path.is_absolute():
+            executable_path = root / executable_path
+        if not executable_path.exists():
+            return None, f"command not found: {executable_path}"
+        if executable_path.is_dir() or not os.access(executable_path, os.X_OK):
+            return str(executable_path), f"not executable: {executable_path}"
+        return str(executable_path), None
+
+    resolved = shutil.which(executable)
+    if resolved is None:
+        return None, f"command not found: {executable}"
+    return resolved, None
+
+
+def provider_health(provider, provider_config, root):
+    issues = []
+    command = None
+    executable = None
+    timeout = None
+
+    try:
+        command = parse_provider_command(provider, provider_config)
+    except ValueError as exc:
+        issues.append(str(exc))
+
+    if command:
+        executable, issue = executable_health(command, root)
+        if issue:
+            issues.append(issue)
+
+    if isinstance(provider_config, dict):
+        try:
+            timeout = provider_timeout(provider, provider_config)
+        except ValueError as exc:
+            issues.append(str(exc))
+
+    return {
+        "provider": provider,
+        "ok": not issues,
+        "executable": executable,
+        "timeout": timeout,
+        "issues": issues,
+    }
+
+
+def provider_health_results(config, providers, root):
+    provider_configs = config.get("providers", {})
+    if not isinstance(provider_configs, dict):
+        return [
+            {
+                "provider": provider,
+                "ok": False,
+                "executable": None,
+                "timeout": None,
+                "issues": ["providers config must be an object"],
+            }
+            for provider in providers
+        ]
+
+    results = []
+    for provider in providers:
+        if provider not in provider_configs:
+            results.append(
+                {
+                    "provider": provider,
+                    "ok": False,
+                    "executable": None,
+                    "timeout": None,
+                    "issues": ["unknown provider"],
+                }
+            )
+            continue
+        results.append(provider_health(provider, provider_configs[provider], root))
+    return results
+
+
+def format_health_results(results):
+    lines = []
+    for result in results:
+        provider = result["provider"]
+        if result["ok"]:
+            lines.append(
+                f"{provider}: OK - {result['executable']} "
+                f"(timeout {result['timeout']}s)"
+            )
+            continue
+        for issue in result["issues"]:
+            lines.append(f"{provider}: FAIL - {issue}")
+    return "\n".join(lines)
+
+
+def health_results_ok(results):
+    return all(result["ok"] for result in results)
 
 
 def scope_pathspec(root, scope):
@@ -245,11 +389,10 @@ def make_review_dir(out_dir, scope):
 
 
 def provider_command(provider, provider_config):
-    cli = provider_config.get("cli")
-    if not cli:
-        raise SystemExit(f"trinity-codex: provider {provider} missing cli")
-    expanded = os.path.expandvars(os.path.expanduser(cli))
-    return shlex.split(expanded)
+    try:
+        return parse_provider_command(provider, provider_config)
+    except ValueError as exc:
+        raise SystemExit(f"trinity-codex: provider {provider} {exc}") from exc
 
 
 def build_prompt_handoff(prompt_path):
@@ -265,7 +408,10 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root):
     cmd = provider_command(provider, provider_config) + [
         build_prompt_handoff(prompt_path)
     ]
-    timeout = int(provider_config.get("timeout", 360))
+    try:
+        timeout = provider_timeout(provider, provider_config)
+    except ValueError as exc:
+        raise SystemExit(f"trinity-codex: provider {provider} {exc}") from exc
     started = dt.datetime.now().isoformat(timespec="seconds")
     try:
         result = subprocess.run(
@@ -338,6 +484,15 @@ def cmd_review(args):
     root = resolve_root(args.root)
     config = load_config(args.config)
     providers = split_providers(args.providers, config)
+    provider_configs = config.get("providers", {})
+    health = provider_health_results(config, providers, root)
+    if args.check_providers:
+        print(format_health_results(health))
+        return 0 if health_results_ok(health) else 1
+    if not health_results_ok(health):
+        print(format_health_results(health), file=sys.stderr)
+        return 1
+
     out_base = args.out_dir or config.get("review", {}).get(
         "output_dir", ".trinity/reviews"
     )
@@ -350,10 +505,7 @@ def cmd_review(args):
     prompt_path.write_text(prompt)
 
     results = []
-    provider_configs = config.get("providers", {})
     for provider in providers:
-        if provider not in provider_configs:
-            raise SystemExit(f"trinity-codex: unknown provider: {provider}")
         results.append(
             run_provider(
                 provider,
@@ -377,6 +529,15 @@ def cmd_review(args):
     return 0 if all(item["returncode"] == 0 for item in results) else 1
 
 
+def cmd_doctor(args):
+    root = resolve_health_root(args.root)
+    config = load_config(args.config)
+    providers = split_providers(args.providers, config)
+    health = provider_health_results(config, providers, root)
+    print(format_health_results(health))
+    return 0 if health_results_ok(health) else 1
+
+
 def build_parser():
     parser = argparse.ArgumentParser(prog="trinity")
     parser.add_argument("--version", action="store_true")
@@ -385,12 +546,18 @@ def build_parser():
     init_config = subparsers.add_parser("init-config")
     init_config.add_argument("--global-config", default=str(DEFAULT_CONFIG))
 
+    doctor = subparsers.add_parser("doctor")
+    doctor.add_argument("--root", default=".")
+    doctor.add_argument("--config", default=str(DEFAULT_CONFIG))
+    doctor.add_argument("--providers")
+
     review = subparsers.add_parser("review")
     review.add_argument("--root", default=".")
     review.add_argument("--config", default=str(DEFAULT_CONFIG))
     review.add_argument("--providers")
     review.add_argument("--scope", default=".")
     review.add_argument("--out-dir")
+    review.add_argument("--check-providers", action="store_true")
     return parser
 
 
@@ -406,6 +573,8 @@ def main(argv=None):
         return 0
     if args.command == "review":
         return cmd_review(args)
+    if args.command == "doctor":
+        return cmd_doctor(args)
     parser.print_help(sys.stderr)
     return 1
 

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -44,9 +44,9 @@ def test_codex_default_config_has_direct_review_providers():
         "timeout": 360,
     }
     assert data["providers"]["deepseek"] == {
-        "cli": "droid exec --model deepseek-v4-pro[1m]",
+        "cli": "~/.codex/skills/trinity/bin/deepseek -p",
         "supports_resume": True,
-        "resume_arg": "-s",
+        "resume_arg": "-r",
         "timeout": 600,
     }
     assert data["review"]["default_providers"] == ["glm", "gemini", "deepseek"]
@@ -218,6 +218,130 @@ def test_codex_review_uses_short_prompt_file_handoff_for_large_diffs(tmp_path):
     assert "large-prompt-file-ok" in raw
 
 
+def test_codex_doctor_reports_provider_health_failures(tmp_path):
+    fake = tmp_path / "fake"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    not_executable = tmp_path / "not-executable"
+    not_executable.write_text("#!/bin/sh\nexit 0\n")
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "empty": {"cli": "", "timeout": 10},
+                    "missing": {"cli": "missing-trinity-provider-cmd", "timeout": 10},
+                    "not_exec": {"cli": str(not_executable), "timeout": 10},
+                    "bad_timeout": {"cli": str(fake), "timeout": 0},
+                },
+                "review": {"default_providers": []},
+            }
+        )
+    )
+
+    rc, out, err = run_codex(
+        [
+            "doctor",
+            "--config",
+            str(config),
+            "--providers",
+            "empty,missing,not_exec,bad_timeout,unknown",
+        ]
+    )
+
+    assert rc == 1
+    report = out + err
+    assert "empty: FAIL - missing cli" in report
+    assert "missing: FAIL - command not found: missing-trinity-provider-cmd" in report
+    assert f"not_exec: FAIL - not executable: {not_executable}" in report
+    assert "bad_timeout: FAIL - invalid timeout: 0" in report
+    assert "unknown: FAIL - unknown provider" in report
+
+
+def test_codex_doctor_passes_healthy_provider(tmp_path):
+    fake = tmp_path / "fake-provider"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "healthy": {"cli": f"{fake} --unused-arg", "timeout": "10"}
+                },
+                "review": {"default_providers": ["healthy"]},
+            }
+        )
+    )
+
+    rc, out, err = run_codex(["doctor", "--config", str(config)])
+
+    assert rc == 0, err
+    assert f"healthy: OK - {fake} (timeout 10s)" in out
+
+
+def test_codex_doctor_resolves_relative_provider_cli_from_git_root(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    nested = repo / "nested"
+    nested.mkdir()
+    tools = repo / "tools"
+    tools.mkdir()
+    provider = tools / "provider"
+    provider.write_text("#!/bin/sh\nexit 0\n")
+    provider.chmod(0o755)
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {"relative": {"cli": "./tools/provider", "timeout": 10}},
+                "review": {"default_providers": ["relative"]},
+            }
+        )
+    )
+
+    rc, out, err = run_codex(["doctor", "--root", str(nested), "--config", str(config)])
+
+    assert rc == 0, err
+    assert f"relative: OK - {provider} (timeout 10s)" in out
+
+
+def test_codex_review_preflights_provider_health_before_creating_review(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "missing": {"cli": "missing-trinity-provider-cmd", "timeout": 10}
+                },
+                "review": {"default_providers": ["missing"]},
+            }
+        )
+    )
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "missing: FAIL - command not found: missing-trinity-provider-cmd" in err
+    assert not out_dir.exists()
+
+
 def test_install_codex_installs_skill_config_and_wrapper_without_claude(tmp_path):
     home = tmp_path / "home"
     env = os.environ.copy()
@@ -236,12 +360,29 @@ def test_install_codex_installs_skill_config_and_wrapper_without_claude(tmp_path
     assert (home / ".codex" / "skills" / "trinity" / "SKILL.md").read_text() == (
         CODEX_SKILL.read_text()
     )
+    deepseek_wrapper = home / ".codex" / "skills" / "trinity" / "bin" / "deepseek"
     installed_config = json.loads((home / ".codex" / "trinity.json").read_text())
     assert installed_config["providers"]["glm"]["cli"] == "droid exec --model glm-5"
     assert installed_config["providers"]["deepseek"]["cli"] == (
-        "droid exec --model deepseek-v4-pro[1m]"
+        "~/.codex/skills/trinity/bin/deepseek -p"
     )
+    assert deepseek_wrapper.exists()
+    assert os.access(deepseek_wrapper, os.X_OK)
     assert (home / ".codex" / "skills" / "trinity" / "scripts" / "codex.py").exists()
     assert (home / ".local" / "bin" / "trinity").read_text() == CODEX_BIN.read_text()
     assert os.access(home / ".local" / "bin" / "trinity", os.X_OK)
     assert not (home / ".claude").exists()
+
+    rc, out, err = run_codex(
+        [
+            "doctor",
+            "--config",
+            str(home / ".codex" / "trinity.json"),
+            "--providers",
+            "deepseek",
+        ],
+        env=env,
+    )
+
+    assert rc == 0, err
+    assert f"deepseek: OK - {deepseek_wrapper} (timeout 600s)" in out


### PR DESCRIPTION
## What

Implements TRN-2014 provider health checks for the Codex-native Trinity review adapter.

- Adds `trinity doctor` and `trinity review --check-providers`.
- Preflights selected review providers before creating `.trinity/reviews/...` output.
- Validates provider config shape, command lookup, executable permissions, and timeout values.
- Installs the DeepSeek wrapper into `~/.codex/skills/trinity/bin/deepseek` and updates Codex DeepSeek config to use `~/.codex/skills/trinity/bin/deepseek -p` instead of the rejected `droid exec --model deepseek-v4-pro[1m]` alias.
- Documents the new health-check flow in README, Codex skills, CHANGELOG, and TRN-2014.

## Why

During TRN-2013 review, the Codex DeepSeek config pointed at a local `droid` model alias that this machine rejects. The installed Trinity DeepSeek wrapper works. This change makes provider setup failures visible before long review runs and makes the default DeepSeek path locally valid after `make install-codex`.

## Validation

- `.venv/bin/pytest tests/test_codex_adapter.py -q` -> 9 passed
- `make test` -> passed, 76 pytest tests plus shell suites
- `make lint` -> passed
- `af validate --root .` -> 86 documents checked, 0 issues found
- clean `HEAD` worktree check: `af validate --root .` -> 82 documents checked, 0 issues found
- `make install-codex` -> installed locally
- `trinity doctor --providers glm,gemini,deepseek` -> all OK
- `trinity review --check-providers --providers glm,gemini,deepseek` -> all OK

## Trinity Review

- GLM: PASS
- DeepSeek: PASS with recommendations; reviewed the recommendation about missing-git fallback and confirmed `resolve_health_root` already catches `OSError`, which is the path raised by `subprocess.run(["git"])` when git is absent.
- Gemini: skipped because Gemini CLI quota was exhausted in this session.

Review artifacts:

- `.trinity/reviews/20260504-193052-./`
- `.trinity/reviews/20260504-194045-./`
