### PR TITLE
[codex] Add PR review input modes

### DIFF
--- a/.agents/skills/trinity/SKILL.md
+++ b/.agents/skills/trinity/SKILL.md
@@ -27,6 +27,8 @@ For Codex-native code review from the terminal, use the installed wrapper:
 ```bash
 trinity doctor --providers glm,gemini,deepseek
 trinity review --providers glm,gemini,deepseek --scope <path-or-label>
+trinity review --base main --head HEAD --providers glm,deepseek
+trinity review --pr 21 --providers glm,deepseek
 ```
 
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
@@ -34,7 +36,8 @@ The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
 and writes a deterministic synthesis markdown under `.trinity/reviews/`.
 `trinity doctor` and `trinity review --check-providers` validate provider config,
 command lookup, executable permissions, and timeout values without making network
-calls.
+calls. Use the default review mode for dirty working-tree changes, `--base` /
+`--head` for committed branch reviews, and `--pr` for GitHub PR reviews.
 
 ## Host Boundary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 - Codex-native review adapter: `.agents/trinity.codex.json`, `scripts/codex.py`, `bin/trinity`, and `make install-codex` install a `trinity review --providers glm,gemini,deepseek` workflow under `~/.codex/` / `~/.local/bin`. The wrapper collects tracked plus untracked git changes, saves raw provider outputs, and writes deterministic review synthesis markdown without using Claude Code worker-agent runtime.
 - `rules/TRN-2010-PRP-Codex-Review-Adapter.md` and `rules/TRN-2011-CHG-Codex-Review-Adapter.md` document the approved design and implementation record. New tests cover Codex config/install/review behavior plus Claude Code compatibility.
 - `trinity doctor` and `trinity review --check-providers` preflight Codex review providers for config shape, command lookup, executable permissions, and timeout values before review dispatch.
+- `trinity review --base <base> --head <head>` and `trinity review --pr <number>` add committed branch / GitHub PR review modes for Codex-native Trinity review.
 
 ### Fixed
 - Backfilled validator-required sections and change-history tables in older TRN docs (`TRN-1001` through `TRN-1005`, `TRN-2002`, `TRN-2003`), bringing `af validate --root .` to 0 issues.
 - Codex review provider calls now use a short prompt-file handoff instead of passing the full rendered review prompt as argv, avoiding OS argument-length failures on large diffs.
 - Codex DeepSeek review config now uses the installed `~/.codex/skills/trinity/bin/deepseek -p` wrapper instead of the locally rejected `droid exec --model deepseek-v4-pro[1m]` alias.
+- Committed PR branches can now be reviewed without relying on dirty working-tree diffs, avoiding misleading "(no tracked or untracked git diff)" review prompts after changes are already committed.
 
 ## [3.0.0] - 2026-04-29
 

--- a/README.md
+++ b/README.md
@@ -238,13 +238,20 @@ can still occur during the actual review.
 
 ```bash
 trinity review --providers glm,gemini,deepseek --scope spikes/hardline
+trinity review --base main --head HEAD --providers glm,deepseek
+trinity review --pr 21 --providers glm,deepseek
 ```
 
-The review wrapper collects tracked and untracked git changes, adds changed file
-snapshots to the prompt, calls each provider CLI directly, stores raw provider
-outputs, and writes a deterministic `synthesis.md` under `.trinity/reviews/`.
-Selected providers are preflighted before output directories are created. This
-path does not require Claude Code worker-agent files.
+Without `--pr` or `--base/--head`, the review wrapper collects tracked and
+untracked working-tree changes. With `--base/--head`, it reviews committed
+branch changes from `git diff base...head` and snapshots changed files from the
+head commit. With `--pr`, it uses `gh pr view` / `gh pr diff` for the GitHub PR
+patch and metadata, then snapshots changed files from the PR head commit when
+that commit is locally available. All modes call each provider CLI directly,
+store raw provider outputs, and write a deterministic `synthesis.md` under
+`.trinity/reviews/`. Selected providers are preflighted before output
+directories are created. This path does not require Claude Code worker-agent
+files.
 
 **Codex repo-local skill**
 

--- a/plugins/trinity/skills/trinity/SKILL.md
+++ b/plugins/trinity/skills/trinity/SKILL.md
@@ -27,6 +27,8 @@ For Codex-native code review from the terminal, use the installed wrapper:
 ```bash
 trinity doctor --providers glm,gemini,deepseek
 trinity review --providers glm,gemini,deepseek --scope <path-or-label>
+trinity review --base main --head HEAD --providers glm,deepseek
+trinity review --pr 21 --providers glm,deepseek
 ```
 
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
@@ -34,7 +36,8 @@ The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
 and writes a deterministic synthesis markdown under `.trinity/reviews/`.
 `trinity doctor` and `trinity review --check-providers` validate provider config,
 command lookup, executable permissions, and timeout values without making network
-calls.
+calls. Use the default review mode for dirty working-tree changes, `--base` /
+`--head` for committed branch reviews, and `--pr` for GitHub PR reviews.
 
 ## Host Boundary
 

--- a/rules/TRN-0000-REF-Document-Index.md
+++ b/rules/TRN-0000-REF-Document-Index.md
@@ -32,6 +32,7 @@
 | 2012 | CHG | Claude Code Provider |
 | 2013 | CHG | Trinity Review Presets |
 | 2014 | CHG | Provider Health Checks and DeepSeek Review Config |
+| 2015 | CHG | PR Base Head Review Mode |
 
 ---
 
@@ -52,3 +53,4 @@
 | 2026-05-04 | Add TRN-2012 for Claude Code Provider | Codex |
 | 2026-05-04 | Add TRN-2013 for Trinity Review Presets | Codex |
 | 2026-05-04 | Add TRN-2014 Provider Health Checks and DeepSeek Review Config | Codex |
+| 2026-05-04 | Add TRN-2015 PR Base Head Review Mode | Codex |

--- a/rules/TRN-2015-CHG-PR-Base-Head-Review-Mode.md
+++ b/rules/TRN-2015-CHG-PR-Base-Head-Review-Mode.md
@@ -1,0 +1,114 @@
+# CHG-2015: PR Base Head Review Mode
+
+**Applies to:** Trinity project (`frankyxhl/trinity`)
+**Last updated:** 2026-05-04
+**Last reviewed:** 2026-05-04
+**Status:** In Progress
+**Date:** 2026-05-04
+**Requested by:** Frank
+**Implementer:** Codex
+**Priority:** High
+**Change Type:** Normal
+**Related:** TRN-1200, TRN-2011, TRN-2013, TRN-2014
+
+---
+
+## What
+
+Add a committed-branch review mode to Codex-native Trinity review:
+
+```bash
+trinity review --pr 20
+trinity review --base main --head HEAD
+```
+
+This mode must collect the actual PR/base-head patch and full snapshots of
+changed files instead of relying only on local uncommitted working-tree changes.
+
+---
+
+## Why
+
+During PR #20 COR-1602 review, the generic `trinity review` path saw no diff
+because the PR changes were already committed. This produced misleading reviewer
+feedback. Trinity needs a first-class mode for reviewing committed branches and
+GitHub PRs.
+
+---
+
+## Impact Analysis
+
+- **Systems affected:** `scripts/codex.py`, `bin/trinity`, README,
+  Codex adapter tests, review metadata schema, and `.trinity/reviews/` prompt
+  content.
+- **Systems intentionally preserved:** current working-tree review behavior,
+  `--providers`, `--scope`, raw outputs, synthesis layout, and Claude Code
+  Trinity behavior.
+- **Downtime required:** No.
+- **Rollback plan:** remove `--pr`, `--base`, and `--head` support plus tests
+  and docs. Working-tree review remains the fallback behavior.
+
+---
+
+## Implementation Plan
+
+1. RED: add tests for `--base main --head HEAD` collecting `git diff
+   main...HEAD` and snapshots for changed files.
+2. RED: add tests for `--pr <number>` using mocked `gh pr diff` /
+   `gh pr view` output, including failure when `gh` is unavailable or
+   unauthenticated.
+3. RED: add tests proving working-tree review still collects tracked and
+   untracked local changes when no PR/base-head options are supplied.
+4. GREEN: add review input mode resolution:
+   explicit `--pr` wins, then explicit `--base/--head`, then current
+   working-tree mode.
+5. GREEN: write review metadata with input mode, base, head, PR number, changed
+   files, and snapshot source.
+6. GREEN: ensure large diffs still use the prompt-file handoff.
+7. REFACTOR: split diff collection into small helpers for working tree,
+   base/head, and PR modes.
+8. Docs: add examples and explain when to use each mode.
+
+---
+
+## Testing / Verification
+
+Expected evidence before marking complete:
+
+- `.venv/bin/pytest tests/test_codex_adapter.py -q`
+- mocked GitHub PR diff tests
+- local git base/head fixture tests
+- `make test`
+- `make lint`
+- `af validate --root .`
+- `trinity review --base main --head HEAD --providers <fake-providers>`
+
+---
+
+## Execution Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-05-04 | Added RED tests for `--base/--head`, `--pr`, and GitHub CLI failure handling | RED confirmed against prior adapter |
+| 2026-05-04 | Implemented review input mode resolution for working-tree, base/head, and PR modes | Focused Codex adapter tests pass |
+| 2026-05-04 | Added metadata for review input mode, base/head, PR number, changed paths, and snapshot source | Prompt and metadata assertions pass |
+| 2026-05-04 | Updated README, Codex skill docs, plugin skill docs, and CHANGELOG | Documentation now covers dirty, committed-branch, and PR review modes |
+| 2026-05-04 | Reviewed committed branch with `trinity review --base main --head HEAD --providers glm,deepseek` | GLM PASS, DeepSeek PASS |
+| 2026-05-04 | Added follow-up tests for partial `--base/--head` usage and unavailable PR head snapshots | Focused tests and lint pass |
+
+---
+
+## Triage Evidence
+
+Trinity improvement triage on 2026-05-04:
+
+- GLM: CREATE_CHG, highest review-quality impact
+- DeepSeek: CREATE_CHG, immediate Trinity-scope follow-up after provider health
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-04 | Initial CHG for PR/base-head review mode | Codex |

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -261,9 +261,20 @@ def git_diff(root, pathspec):
     return run_git(root, args + pathspec, allow_error=True)
 
 
+def git_diff_range(root, base, head, pathspec):
+    args = ["diff", "--no-ext-diff", "--binary", f"{base}...{head}", "--"]
+    return run_git(root, args + pathspec)
+
+
 def changed_paths(root, pathspec):
     args = ["diff", "--name-only", "--diff-filter=ACMRT", "HEAD", "--"]
     output = run_git(root, args + pathspec, allow_error=True)
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def changed_paths_range(root, base, head, pathspec):
+    args = ["diff", "--name-only", "--diff-filter=ACMRT", f"{base}...{head}", "--"]
+    output = run_git(root, args + pathspec)
     return [line for line in output.splitlines() if line.strip()]
 
 
@@ -286,6 +297,24 @@ def read_text_file(path, max_bytes=200000):
         data = path.read_bytes()
     except OSError as exc:
         return f"[unreadable: {exc}]"
+    if b"\0" in data:
+        return "[binary file omitted]"
+    if len(data) > max_bytes:
+        head = data[:max_bytes].decode("utf-8", errors="replace")
+        return head + "\n[truncated: file exceeds max snapshot bytes]\n"
+    return data.decode("utf-8", errors="replace")
+
+
+def read_text_file_at_ref(root, ref, rel, max_bytes=200000):
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{rel}"],
+        cwd=str(root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        return None
+    data = result.stdout
     if b"\0" in data:
         return "[binary file omitted]"
     if len(data) > max_bytes:
@@ -343,7 +372,30 @@ def file_snapshots(root, paths):
     return "".join(chunks)
 
 
-def render_prompt(config, root, scope):
+def file_snapshots_at_ref(root, paths, ref):
+    if not paths:
+        return "(no changed file snapshots)\n"
+
+    chunks = []
+    seen = set()
+    for rel in paths:
+        if rel in seen:
+            continue
+        seen.add(rel)
+        chunks.append(f"### {rel}\n\n")
+        content = read_text_file_at_ref(root, ref, rel)
+        if content is None:
+            chunks.append("[deleted]\n\n")
+            continue
+        chunks.append("```text\n")
+        chunks.append(content)
+        if content and not content.endswith("\n"):
+            chunks.append("\n")
+        chunks.append("```\n\n")
+    return "".join(chunks)
+
+
+def working_tree_review_input(root, scope):
     pathspec = scope_pathspec(root, scope)
     tracked_diff = git_diff(root, pathspec)
     untracked = untracked_paths(root, pathspec)
@@ -355,9 +407,174 @@ def render_prompt(config, root, scope):
     )
     paths = changed_paths(root, pathspec) + untracked
     files = file_snapshots(root, paths)
-    template = config.get("review", {}).get("prompt_template", "{diff}\n\n{files}\n")
     if not diff.strip():
         diff = "(no tracked or untracked git diff)"
+    return {
+        "diff": diff,
+        "files": files,
+        "metadata": {
+            "mode": "working-tree",
+            "base": "HEAD",
+            "head": "working-tree",
+            "pr": None,
+            "scope": scope or ".",
+            "changed_paths": paths,
+            "snapshot_source": "working-tree",
+        },
+    }
+
+
+def base_head_review_input(root, base, head, scope):
+    pathspec = scope_pathspec(root, scope)
+    try:
+        diff = git_diff_range(root, base, head, pathspec)
+        paths = changed_paths_range(root, base, head, pathspec)
+    except RuntimeError as exc:
+        raise SystemExit(
+            f"trinity-codex: unable to collect git diff for {base}...{head}: {exc}"
+        ) from exc
+    files = file_snapshots_at_ref(root, paths, head)
+    if not diff.strip():
+        diff = f"(no git diff for {base}...{head})"
+    return {
+        "diff": diff,
+        "files": files,
+        "metadata": {
+            "mode": "base-head",
+            "base": base,
+            "head": head,
+            "pr": None,
+            "scope": scope or ".",
+            "changed_paths": paths,
+            "snapshot_source": f"git:{head}",
+        },
+    }
+
+
+def run_gh(root, args, label):
+    try:
+        result = subprocess.run(
+            ["gh"] + args,
+            cwd=str(root),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+    except FileNotFoundError:
+        raise SystemExit(
+            "trinity-codex: gh command not found; install/authenticate gh for --pr"
+        )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip() or "gh command failed"
+        raise SystemExit(f"trinity-codex: {label} failed: {detail}")
+    return result.stdout
+
+
+def gh_pr_view(root, pr_number):
+    output = run_gh(
+        root,
+        [
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "number,url,baseRefName,headRefName,headRefOid,files",
+        ],
+        f"gh pr view {pr_number}",
+    )
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"trinity-codex: invalid gh pr view JSON: {exc}")
+
+
+def gh_pr_diff(root, pr_number):
+    return run_gh(
+        root,
+        ["pr", "diff", str(pr_number), "--patch", "--color", "never"],
+        f"gh pr diff {pr_number}",
+    )
+
+
+def git_commit_exists(root, ref):
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{ref}^{{commit}}"],
+        cwd=str(root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.returncode == 0
+
+
+def ensure_pr_head_available(root, pr_number, head_oid):
+    if not head_oid:
+        return None
+    if git_commit_exists(root, head_oid):
+        return head_oid
+    run_git(
+        root,
+        ["fetch", "--quiet", "origin", f"pull/{pr_number}/head"],
+        allow_error=True,
+    )
+    if git_commit_exists(root, head_oid):
+        return head_oid
+    return None
+
+
+def pr_changed_paths(view):
+    paths = []
+    for item in view.get("files", []) or []:
+        path = item.get("path")
+        if path:
+            paths.append(path)
+    return paths
+
+
+def pr_review_input(root, pr_number, scope):
+    view = gh_pr_view(root, pr_number)
+    diff = gh_pr_diff(root, pr_number)
+    paths = pr_changed_paths(view)
+    head_oid = view.get("headRefOid")
+    snapshot_ref = ensure_pr_head_available(root, pr_number, head_oid)
+    if snapshot_ref:
+        files = file_snapshots_at_ref(root, paths, snapshot_ref)
+        snapshot_source = f"git:{snapshot_ref}"
+    else:
+        files = "(PR head snapshots unavailable locally)\n"
+        snapshot_source = "unavailable"
+    if not diff.strip():
+        diff = f"(no GitHub PR diff for PR #{pr_number})"
+    return {
+        "diff": diff,
+        "files": files,
+        "metadata": {
+            "mode": "pr",
+            "base": view.get("baseRefName"),
+            "head": view.get("headRefName"),
+            "head_oid": head_oid,
+            "pr": int(view.get("number") or pr_number),
+            "pr_url": view.get("url"),
+            "scope": scope or ".",
+            "changed_paths": paths,
+            "snapshot_source": snapshot_source,
+        },
+    }
+
+
+def resolve_review_input(args, root):
+    if args.pr is not None:
+        return pr_review_input(root, args.pr, args.scope)
+    if args.base or args.head:
+        if not args.base or not args.head:
+            raise SystemExit("trinity-codex: --base and --head must be used together")
+        return base_head_review_input(root, args.base, args.head, args.scope)
+    return working_tree_review_input(root, args.scope)
+
+
+def render_prompt(config, root, scope, review_input):
+    diff = review_input["diff"]
+    files = review_input["files"]
+    template = config.get("review", {}).get("prompt_template", "{diff}\n\n{files}\n")
     return (
         template.replace("{scope}", scope or ".")
         .replace("{root}", str(root))
@@ -492,6 +709,7 @@ def cmd_review(args):
     if not health_results_ok(health):
         print(format_health_results(health), file=sys.stderr)
         return 1
+    review_input = resolve_review_input(args, root)
 
     out_base = args.out_dir or config.get("review", {}).get(
         "output_dir", ".trinity/reviews"
@@ -500,7 +718,7 @@ def cmd_review(args):
     if not out_base.is_absolute():
         out_base = root / out_base
     review_dir = make_review_dir(out_base, args.scope)
-    prompt = render_prompt(config, root, args.scope)
+    prompt = render_prompt(config, root, args.scope, review_input)
     prompt_path = review_dir / "prompt.md"
     prompt_path.write_text(prompt)
 
@@ -519,6 +737,7 @@ def cmd_review(args):
         "scope": args.scope,
         "root": str(root),
         "providers": providers,
+        "input": review_input["metadata"],
         "results": results,
     }
     (review_dir / "metadata.json").write_text(
@@ -539,7 +758,7 @@ def cmd_doctor(args):
 
 
 def build_parser():
-    parser = argparse.ArgumentParser(prog="trinity")
+    parser = argparse.ArgumentParser(prog="trinity", allow_abbrev=False)
     parser.add_argument("--version", action="store_true")
     subparsers = parser.add_subparsers(dest="command")
 
@@ -558,6 +777,9 @@ def build_parser():
     review.add_argument("--scope", default=".")
     review.add_argument("--out-dir")
     review.add_argument("--check-providers", action="store_true")
+    review.add_argument("--pr", type=int)
+    review.add_argument("--base")
+    review.add_argument("--head")
     return parser
 
 

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -28,6 +28,40 @@ def run_codex(args, cwd=None, env=None):
     return result.returncode, result.stdout.strip(), result.stderr.strip()
 
 
+def init_repo(repo):
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+
+
+def commit_all(repo, message):
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", message], cwd=repo, check=True)
+
+
+def write_fake_provider(path, marker="provider-ok"):
+    path.write_text(f"#!/bin/sh\necho {marker}\n")
+    path.chmod(0o755)
+
+
+def simple_review_config(config, provider):
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {"glm": {"cli": str(provider), "timeout": 10}},
+                "review": {
+                    "prompt_template": "Scope: {scope}\n\n{diff}\n\n{files}\n",
+                    "default_providers": ["glm"],
+                },
+            }
+        )
+    )
+
+
 def test_codex_default_config_has_direct_review_providers():
     data = json.loads(CODEX_CONFIG.read_text())
 
@@ -216,6 +250,304 @@ def test_codex_review_uses_short_prompt_file_handoff_for_large_diffs(tmp_path):
     assert rc == 0, err
     raw = (Path(out) / "raw" / "glm.txt").read_text()
     assert "large-prompt-file-ok" in raw
+
+
+def test_codex_review_base_head_collects_committed_diff_and_head_snapshots(tmp_path):
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    tracked = repo / "review.txt"
+    tracked.write_text("base version\n")
+    commit_all(repo, "base")
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=repo, check=True)
+    tracked.write_text("feature committed version\n")
+    commit_all(repo, "feature change")
+    tracked.write_text("dirty local version must not leak\n")
+    (repo / "untracked.txt").write_text("untracked local must not leak\n")
+
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--base",
+            "main",
+            "--head",
+            "feature",
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert rc == 0, err
+    review_dir = Path(out)
+    prompt = (review_dir / "prompt.md").read_text()
+    assert "feature committed version" in prompt
+    assert "base version" in prompt
+    assert "dirty local version must not leak" not in prompt
+    assert "untracked local must not leak" not in prompt
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["input"] == {
+        "mode": "base-head",
+        "base": "main",
+        "head": "feature",
+        "pr": None,
+        "scope": ".",
+        "changed_paths": ["review.txt"],
+        "snapshot_source": "git:feature",
+    }
+
+
+def test_codex_review_base_head_fails_before_review_dir_for_bad_ref(tmp_path):
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    (repo / "review.txt").write_text("base version\n")
+    commit_all(repo, "base")
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--base",
+            "main",
+            "--head",
+            "missing-head",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "unable to collect git diff for main...missing-head" in err
+    assert not out_dir.exists()
+
+
+def test_codex_review_base_head_requires_base_and_head_together(tmp_path):
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    (repo / "review.txt").write_text("base version\n")
+    commit_all(repo, "base")
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--base",
+            "main",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "trinity-codex: --base and --head must be used together" in err
+    assert not out_dir.exists()
+
+
+def test_codex_review_pr_uses_gh_diff_view_and_head_snapshots(tmp_path):
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    tracked = repo / "review.txt"
+    tracked.write_text("base version\n")
+    commit_all(repo, "base")
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=repo, check=True)
+    tracked.write_text("pr head snapshot\n")
+    commit_all(repo, "feature change")
+    head_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    gh = fake_bin / "gh"
+    gh.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "args = sys.argv[1:]\n"
+        "if args[:3] == ['pr', 'diff', '123']:\n"
+        "    print('diff --git a/review.txt b/review.txt')\n"
+        "    print('+from mocked gh pr diff')\n"
+        "elif args[:3] == ['pr', 'view', '123']:\n"
+        "    print(json.dumps({\n"
+        "        'number': 123,\n"
+        "        'url': 'https://github.example/pr/123',\n"
+        "        'baseRefName': 'main',\n"
+        "        'headRefName': 'feature',\n"
+        f"        'headRefOid': '{head_oid}',\n"
+        "        'files': [{'path': 'review.txt', 'changeType': 'MODIFIED'}],\n"
+        "    }))\n"
+        "else:\n"
+        "    raise SystemExit(f'unexpected gh args: {args}')\n"
+    )
+    gh.chmod(0o755)
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--pr",
+            "123",
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ],
+        env=env,
+    )
+
+    assert rc == 0, err
+    review_dir = Path(out)
+    prompt = (review_dir / "prompt.md").read_text()
+    assert "from mocked gh pr diff" in prompt
+    assert "pr head snapshot" in prompt
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["input"] == {
+        "mode": "pr",
+        "base": "main",
+        "head": "feature",
+        "head_oid": head_oid,
+        "pr": 123,
+        "pr_url": "https://github.example/pr/123",
+        "scope": ".",
+        "changed_paths": ["review.txt"],
+        "snapshot_source": f"git:{head_oid}",
+    }
+
+
+def test_codex_review_pr_records_unavailable_head_snapshots(tmp_path):
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    (repo / "review.txt").write_text("base version\n")
+    commit_all(repo, "base")
+    missing_oid = "0" * 40
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    gh = fake_bin / "gh"
+    gh.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "args = sys.argv[1:]\n"
+        "if args[:3] == ['pr', 'diff', '123']:\n"
+        "    print('diff --git a/review.txt b/review.txt')\n"
+        "    print('+from mocked gh pr diff')\n"
+        "elif args[:3] == ['pr', 'view', '123']:\n"
+        "    print(json.dumps({\n"
+        "        'number': 123,\n"
+        "        'url': 'https://github.example/pr/123',\n"
+        "        'baseRefName': 'main',\n"
+        "        'headRefName': 'feature',\n"
+        f"        'headRefOid': '{missing_oid}',\n"
+        "        'files': [{'path': 'review.txt', 'changeType': 'MODIFIED'}],\n"
+        "    }))\n"
+        "else:\n"
+        "    raise SystemExit(f'unexpected gh args: {args}')\n"
+    )
+    gh.chmod(0o755)
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--pr",
+            "123",
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ],
+        env=env,
+    )
+
+    assert rc == 0, err
+    review_dir = Path(out)
+    prompt = (review_dir / "prompt.md").read_text()
+    assert "from mocked gh pr diff" in prompt
+    assert "(PR head snapshots unavailable locally)" in prompt
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["input"]["snapshot_source"] == "unavailable"
+    assert metadata["input"]["changed_paths"] == ["review.txt"]
+
+
+def test_codex_review_pr_fails_before_review_dir_when_gh_fails(tmp_path):
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    (repo / "review.txt").write_text("base\n")
+    commit_all(repo, "base")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    gh = fake_bin / "gh"
+    gh.write_text("#!/bin/sh\necho gh auth failed >&2\nexit 4\n")
+    gh.chmod(0o755)
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+    out_dir = tmp_path / "reviews"
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--pr",
+            "123",
+            "--out-dir",
+            str(out_dir),
+        ],
+        env=env,
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "trinity-codex: gh pr view 123 failed: gh auth failed" in err
+    assert not out_dir.exists()
 
 
 def test_codex_doctor_reports_provider_health_failures(tmp_path):


### PR DESCRIPTION
## What

Implements TRN-2015 PR/base-head review mode for the Codex-native Trinity review adapter.

- Adds `trinity review --base <base> --head <head>` for committed branch review.
- Adds `trinity review --pr <number>` for GitHub PR review through `gh pr view` / `gh pr diff`.
- Preserves the existing working-tree review mode when no new input flags are supplied.
- Records review input metadata: mode, base, head, PR number, changed paths, and snapshot source.
- Reads committed branch snapshots from the head commit with `git show <head>:<path>` so dirty local files do not contaminate committed review prompts.
- Disables argparse abbreviation so `--pr` can no longer be misparsed as `--providers`.

## Why

The previous Codex review wrapper only looked at local working-tree changes. That produced misleading no-diff prompts when reviewing already-committed PR branches, such as the PR #20 review flow that motivated TRN-2015.

## Validation

- `.venv/bin/pytest tests/test_codex_adapter.py -q` -> 15 passed
- `make test` -> passed, 82 pytest tests plus shell suites
- `make lint` -> passed
- `af validate --root .` -> 86 documents checked, 0 issues found
- clean `HEAD` worktree check: `af validate --root .` -> 83 documents checked, 0 issues found
- `make install-codex` -> installed locally
- `trinity doctor --providers glm,gemini,deepseek` -> all OK
- fake-provider smoke: `trinity review --config <temp> --providers glm --base main --head HEAD` -> base-head metadata written correctly

## Trinity Review

Reviewed the committed branch with the new mode:

```bash
trinity review --base main --head HEAD --providers glm,deepseek --scope TRN-2015
```

Results:

- GLM: PASS
- DeepSeek: PASS

Review artifact:

- `.trinity/reviews/20260504-231436-TRN-2015/`

DeepSeek suggested additional non-blocking tests for partial `--base/--head` usage and unavailable PR head snapshots; both were added before this PR.
