### PR TITLE
Seed Codex review preset config

### DIFF
--- a/.agents/trinity.codex.json
+++ b/.agents/trinity.codex.json
@@ -45,7 +45,7 @@
     "fast-review": {
       "providers": [
         "glm",
-        "gemini"
+        "deepseek"
       ],
       "task_type": "review"
     },

--- a/.agents/trinity.codex.json
+++ b/.agents/trinity.codex.json
@@ -26,6 +26,45 @@
       "deepseek"
     ],
     "output_dir": ".trinity/reviews",
-    "prompt_template": "# Trinity Code Review\n\nScope: {scope}\nRepository: {root}\n\nReview the changes below for correctness, regressions, missing tests, compatibility risk, and unclear implementation choices. Prioritize concrete findings with file/path references. Return PASS only if no blocking issues remain.\n\n## Git Diff\n\n```diff\n{diff}\n```\n\n## Full File Snapshots\n\n{files}\n"
+    "prompt_template": "# Trinity Code Review\n\nScope: {scope}\nRepository: {root}\n\nReview the changes below for correctness, regressions, missing tests, compatibility risk, and unclear implementation choices. Prioritize concrete findings with file/path references. Return PASS only if no blocking issues remain.\n\n## Git Diff\n\n```diff\n{diff}\n```\n\n## Full File Snapshots\n\n{files}\n",
+    "default_preset": "review"
+  },
+  "presets": {
+    "review": {
+      "providers": [
+        "glm",
+        "gemini",
+        "deepseek"
+      ],
+      "optional_providers": [
+        "codex",
+        "claude-code"
+      ],
+      "task_type": "review"
+    },
+    "fast-review": {
+      "providers": [
+        "glm",
+        "gemini"
+      ],
+      "task_type": "review"
+    },
+    "deep-review": {
+      "providers": [
+        "glm",
+        "gemini",
+        "deepseek"
+      ],
+      "optional_providers": [
+        "codex",
+        "claude-code"
+      ],
+      "task_type": "review"
+    }
+  },
+  "preset_aliases": {
+    "r": "review",
+    "fr": "fast-review",
+    "dr": "deep-review"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `rules/TRN-2010-PRP-Codex-Review-Adapter.md` and `rules/TRN-2011-CHG-Codex-Review-Adapter.md` document the approved design and implementation record. New tests cover Codex config/install/review behavior plus Claude Code compatibility.
 - `trinity doctor` and `trinity review --check-providers` preflight Codex review providers for config shape, command lookup, executable permissions, and timeout values before review dispatch.
 - `trinity review --base <base> --head <head>` and `trinity review --pr <number>` add committed branch / GitHub PR review modes for Codex-native Trinity review.
+- Codex config now seeds `review`, `fast-review`, and `deep-review` preset definitions plus `r`/`fr`/`dr` aliases, and `make install-codex` preserves those sections in `~/.codex/trinity.json`.
 
 ### Fixed
 - Backfilled validator-required sections and change-history tables in older TRN docs (`TRN-1001` through `TRN-1005`, `TRN-2002`, `TRN-2003`), bringing `af validate --root .` to 0 issues.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ This installs:
 The committed default config lives at `.agents/trinity.codex.json`. It registers
 `glm`, `gemini`, and `deepseek` for direct CLI review calls and records each
 provider's command, resume support flag, timeout, and review prompt template.
+It also seeds future review preset config under `presets` (`review`,
+`fast-review`, `deep-review`) plus short aliases under `preset_aliases`.
+Until preset resolution is implemented, `trinity review` still selects
+providers from `--providers` or `review.default_providers`.
 The Codex DeepSeek entry uses the installed
 `~/.codex/skills/trinity/bin/deepseek -p` wrapper so it does not depend on a
 locally accepted `droid` model alias.

--- a/rules/TRN-2013-CHG-Trinity-Review-Presets.md
+++ b/rules/TRN-2013-CHG-Trinity-Review-Presets.md
@@ -299,6 +299,7 @@ Expected evidence before marking complete:
 | 2026-05-04 | Re-reviewed with GLM, Gemini, and DeepSeek wrapper config | GLM/DeepSeek requested explicit `--providers` + `--preset` warning, all-unusable error, `/trinity review` wording, Reserved Words update, and task_type precedence; Gemini hit quota |
 | 2026-05-04 | COR-1602 strict review round on PR #20 | DeepSeek scored 9.3 PASS with metadata-order advisory; GLM saw no PR diff due committed-branch review wrapper limitation |
 | 2026-05-04 | COR-1602 strict review round 2 with explicit PR diff | GLM scored 9.2 PASS; DeepSeek scored 8.5 FIX for under-specified textual tests, rollback verification, missing REFACTOR step, and bare `/trinity review` behavior |
+| 2026-05-04 | Seeded preset config files | Added `review`, `fast-review`, `deep-review`, and `r`/`fr`/`dr` config seeds; preset resolution remains pending under this CHG |
 
 ---
 
@@ -312,3 +313,4 @@ Expected evidence before marking complete:
 | 2026-05-04 | Revised after final GLM/DeepSeek review pass | Codex |
 | 2026-05-04 | Reordered CHG metadata and added migration note after COR-1602 review | Codex |
 | 2026-05-04 | Added rollback test, explicit textual test mechanism, REFACTOR step, and empty-task behavior after COR-1602 round 2 | Codex |
+| 2026-05-04 | Recorded preset config seed as a partial setup step before resolver implementation | Codex |

--- a/rules/TRN-2013-CHG-Trinity-Review-Presets.md
+++ b/rules/TRN-2013-CHG-Trinity-Review-Presets.md
@@ -69,7 +69,7 @@ Example:
       "task_type": "review"
     },
     "fast-review": {
-      "providers": ["gemini", "glm"],
+      "providers": ["glm", "deepseek"],
       "task_type": "review"
     },
     "deep-review": {

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -21,6 +21,7 @@ DEFAULT_CONFIG_CANDIDATES = [
     SCRIPT_ROOT / "trinity.codex.json",
     SCRIPT_ROOT / ".agents" / "trinity.codex.json",
 ]
+DEFAULT_CONFIG_SECTIONS = ("providers", "review", "presets", "preset_aliases")
 
 
 def _load_version():
@@ -93,8 +94,9 @@ def write_default_config(path):
     else:
         current = {}
 
-    current["providers"] = source["providers"]
-    current["review"] = source["review"]
+    for section in DEFAULT_CONFIG_SECTIONS:
+        if section in source:
+            current[section] = source[section]
     target.write_text(json.dumps(current, indent=2, ensure_ascii=False) + "\n")
     return target
 

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -84,8 +84,28 @@ def test_codex_default_config_has_direct_review_providers():
         "timeout": 600,
     }
     assert data["review"]["default_providers"] == ["glm", "gemini", "deepseek"]
+    assert data["review"]["default_preset"] == "review"
     assert "{diff}" in data["review"]["prompt_template"]
     assert "{files}" in data["review"]["prompt_template"]
+    assert data["presets"]["review"] == {
+        "providers": ["glm", "gemini", "deepseek"],
+        "optional_providers": ["codex", "claude-code"],
+        "task_type": "review",
+    }
+    assert data["presets"]["fast-review"] == {
+        "providers": ["glm", "gemini"],
+        "task_type": "review",
+    }
+    assert data["presets"]["deep-review"] == {
+        "providers": ["glm", "gemini", "deepseek"],
+        "optional_providers": ["codex", "claude-code"],
+        "task_type": "review",
+    }
+    assert data["preset_aliases"] == {
+        "r": "review",
+        "fr": "fast-review",
+        "dr": "deep-review",
+    }
 
 
 def test_claude_code_install_path_remains_unchanged():
@@ -698,6 +718,14 @@ def test_install_codex_installs_skill_config_and_wrapper_without_claude(tmp_path
     assert installed_config["providers"]["deepseek"]["cli"] == (
         "~/.codex/skills/trinity/bin/deepseek -p"
     )
+    assert installed_config["review"]["default_preset"] == "review"
+    assert installed_config["presets"]["fast-review"]["providers"] == ["glm", "gemini"]
+    assert installed_config["presets"]["deep-review"]["providers"] == [
+        "glm",
+        "gemini",
+        "deepseek",
+    ]
+    assert installed_config["preset_aliases"]["dr"] == "deep-review"
     assert deepseek_wrapper.exists()
     assert os.access(deepseek_wrapper, os.X_OK)
     assert (home / ".codex" / "skills" / "trinity" / "scripts" / "codex.py").exists()

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -93,7 +93,7 @@ def test_codex_default_config_has_direct_review_providers():
         "task_type": "review",
     }
     assert data["presets"]["fast-review"] == {
-        "providers": ["glm", "gemini"],
+        "providers": ["glm", "deepseek"],
         "task_type": "review",
     }
     assert data["presets"]["deep-review"] == {
@@ -719,7 +719,7 @@ def test_install_codex_installs_skill_config_and_wrapper_without_claude(tmp_path
         "~/.codex/skills/trinity/bin/deepseek -p"
     )
     assert installed_config["review"]["default_preset"] == "review"
-    assert installed_config["presets"]["fast-review"]["providers"] == ["glm", "gemini"]
+    assert installed_config["presets"]["fast-review"]["providers"] == ["glm", "deepseek"]
     assert installed_config["presets"]["deep-review"]["providers"] == [
         "glm",
         "gemini",


### PR DESCRIPTION
## Summary
- Seed `review`, `fast-review`, and `deep-review` presets plus `r`/`fr`/`dr` aliases in the Codex default config.
- Preserve preset sections when `make install-codex` writes `~/.codex/trinity.json`.
- Document that these config seeds are preparatory and preset resolution is still pending under TRN-2013.

## Verification
- `.venv/bin/pytest tests/test_codex_adapter.py tests/test_codex_compat.py tests/test_install.py -q`
- `.venv/bin/ruff check scripts/ tests/`
- `.venv/bin/ruff format --check scripts/ tests/`
- `af validate --root .`
- `trinity doctor --providers glm,gemini,deepseek`
- `trinity review --check-providers --providers glm,gemini,deepseek`
- `make test`