### PR TITLE
Clarify review preset docs

### DIFF
--- a/.agents/skills/trinity/SKILL.md
+++ b/.agents/skills/trinity/SKILL.md
@@ -34,6 +34,11 @@ trinity review --pr 21 --providers glm,deepseek
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
 `.agents/trinity.codex.json`. It calls provider CLIs directly, saves raw outputs,
 and writes a deterministic synthesis markdown under `.trinity/reviews/`.
+The config seeds future review presets: `review` expands to `glm`, `gemini`,
+and `deepseek`; `fast-review` expands to `glm` and `deepseek`; `deep-review`
+expands to `glm`, `gemini`, and `deepseek`. These are configuration seeds only
+until preset resolution is implemented, so current reviews still use
+`--providers` or `review.default_providers`.
 `trinity doctor` and `trinity review --check-providers` validate provider config,
 command lookup, executable permissions, and timeout values without making network
 calls. Use the default review mode for dirty working-tree changes, `--base` /

--- a/README.md
+++ b/README.md
@@ -222,6 +222,15 @@ It also seeds future review preset config under `presets` (`review`,
 `fast-review`, `deep-review`) plus short aliases under `preset_aliases`.
 Until preset resolution is implemented, `trinity review` still selects
 providers from `--providers` or `review.default_providers`.
+
+Seeded preset config:
+
+| Preset | Required providers | Optional providers |
+|--------|--------------------|--------------------|
+| `review` | `glm`, `gemini`, `deepseek` | `codex`, `claude-code` |
+| `fast-review` | `glm`, `deepseek` | none |
+| `deep-review` | `glm`, `gemini`, `deepseek` | `codex`, `claude-code` |
+
 The Codex DeepSeek entry uses the installed
 `~/.codex/skills/trinity/bin/deepseek -p` wrapper so it does not depend on a
 locally accepted `droid` model alias.

--- a/plugins/trinity/skills/trinity/SKILL.md
+++ b/plugins/trinity/skills/trinity/SKILL.md
@@ -34,6 +34,11 @@ trinity review --pr 21 --providers glm,deepseek
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
 `.agents/trinity.codex.json`. It calls provider CLIs directly, saves raw outputs,
 and writes a deterministic synthesis markdown under `.trinity/reviews/`.
+The config seeds future review presets: `review` expands to `glm`, `gemini`,
+and `deepseek`; `fast-review` expands to `glm` and `deepseek`; `deep-review`
+expands to `glm`, `gemini`, and `deepseek`. These are configuration seeds only
+until preset resolution is implemented, so current reviews still use
+`--providers` or `review.default_providers`.
 `trinity doctor` and `trinity review --check-providers` validate provider config,
 command lookup, executable permissions, and timeout values without making network
 calls. Use the default review mode for dirty working-tree changes, `--base` /

--- a/rules/TRN-2013-CHG-Trinity-Review-Presets.md
+++ b/rules/TRN-2013-CHG-Trinity-Review-Presets.md
@@ -36,6 +36,12 @@ trinity review --preset deep-review --scope rules/TRN-2013-CHG-Trinity-Review-Pr
 `trinity review --scope .` should continue to work and use the configured
 default preset when available.
 
+Current state as of 2026-05-05: PR #23 seeded the preset config only. The
+resolver is not implemented yet, so `trinity review --preset ...` and
+`/trinity fast-review ...` are target syntax, not supported commands. Current
+Codex review runs must still pass `--providers` explicitly or rely on
+`review.default_providers`.
+
 ---
 
 ## Why

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -719,7 +719,10 @@ def test_install_codex_installs_skill_config_and_wrapper_without_claude(tmp_path
         "~/.codex/skills/trinity/bin/deepseek -p"
     )
     assert installed_config["review"]["default_preset"] == "review"
-    assert installed_config["presets"]["fast-review"]["providers"] == ["glm", "deepseek"]
+    assert installed_config["presets"]["fast-review"]["providers"] == [
+        "glm",
+        "deepseek",
+    ]
     assert installed_config["presets"]["deep-review"]["providers"] == [
         "glm",
         "gemini",

--- a/tests/test_codex_compat.py
+++ b/tests/test_codex_compat.py
@@ -84,3 +84,13 @@ def test_readme_documents_claude_and_codex_load_smoke_checks():
     assert "make install-codex" in text
     assert "trinity review --providers glm,gemini,deepseek" in text
     assert ".agents/trinity.codex.json" in text
+    assert "| `fast-review` | `glm`, `deepseek` | none |" in text
+    assert "Until preset resolution is implemented" in text
+
+
+def test_codex_skill_documents_preset_config_as_seed_only():
+    text = REPO_SKILL.read_text()
+
+    assert "`fast-review` expands to `glm` and `deepseek`" in text
+    assert "configuration seeds only" in text
+    assert "--providers` or `review.default_providers`" in text


### PR DESCRIPTION
## Summary
- Document the seeded preset expansion table, including `fast-review = glm + deepseek`.
- Clarify in README, Codex skill docs, and TRN-2013 that preset config is seeded only and resolver commands are not implemented yet.
- Add text regression checks for the preset documentation.

## Verification
- `.venv/bin/pytest tests/test_codex_compat.py tests/test_codex_adapter.py::test_codex_default_config_has_direct_review_providers tests/test_codex_adapter.py::test_install_codex_installs_skill_config_and_wrapper_without_claude -q`
- `.venv/bin/ruff check scripts/ tests/`
- `.venv/bin/ruff format --check scripts/ tests/`
- `af validate --root .`
- `make install-codex`