### PR TITLE
Implement Trinity review presets

### DIFF
--- a/.agents/skills/trinity/SKILL.md
+++ b/.agents/skills/trinity/SKILL.md
@@ -26,19 +26,25 @@ For Codex-native code review from the terminal, use the installed wrapper:
 
 ```bash
 trinity doctor --providers glm,gemini,deepseek
+trinity doctor --preset fast-review
 trinity review --providers glm,gemini,deepseek --scope <path-or-label>
+trinity review --preset fast-review --scope <path-or-label>
+trinity review --preset dr --scope <path-or-label>
 trinity review --base main --head HEAD --providers glm,deepseek
-trinity review --pr 21 --providers glm,deepseek
+trinity review --pr 21 --preset deep-review
 ```
 
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
 `.agents/trinity.codex.json`. It calls provider CLIs directly, saves raw outputs,
 and writes a deterministic synthesis markdown under `.trinity/reviews/`.
-The config seeds future review presets: `review` expands to `glm`, `gemini`,
-and `deepseek`; `fast-review` expands to `glm` and `deepseek`; `deep-review`
-expands to `glm`, `gemini`, and `deepseek`. These are configuration seeds only
-until preset resolution is implemented, so current reviews still use
-`--providers` or `review.default_providers`.
+The review preset resolver selects providers from explicit `--providers`,
+explicit `--preset`, `review.default_preset`, then legacy
+`review.default_providers`. `review` expands to `glm`, `gemini`, and
+`deepseek`; `fast-review` expands to `glm` and `deepseek`; `deep-review`
+expands to `glm`, `gemini`, and `deepseek`. Aliases `r`, `fr`, and `dr` resolve
+to those preset names. Optional providers are skipped with stderr warnings when
+they lack config or a CLI, and skipped providers are recorded in
+`metadata.json`.
 `trinity doctor` and `trinity review --check-providers` validate provider config,
 command lookup, executable permissions, and timeout values without making network
 calls. Use the default review mode for dirty working-tree changes, `--base` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `trinity doctor` and `trinity review --check-providers` preflight Codex review providers for config shape, command lookup, executable permissions, and timeout values before review dispatch.
 - `trinity review --base <base> --head <head>` and `trinity review --pr <number>` add committed branch / GitHub PR review modes for Codex-native Trinity review.
 - Codex config now seeds `review`, `fast-review`, and `deep-review` preset definitions plus `r`/`fr`/`dr` aliases, and `make install-codex` preserves those sections in `~/.codex/trinity.json`.
+- `trinity review --preset <name>` and `trinity doctor --preset <name>` now resolve review presets and aliases, use `review.default_preset` by default, preserve `review.default_providers` as the compatibility fallback, and record skipped optional providers in review metadata.
 
 ### Fixed
 - Backfilled validator-required sections and change-history tables in older TRN docs (`TRN-1001` through `TRN-1005`, `TRN-2002`, `TRN-2003`), bringing `af validate --root .` to 0 issues.

--- a/README.md
+++ b/README.md
@@ -218,12 +218,12 @@ This installs:
 The committed default config lives at `.agents/trinity.codex.json`. It registers
 `glm`, `gemini`, and `deepseek` for direct CLI review calls and records each
 provider's command, resume support flag, timeout, and review prompt template.
-It also seeds future review preset config under `presets` (`review`,
-`fast-review`, `deep-review`) plus short aliases under `preset_aliases`.
-Until preset resolution is implemented, `trinity review` still selects
-providers from `--providers` or `review.default_providers`.
+It also configures review presets under `presets` (`review`, `fast-review`,
+`deep-review`) plus short aliases under `preset_aliases`. `trinity review`
+selects providers in this order: explicit `--providers`, explicit `--preset`,
+`review.default_preset`, then legacy `review.default_providers`.
 
-Seeded preset config:
+Default preset config:
 
 | Preset | Required providers | Optional providers |
 |--------|--------------------|--------------------|
@@ -239,7 +239,9 @@ locally accepted `droid` model alias.
 
 ```bash
 trinity doctor --providers glm,gemini,deepseek
+trinity doctor --preset fast-review
 trinity review --check-providers --providers glm,gemini,deepseek
+trinity review --check-providers --preset dr
 ```
 
 Health checks validate the selected provider config, command lookup,
@@ -251,8 +253,10 @@ can still occur during the actual review.
 
 ```bash
 trinity review --providers glm,gemini,deepseek --scope spikes/hardline
+trinity review --preset fast-review --scope spikes/hardline
+trinity review --preset dr --scope .
 trinity review --base main --head HEAD --providers glm,deepseek
-trinity review --pr 21 --providers glm,deepseek
+trinity review --pr 21 --preset deep-review
 ```
 
 Without `--pr` or `--base/--head`, the review wrapper collects tracked and
@@ -263,8 +267,10 @@ patch and metadata, then snapshots changed files from the PR head commit when
 that commit is locally available. All modes call each provider CLI directly,
 store raw provider outputs, and write a deterministic `synthesis.md` under
 `.trinity/reviews/`. Selected providers are preflighted before output
-directories are created. This path does not require Claude Code worker-agent
-files.
+directories are created. If a preset has optional providers that are not
+configured or have no CLI, they are skipped with a stderr warning and recorded
+in `metadata.json`; required providers still fail preflight when unavailable.
+This path does not require Claude Code worker-agent files.
 
 **Codex repo-local skill**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -36,6 +36,9 @@ If scripts pass the version check, proceed normally.
 /trinity <provider>[:<instance>] "task"          # single dispatch
 /trinity <p1>[:<i>] "t1" <p2> "t2"              # multi-provider parallel
 /trinity <provider>*N "task"                     # N parallel same-provider
+/trinity review "task"                           # preset dispatch
+/trinity fast-review "task"                      # preset dispatch
+/trinity deep-review "task"                      # preset dispatch
 /trinity plan <p1> "t1" <p2> "t2"               # plan with diagram, confirm, execute
 /trinity plan "high-level description"           # auto-decompose, confirm, execute
 /trinity install <provider>                      # install + register provider
@@ -47,9 +50,9 @@ If scripts pass the version check, proceed normally.
 
 ## Provider Discovery
 
-On every dispatch, resolve available providers:
-1. Load `~/.claude/trinity.json` → `providers` map (global)
-2. Load `.claude/trinity.json` → `providers` map (project); project entries win on conflict
+On every dispatch, resolve available providers and presets:
+1. Load `~/.claude/trinity.json` → `providers`, `presets`, and `preset_aliases` (global)
+2. Load `.claude/trinity.json` → project overlay; project entries win on conflict
 3. Verify each provider has a matching agent file: `~/.claude/agents/trinity-<name>.md` or `.claude/agents/trinity-<name>.md`
 
 A provider is **usable** only when it has both a config entry AND an agent file.
@@ -62,6 +65,8 @@ A provider is **usable** only when it has both a config entry AND an agent file.
 **Merge semantics:**
 - `providers`: merged by key; project entry wins on same key. Global providers not overridden remain available.
 - `defaults`: shallow merge; project value overrides global for each key. Keys absent in project inherit from global.
+- `presets`: merged by key; project preset replaces the whole global preset object with that name.
+- `preset_aliases`: merged by key; project alias wins on same alias.
 - `sessions`: project-only; never in global config.
 
 **Global** `~/.claude/trinity.json`:
@@ -108,9 +113,31 @@ Field notes:
 - `stopped`: `true` when stopped. Distinguishes ⏸️ stopped from ❌ failed.
 - `task_type`: one of `tdd`, `review`, `prp`, `general`. Used for timeout thresholds.
 
+## Review Presets
+
+Preset dispatch expands one keyword into a configured provider set:
+
+| Preset | Required providers | Optional providers |
+|--------|--------------------|--------------------|
+| `review` | `glm`, `gemini`, `deepseek` | `codex`, `claude-code` |
+| `fast-review` | `glm`, `deepseek` | none |
+| `deep-review` | `glm`, `gemini`, `deepseek` | `codex`, `claude-code` |
+
+Aliases `r`, `fr`, and `dr` resolve to `review`, `fast-review`, and `deep-review`.
+Optional providers are used only when discovery marks them usable; otherwise
+show a warning and continue with the required providers.
+
 ## Execution Rules
 
-### Dispatch mode (provider detected)
+### Dispatch mode (preset or provider detected)
+
+Parse dispatch in this order:
+1. Built-in subcommands: `status`, `clear`, `plan`, `heartbeat`, `install`, `help`.
+2. Preset or alias name: expand providers and dispatch the same task to each.
+3. Provider syntax: `provider`, `provider:instance`, or `provider*N`.
+
+If a token is both a provider and a preset/alias, fail with an ambiguity error
+instead of guessing.
 
 For EACH (provider, task) pair in the arguments:
 
@@ -236,6 +263,15 @@ Run provider discovery. Display two sections:
 
 **Registered providers:**
 ```
+
+**Configured presets:**
+```
+| Preset      | Providers               | Optional           | Aliases |
+|-------------|-------------------------|--------------------|---------|
+| review      | glm, gemini, deepseek   | codex, claude-code | r       |
+| fast-review | glm, deepseek           |                    | fr      |
+| deep-review | glm, gemini, deepseek   | codex, claude-code | dr      |
+```
 | Provider | Status    | CLI                              |
 |----------|-----------|----------------------------------|
 | glm      | ✅ usable  | droid exec --model glm-5         |
@@ -348,7 +384,9 @@ Synchronous. Read `~/.claude/skills/trinity/README.md` and output its full conte
 
 ## Reserved Words
 
-`status`, `clear`, `plan`, `heartbeat`, `install`, and `help` are subcommands, NOT provider names.
+`status`, `clear`, `plan`, `heartbeat`, `install`, and `help` are subcommands, NOT provider or preset names.
+Preset/provider collisions are invalid and must be reported as ambiguous.
+Alias names must not collide with subcommands, providers, or preset names.
 
 ## Examples
 

--- a/plugins/trinity/skills/trinity/SKILL.md
+++ b/plugins/trinity/skills/trinity/SKILL.md
@@ -26,19 +26,25 @@ For Codex-native code review from the terminal, use the installed wrapper:
 
 ```bash
 trinity doctor --providers glm,gemini,deepseek
+trinity doctor --preset fast-review
 trinity review --providers glm,gemini,deepseek --scope <path-or-label>
+trinity review --preset fast-review --scope <path-or-label>
+trinity review --preset dr --scope <path-or-label>
 trinity review --base main --head HEAD --providers glm,deepseek
-trinity review --pr 21 --providers glm,deepseek
+trinity review --pr 21 --preset deep-review
 ```
 
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
 `.agents/trinity.codex.json`. It calls provider CLIs directly, saves raw outputs,
 and writes a deterministic synthesis markdown under `.trinity/reviews/`.
-The config seeds future review presets: `review` expands to `glm`, `gemini`,
-and `deepseek`; `fast-review` expands to `glm` and `deepseek`; `deep-review`
-expands to `glm`, `gemini`, and `deepseek`. These are configuration seeds only
-until preset resolution is implemented, so current reviews still use
-`--providers` or `review.default_providers`.
+The review preset resolver selects providers from explicit `--providers`,
+explicit `--preset`, `review.default_preset`, then legacy
+`review.default_providers`. `review` expands to `glm`, `gemini`, and
+`deepseek`; `fast-review` expands to `glm` and `deepseek`; `deep-review`
+expands to `glm`, `gemini`, and `deepseek`. Aliases `r`, `fr`, and `dr` resolve
+to those preset names. Optional providers are skipped with stderr warnings when
+they lack config or a CLI, and skipped providers are recorded in
+`metadata.json`.
 `trinity doctor` and `trinity review --check-providers` validate provider config,
 command lookup, executable permissions, and timeout values without making network
 calls. Use the default review mode for dirty working-tree changes, `--base` /

--- a/rules/TRN-2013-CHG-Trinity-Review-Presets.md
+++ b/rules/TRN-2013-CHG-Trinity-Review-Presets.md
@@ -1,9 +1,9 @@
 # CHG-2013: Trinity Review Presets
 
 **Applies to:** Trinity project (`frankyxhl/trinity`)
-**Last updated:** 2026-05-04
-**Last reviewed:** 2026-05-04
-**Status:** Proposed
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
+**Status:** In Progress
 **Date:** 2026-05-04
 **Requested by:** Frank
 **Implementer:** Codex
@@ -36,11 +36,11 @@ trinity review --preset deep-review --scope rules/TRN-2013-CHG-Trinity-Review-Pr
 `trinity review --scope .` should continue to work and use the configured
 default preset when available.
 
-Current state as of 2026-05-05: PR #23 seeded the preset config only. The
-resolver is not implemented yet, so `trinity review --preset ...` and
-`/trinity fast-review ...` are target syntax, not supported commands. Current
-Codex review runs must still pass `--providers` explicitly or rely on
-`review.default_providers`.
+Current implementation scope as of 2026-05-05: Codex terminal review and doctor
+support `--preset ...`, preset aliases, `review.default_preset`, optional
+provider skip warnings, and legacy `review.default_providers` fallback. Claude
+Code `/trinity <preset> "task"` is documented in the root skill instructions and
+still depends on Claude Code following those instructions at runtime.
 
 ---
 
@@ -288,9 +288,9 @@ Expected evidence before marking complete:
 
 ## Approval
 
-- [ ] Approved for implementation
-- [ ] Implemented
-- [ ] Verified locally
+- [x] Approved for implementation
+- [x] Implemented
+- [x] Verified locally
 - [ ] PR opened
 
 ---
@@ -305,7 +305,11 @@ Expected evidence before marking complete:
 | 2026-05-04 | Re-reviewed with GLM, Gemini, and DeepSeek wrapper config | GLM/DeepSeek requested explicit `--providers` + `--preset` warning, all-unusable error, `/trinity review` wording, Reserved Words update, and task_type precedence; Gemini hit quota |
 | 2026-05-04 | COR-1602 strict review round on PR #20 | DeepSeek scored 9.3 PASS with metadata-order advisory; GLM saw no PR diff due committed-branch review wrapper limitation |
 | 2026-05-04 | COR-1602 strict review round 2 with explicit PR diff | GLM scored 9.2 PASS; DeepSeek scored 8.5 FIX for under-specified textual tests, rollback verification, missing REFACTOR step, and bare `/trinity review` behavior |
-| 2026-05-04 | Seeded preset config files | Added `review`, `fast-review`, `deep-review`, and `r`/`fr`/`dr` config seeds; preset resolution remains pending under this CHG |
+| 2026-05-04 | Seeded preset config files | Added `review`, `fast-review`, `deep-review`, and `r`/`fr`/`dr` config seeds; preset resolution remained pending under this CHG |
+| 2026-05-05 | Implemented Codex preset resolver | Added `trinity review --preset`, `trinity doctor --preset`, alias resolution, default-preset priority, optional-provider skip metadata, and legacy fallback |
+| 2026-05-05 | Verified locally | `make test`, `make lint`, `af validate --root .`, `make install-codex`, `trinity doctor --preset fast-review`, and `trinity review --check-providers --preset fast-review` passed |
+| 2026-05-05 | Reviewed with Trinity GLM and DeepSeek | Round 1 PASS from both; DeepSeek advisory on `doctor` preset support was implemented |
+| 2026-05-05 | Re-reviewed with Trinity GLM and DeepSeek | Round 2 PASS from both; DeepSeek cleanup advisory to remove unused `split_providers()` was implemented |
 
 ---
 
@@ -320,3 +324,5 @@ Expected evidence before marking complete:
 | 2026-05-04 | Reordered CHG metadata and added migration note after COR-1602 review | Codex |
 | 2026-05-04 | Added rollback test, explicit textual test mechanism, REFACTOR step, and empty-task behavior after COR-1602 round 2 | Codex |
 | 2026-05-04 | Recorded preset config seed as a partial setup step before resolver implementation | Codex |
+| 2026-05-05 | Implemented Codex terminal preset resolver and updated Claude/Codex docs | Codex |
+| 2026-05-05 | Added doctor preset support and removed dead resolver code after Trinity review | Codex |

--- a/rules/TRN-2013-CHG-Trinity-Review-Presets.md
+++ b/rules/TRN-2013-CHG-Trinity-Review-Presets.md
@@ -291,7 +291,7 @@ Expected evidence before marking complete:
 - [x] Approved for implementation
 - [x] Implemented
 - [x] Verified locally
-- [ ] PR opened
+- [x] PR opened
 
 ---
 
@@ -310,6 +310,7 @@ Expected evidence before marking complete:
 | 2026-05-05 | Verified locally | `make test`, `make lint`, `af validate --root .`, `make install-codex`, `trinity doctor --preset fast-review`, and `trinity review --check-providers --preset fast-review` passed |
 | 2026-05-05 | Reviewed with Trinity GLM and DeepSeek | Round 1 PASS from both; DeepSeek advisory on `doctor` preset support was implemented |
 | 2026-05-05 | Re-reviewed with Trinity GLM and DeepSeek | Round 2 PASS from both; DeepSeek cleanup advisory to remove unused `split_providers()` was implemented |
+| 2026-05-05 | Opened PR #25 | Ready for review |
 
 ---
 

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -22,6 +22,8 @@ DEFAULT_CONFIG_CANDIDATES = [
     SCRIPT_ROOT / ".agents" / "trinity.codex.json",
 ]
 DEFAULT_CONFIG_SECTIONS = ("providers", "review", "presets", "preset_aliases")
+PRESET_TASK_TYPES = {"tdd", "review", "prp", "general"}
+PRESET_ALIAS_RESERVED_WORDS = {"init-config", "doctor", "review", "help"}
 
 
 def _load_version():
@@ -101,14 +103,178 @@ def write_default_config(path):
     return target
 
 
-def split_providers(value, config):
-    if value:
-        providers = [item.strip() for item in value.split(",") if item.strip()]
-    else:
-        providers = config.get("review", {}).get("default_providers", [])
+def split_provider_csv(value):
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def config_section(config, key):
+    value = config.get(key, {}) or {}
+    if not isinstance(value, dict):
+        raise SystemExit(f"trinity: {key} must be an object")
+    return value
+
+
+def review_section(config):
+    return config_section(config, "review")
+
+
+def provider_configs_section(config):
+    return config_section(config, "providers")
+
+
+def provider_config_missing_cli_reason(provider_configs, provider):
+    provider_config = provider_configs.get(provider)
+    if provider_config is None:
+        return "missing config"
+    if not isinstance(provider_config, dict):
+        return "missing cli"
+    cli = provider_config.get("cli")
+    if not isinstance(cli, str) or not cli.strip():
+        return "missing cli"
+    return None
+
+
+def validate_preset_aliases(config, presets, aliases):
+    provider_configs = provider_configs_section(config)
+    for alias, target in aliases.items():
+        if alias in PRESET_ALIAS_RESERVED_WORDS:
+            raise SystemExit(
+                f"trinity: preset alias '{alias}' collides with subcommand"
+            )
+        if alias in provider_configs:
+            raise SystemExit(f"trinity: preset alias '{alias}' collides with provider")
+        if alias in presets:
+            raise SystemExit(f"trinity: preset alias '{alias}' collides with preset")
+        if target in aliases:
+            raise SystemExit(f"trinity: preset alias '{alias}' points to another alias")
+        if target not in presets:
+            raise SystemExit(
+                f"trinity: preset alias '{alias}' targets unknown preset '{target}'"
+            )
+
+
+def resolve_preset_name(config, requested, source):
+    presets = config_section(config, "presets")
+    aliases = config_section(config, "preset_aliases")
+    validate_preset_aliases(config, presets, aliases)
+
+    resolved = aliases.get(requested, requested)
+    if resolved not in presets:
+        if source == "default":
+            raise SystemExit(f"trinity: review.default_preset '{requested}' not found")
+        raise SystemExit(f"trinity: unknown preset '{requested}'")
+    if resolved in provider_configs_section(config):
+        raise SystemExit(f"trinity: '{resolved}' is both provider and preset")
+    return resolved, presets[resolved]
+
+
+def append_unique(items, value):
+    if value not in items:
+        items.append(value)
+
+
+def resolve_preset_providers(config, requested, source):
+    resolved, preset = resolve_preset_name(config, requested, source)
+    if not isinstance(preset, dict):
+        raise SystemExit(f"trinity: preset '{resolved}' must be an object")
+
+    task_type = preset.get("task_type")
+    if task_type is not None and task_type not in PRESET_TASK_TYPES:
+        raise SystemExit(
+            f"trinity: preset '{resolved}' has invalid task_type '{task_type}'"
+        )
+
+    required = preset.get("providers", [])
+    optional = preset.get("optional_providers", [])
+    if not isinstance(required, list):
+        raise SystemExit(f"trinity: preset '{resolved}' providers must be a list")
+    if not isinstance(optional, list):
+        raise SystemExit(
+            f"trinity: preset '{resolved}' optional_providers must be a list"
+        )
+    required = [
+        item.strip() for item in required if isinstance(item, str) and item.strip()
+    ]
+    optional = [
+        item.strip() for item in optional if isinstance(item, str) and item.strip()
+    ]
+    if not required:
+        raise SystemExit(f"trinity: preset '{resolved}' has no providers")
+
+    provider_configs = provider_configs_section(config)
+    providers = []
+    for provider in required:
+        append_unique(providers, provider)
+
+    skipped = []
+    warnings = []
+    for provider in optional:
+        reason = provider_config_missing_cli_reason(provider_configs, provider)
+        if reason:
+            skipped.append({"provider": provider, "reason": reason})
+            warnings.append(
+                f"trinity: optional provider '{provider}' skipped: {reason}"
+            )
+            continue
+        append_unique(providers, provider)
+
+    return (
+        providers,
+        {
+            "requested": requested,
+            "resolved": resolved,
+            "source": source,
+            "task_type": task_type,
+            "skipped_optional_providers": skipped,
+        },
+        warnings,
+    )
+
+
+def resolve_review_providers(args, config):
+    if args.providers:
+        providers = split_provider_csv(args.providers)
+        if not providers:
+            raise SystemExit("trinity-codex: no providers selected")
+        warnings = []
+        if args.preset:
+            warnings.append(
+                f"trinity: --providers supplied; ignoring --preset '{args.preset}'"
+            )
+        return (
+            providers,
+            {
+                "requested": args.preset,
+                "resolved": None,
+                "source": "providers",
+                "task_type": None,
+                "skipped_optional_providers": [],
+            },
+            warnings,
+        )
+
+    review_config = review_section(config)
+    if args.preset:
+        return resolve_preset_providers(config, args.preset, "explicit")
+
+    default_preset = review_config.get("default_preset")
+    if default_preset:
+        return resolve_preset_providers(config, default_preset, "default")
+
+    providers = review_config.get("default_providers", [])
     if not providers:
         raise SystemExit("trinity-codex: no providers selected")
-    return providers
+    return (
+        providers,
+        {
+            "requested": None,
+            "resolved": None,
+            "source": "default_providers",
+            "task_type": None,
+            "skipped_optional_providers": [],
+        },
+        [],
+    )
 
 
 def parse_provider_command(provider, provider_config):
@@ -702,7 +868,11 @@ def write_synthesis(review_dir, scope, results):
 def cmd_review(args):
     root = resolve_root(args.root)
     config = load_config(args.config)
-    providers = split_providers(args.providers, config)
+    providers, preset_metadata, resolver_warnings = resolve_review_providers(
+        args, config
+    )
+    for warning in resolver_warnings:
+        print(warning, file=sys.stderr)
     provider_configs = config.get("providers", {})
     health = provider_health_results(config, providers, root)
     if args.check_providers:
@@ -739,6 +909,7 @@ def cmd_review(args):
         "scope": args.scope,
         "root": str(root),
         "providers": providers,
+        "preset": preset_metadata,
         "input": review_input["metadata"],
         "results": results,
     }
@@ -753,7 +924,9 @@ def cmd_review(args):
 def cmd_doctor(args):
     root = resolve_health_root(args.root)
     config = load_config(args.config)
-    providers = split_providers(args.providers, config)
+    providers, _, resolver_warnings = resolve_review_providers(args, config)
+    for warning in resolver_warnings:
+        print(warning, file=sys.stderr)
     health = provider_health_results(config, providers, root)
     print(format_health_results(health))
     return 0 if health_results_ok(health) else 1
@@ -771,11 +944,13 @@ def build_parser():
     doctor.add_argument("--root", default=".")
     doctor.add_argument("--config", default=str(DEFAULT_CONFIG))
     doctor.add_argument("--providers")
+    doctor.add_argument("--preset")
 
     review = subparsers.add_parser("review")
     review.add_argument("--root", default=".")
     review.add_argument("--config", default=str(DEFAULT_CONFIG))
     review.add_argument("--providers")
+    review.add_argument("--preset")
     review.add_argument("--scope", default=".")
     review.add_argument("--out-dir")
     review.add_argument("--check-providers", action="store_true")

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -52,6 +52,9 @@ def merge_configs(global_data, project_data):
                 missing project key inherits from global;
                 project null overrides global;
                 project array replaces global array entirely
+    - presets: dict merge, project key wins on conflict; preset objects are
+               replaced as atomic values
+    - preset_aliases: dict merge, project key wins on conflict
     - sessions: project-only; global sessions key is ignored
     """
     result = {}
@@ -71,6 +74,20 @@ def merge_configs(global_data, project_data):
         for k, v in project_defaults.items():
             merged_defaults[k] = v  # project value wins, including None
         result["defaults"] = merged_defaults
+
+    # presets: dict merge, project wins by preset name
+    global_presets = global_data.get("presets", {}) or {}
+    project_presets = project_data.get("presets", {}) or {}
+    merged_presets = {**global_presets, **project_presets}
+    if merged_presets:
+        result["presets"] = merged_presets
+
+    # preset_aliases: dict merge, project wins by alias
+    global_preset_aliases = global_data.get("preset_aliases", {}) or {}
+    project_preset_aliases = project_data.get("preset_aliases", {}) or {}
+    merged_preset_aliases = {**global_preset_aliases, **project_preset_aliases}
+    if merged_preset_aliases:
+        result["preset_aliases"] = merged_preset_aliases
 
     # sessions: project-only (never include global sessions)
     project_sessions = project_data.get("sessions")

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -62,6 +62,68 @@ def simple_review_config(config, provider):
     )
 
 
+def simple_repo(tmp_path):
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    tracked = repo / "review.txt"
+    tracked.write_text("before\n")
+    commit_all(repo, "init")
+    tracked.write_text("before\nafter\n")
+    return repo
+
+
+def write_named_fake_providers(fake_bin, providers):
+    fake_bin.mkdir()
+    for provider in providers:
+        script = fake_bin / provider
+        script.write_text(
+            "#!/usr/bin/env python3\n"
+            "import pathlib, re, sys\n"
+            "provider = pathlib.Path(sys.argv[0]).name\n"
+            "print(f'provider={provider}')\n"
+            "match = re.search(r'Prompt file: (.+)', sys.argv[-1])\n"
+            "assert match, sys.argv[-1]\n"
+            "prompt = pathlib.Path(match.group(1).strip()).read_text()\n"
+            "if 'after' in prompt:\n"
+            "    print('prompt-ok')\n"
+        )
+        script.chmod(0o755)
+
+
+def preset_review_config(config, fake_bin):
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "glm": {"cli": str(fake_bin / "glm"), "timeout": 10},
+                    "deepseek": {"cli": str(fake_bin / "deepseek"), "timeout": 10},
+                    "codex": {"cli": str(fake_bin / "codex"), "timeout": 10},
+                },
+                "review": {
+                    "prompt_template": "Scope: {scope}\n\n{diff}\n\n{files}\n",
+                    "default_providers": ["glm"],
+                    "default_preset": "fast-review",
+                },
+                "presets": {
+                    "fast-review": {
+                        "providers": ["glm", "deepseek"],
+                        "task_type": "review",
+                    },
+                    "deep-review": {
+                        "providers": ["deepseek"],
+                        "optional_providers": ["codex", "missing"],
+                        "task_type": "review",
+                    },
+                },
+                "preset_aliases": {
+                    "fr": "fast-review",
+                    "dr": "deep-review",
+                },
+            }
+        )
+    )
+
+
 def test_codex_default_config_has_direct_review_providers():
     data = json.loads(CODEX_CONFIG.read_text())
 
@@ -207,6 +269,427 @@ def test_codex_review_collects_tracked_and_untracked_changes(tmp_path):
     synthesis = (review_dir / "synthesis.md").read_text()
     assert "Trinity Review Synthesis" in synthesis
     assert "raw/glm.txt" in synthesis
+
+
+def test_codex_review_explicit_preset_expands_required_and_optional_providers(
+    tmp_path,
+):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm", "deepseek", "codex"])
+    config = tmp_path / "codex.json"
+    preset_review_config(config, fake_bin)
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--preset",
+            "deep-review",
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert rc == 0, err
+    assert "optional provider 'missing' skipped: missing config" in err
+    review_dir = Path(out)
+    assert not (review_dir / "raw" / "glm.txt").exists()
+    for provider in ["deepseek", "codex"]:
+        raw = (review_dir / "raw" / f"{provider}.txt").read_text()
+        assert f"provider={provider}" in raw
+        assert "prompt-ok" in raw
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["providers"] == ["deepseek", "codex"]
+    assert metadata["preset"] == {
+        "requested": "deep-review",
+        "resolved": "deep-review",
+        "source": "explicit",
+        "task_type": "review",
+        "skipped_optional_providers": [
+            {"provider": "missing", "reason": "missing config"}
+        ],
+    }
+
+
+def test_codex_review_preset_alias_resolves(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm", "deepseek", "codex"])
+    config = tmp_path / "codex.json"
+    preset_review_config(config, fake_bin)
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--preset",
+            "fr",
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert rc == 0, err
+    review_dir = Path(out)
+    assert (review_dir / "raw" / "glm.txt").exists()
+    assert (review_dir / "raw" / "deepseek.txt").exists()
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["providers"] == ["glm", "deepseek"]
+    assert metadata["preset"]["requested"] == "fr"
+    assert metadata["preset"]["resolved"] == "fast-review"
+    assert metadata["preset"]["source"] == "explicit"
+
+
+def test_codex_review_default_preset_wins_over_default_providers(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm", "deepseek", "codex"])
+    config = tmp_path / "codex.json"
+    preset_review_config(config, fake_bin)
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert rc == 0, err
+    review_dir = Path(out)
+    assert (review_dir / "raw" / "glm.txt").exists()
+    assert (review_dir / "raw" / "deepseek.txt").exists()
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["providers"] == ["glm", "deepseek"]
+    assert metadata["preset"]["resolved"] == "fast-review"
+    assert metadata["preset"]["source"] == "default"
+
+
+def test_codex_review_providers_override_preset_with_warning(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm", "deepseek", "codex"])
+    config = tmp_path / "codex.json"
+    preset_review_config(config, fake_bin)
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--providers",
+            "glm",
+            "--preset",
+            "deep-review",
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert rc == 0, err
+    assert "--providers supplied; ignoring --preset 'deep-review'" in err
+    review_dir = Path(out)
+    assert (review_dir / "raw" / "glm.txt").exists()
+    assert not (review_dir / "raw" / "deepseek.txt").exists()
+    assert not (review_dir / "raw" / "codex.txt").exists()
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["providers"] == ["glm"]
+    assert metadata["preset"]["source"] == "providers"
+
+
+def test_codex_review_legacy_default_providers_still_work_without_presets(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm"])
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {"glm": {"cli": str(fake_bin / "glm"), "timeout": 10}},
+                "review": {
+                    "prompt_template": "{diff}\n\n{files}\n",
+                    "default_providers": ["glm"],
+                },
+            }
+        )
+    )
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert rc == 0, err
+    metadata = json.loads((Path(out) / "metadata.json").read_text())
+    assert metadata["providers"] == ["glm"]
+    assert metadata["preset"]["source"] == "default_providers"
+    assert metadata["preset"]["resolved"] is None
+
+
+def test_codex_review_unknown_preset_fails_before_review_dir(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm", "deepseek", "codex"])
+    config = tmp_path / "codex.json"
+    preset_review_config(config, fake_bin)
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--preset",
+            "missing",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "trinity: unknown preset 'missing'" in err
+    assert not out_dir.exists()
+
+
+def test_codex_review_invalid_preset_alias_fails_before_review_dir(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm"])
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {"glm": {"cli": str(fake_bin / "glm"), "timeout": 10}},
+                "review": {"default_preset": "review"},
+                "presets": {"review": {"providers": ["glm"]}},
+                "preset_aliases": {"r": "fr", "fr": "review"},
+            }
+        )
+    )
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--preset",
+            "r",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "trinity: preset alias 'r' points to another alias" in err
+    assert not out_dir.exists()
+
+
+def test_codex_review_invalid_task_type_fails_before_review_dir(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm"])
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {"glm": {"cli": str(fake_bin / "glm"), "timeout": 10}},
+                "review": {"default_preset": "review"},
+                "presets": {"review": {"providers": ["glm"], "task_type": "security"}},
+            }
+        )
+    )
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "trinity: preset 'review' has invalid task_type 'security'" in err
+    assert not out_dir.exists()
+
+
+def test_codex_review_missing_default_preset_fails_before_review_dir(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm"])
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {"glm": {"cli": str(fake_bin / "glm"), "timeout": 10}},
+                "review": {"default_preset": "missing"},
+                "presets": {"review": {"providers": ["glm"]}},
+            }
+        )
+    )
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "trinity: review.default_preset 'missing' not found" in err
+    assert not out_dir.exists()
+
+
+def test_codex_review_empty_preset_fails_before_review_dir(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm"])
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {"glm": {"cli": str(fake_bin / "glm"), "timeout": 10}},
+                "review": {"default_preset": "review"},
+                "presets": {"review": {"providers": []}},
+            }
+        )
+    )
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "trinity: preset 'review' has no providers" in err
+    assert not out_dir.exists()
+
+
+def test_codex_review_alias_collision_fails_before_review_dir(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm"])
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {"glm": {"cli": str(fake_bin / "glm"), "timeout": 10}},
+                "review": {"default_preset": "review"},
+                "presets": {"review": {"providers": ["glm"]}},
+                "preset_aliases": {"glm": "review"},
+            }
+        )
+    )
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "trinity: preset alias 'glm' collides with provider" in err
+    assert not out_dir.exists()
+
+
+def test_codex_review_optional_provider_with_empty_cli_is_skipped(tmp_path):
+    repo = simple_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm"])
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "glm": {"cli": str(fake_bin / "glm"), "timeout": 10},
+                    "codex": {"cli": " ", "timeout": 10},
+                },
+                "review": {"default_preset": "review"},
+                "presets": {
+                    "review": {
+                        "providers": ["glm"],
+                        "optional_providers": ["codex"],
+                    }
+                },
+            }
+        )
+    )
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert rc == 0, err
+    assert "optional provider 'codex' skipped: missing cli" in err
+    metadata = json.loads((Path(out) / "metadata.json").read_text())
+    assert metadata["providers"] == ["glm"]
+    assert metadata["preset"]["skipped_optional_providers"] == [
+        {"provider": "codex", "reason": "missing cli"}
+    ]
 
 
 def test_codex_review_uses_short_prompt_file_handoff_for_large_diffs(tmp_path):
@@ -630,6 +1113,63 @@ def test_codex_doctor_passes_healthy_provider(tmp_path):
 
     assert rc == 0, err
     assert f"healthy: OK - {fake} (timeout 10s)" in out
+
+
+def test_codex_doctor_uses_default_preset_when_no_providers_supplied(tmp_path):
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm", "deepseek"])
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "glm": {"cli": str(fake_bin / "glm"), "timeout": 10},
+                    "deepseek": {"cli": str(fake_bin / "deepseek"), "timeout": 10},
+                },
+                "review": {
+                    "default_preset": "fast-review",
+                    "default_providers": [],
+                },
+                "presets": {
+                    "fast-review": {
+                        "providers": ["glm", "deepseek"],
+                        "task_type": "review",
+                    }
+                },
+            }
+        )
+    )
+
+    rc, out, err = run_codex(["doctor", "--config", str(config)])
+
+    assert rc == 0, err
+    assert f"glm: OK - {fake_bin / 'glm'} (timeout 10s)" in out
+    assert f"deepseek: OK - {fake_bin / 'deepseek'} (timeout 10s)" in out
+
+
+def test_codex_doctor_accepts_preset_alias(tmp_path):
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm", "deepseek"])
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "glm": {"cli": str(fake_bin / "glm"), "timeout": 10},
+                    "deepseek": {"cli": str(fake_bin / "deepseek"), "timeout": 10},
+                },
+                "review": {"default_providers": []},
+                "presets": {"fast-review": {"providers": ["glm", "deepseek"]}},
+                "preset_aliases": {"fr": "fast-review"},
+            }
+        )
+    )
+
+    rc, out, err = run_codex(["doctor", "--config", str(config), "--preset", "fr"])
+
+    assert rc == 0, err
+    assert f"glm: OK - {fake_bin / 'glm'} (timeout 10s)" in out
+    assert f"deepseek: OK - {fake_bin / 'deepseek'} (timeout 10s)" in out
 
 
 def test_codex_doctor_resolves_relative_provider_cli_from_git_root(tmp_path):

--- a/tests/test_codex_compat.py
+++ b/tests/test_codex_compat.py
@@ -13,6 +13,7 @@ PLUGIN_MANIFEST = PLUGIN_ROOT / ".codex-plugin" / "plugin.json"
 PLUGIN_SKILL = PLUGIN_ROOT / "skills" / "trinity" / "SKILL.md"
 MARKETPLACE = ROOT / ".agents" / "plugins" / "marketplace.json"
 README = ROOT / "README.md"
+ROOT_SKILL = ROOT / "SKILL.md"
 
 
 def _frontmatter_value(text, key):
@@ -83,14 +84,28 @@ def test_readme_documents_claude_and_codex_load_smoke_checks():
     assert "Claude Code" in text
     assert "make install-codex" in text
     assert "trinity review --providers glm,gemini,deepseek" in text
+    assert "trinity doctor --preset fast-review" in text
+    assert "trinity review --preset fast-review" in text
+    assert "trinity review --pr 21 --preset deep-review" in text
     assert ".agents/trinity.codex.json" in text
     assert "| `fast-review` | `glm`, `deepseek` | none |" in text
-    assert "Until preset resolution is implemented" in text
+    assert "explicit `--providers`, explicit `--preset`" in text
 
 
-def test_codex_skill_documents_preset_config_as_seed_only():
+def test_codex_skill_documents_preset_resolution():
     text = REPO_SKILL.read_text()
 
+    assert "trinity doctor --preset fast-review" in text
+    assert "trinity review --preset fast-review" in text
     assert "`fast-review` expands to `glm` and `deepseek`" in text
-    assert "configuration seeds only" in text
-    assert "--providers` or `review.default_providers`" in text
+    assert "review.default_preset" in text
+    assert "skipped providers are recorded" in text
+
+
+def test_claude_skill_documents_review_presets():
+    text = ROOT_SKILL.read_text()
+
+    assert '/trinity fast-review "task"' in text
+    assert "| `fast-review` | `glm`, `deepseek` | none |" in text
+    assert "Configured presets" in text
+    assert "Preset/provider collisions are invalid" in text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -211,6 +211,76 @@ def test_defaults_project_array_replaces_global_array(tmp_path):
     assert result["defaults"]["tags"] == ["c"]
 
 
+def test_presets_project_key_wins_shallowly(tmp_path):
+    global_config = tmp_path / "global" / "trinity.json"
+    write_config(
+        global_config,
+        {
+            "presets": {
+                "review": {
+                    "providers": ["gemini", "glm"],
+                    "optional_providers": ["codex"],
+                    "task_type": "review",
+                },
+                "deep-review": {"providers": ["glm", "gemini", "deepseek"]},
+            }
+        },
+    )
+    project_dir = tmp_path / "project"
+    project_trinity = project_dir / ".claude" / "trinity.json"
+    write_config(project_trinity, {"presets": {"review": {"providers": ["glm"]}}})
+
+    rc, out, err = run(
+        [
+            "merge",
+            "--global-config",
+            str(global_config),
+            "--project-dir",
+            str(project_dir),
+        ]
+    )
+
+    assert rc == 0
+    result = json.loads(out)
+    assert result["presets"]["review"] == {"providers": ["glm"]}
+    assert result["presets"]["deep-review"] == {
+        "providers": ["glm", "gemini", "deepseek"]
+    }
+
+
+def test_preset_aliases_project_key_wins(tmp_path):
+    global_config = tmp_path / "global" / "trinity.json"
+    write_config(
+        global_config,
+        {
+            "preset_aliases": {
+                "r": "review",
+                "fr": "fast-review",
+            }
+        },
+    )
+    project_dir = tmp_path / "project"
+    project_trinity = project_dir / ".claude" / "trinity.json"
+    write_config(project_trinity, {"preset_aliases": {"fr": "project-fast"}})
+
+    rc, out, err = run(
+        [
+            "merge",
+            "--global-config",
+            str(global_config),
+            "--project-dir",
+            str(project_dir),
+        ]
+    )
+
+    assert rc == 0
+    result = json.loads(out)
+    assert result["preset_aliases"] == {
+        "r": "review",
+        "fr": "project-fast",
+    }
+
+
 def test_invalid_json_in_global_exits_1(tmp_path):
     global_config = tmp_path / "global" / "trinity.json"
     global_config.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Implement Codex preset resolution for `trinity review --preset <name>` and `trinity doctor --preset <name>`.
- Support aliases, `review.default_preset`, explicit `--providers` override warnings, optional-provider skip warnings, and legacy `review.default_providers` fallback.
- Record preset resolution metadata in review artifacts and update Claude/Codex docs for `review`, `fast-review`, and `deep-review`.

## Trinity Review
- GLM: PASS
- DeepSeek: PASS
- Round 1 advisory: add doctor preset support; fixed.
- Round 2 advisory: remove unused `split_providers()`; fixed.

Review artifacts:
- `.trinity/reviews/20260505-001712-./`
- `.trinity/reviews/20260505-002311-./`

## Verification
- RED tests confirmed missing preset merge/resolver behavior before implementation.
- `.venv/bin/pytest tests/test_config.py tests/test_codex_adapter.py tests/test_codex_compat.py -q` -> `48 passed`
- `make test` -> `100 passed` plus shell regression suites passed
- `make lint`
- `af validate --root .` -> `84 documents checked, 0 issues found`
- `make install-codex`
- `trinity doctor --preset fast-review`
- `trinity review --check-providers --preset fast-review`