### PR TITLE
TRN-2016: Add COR strict review mode

### DIFF
--- a/.agents/skills/trinity/SKILL.md
+++ b/.agents/skills/trinity/SKILL.md
@@ -32,6 +32,9 @@ trinity review --preset fast-review --scope <path-or-label>
 trinity review --preset dr --scope <path-or-label>
 trinity review --base main --head HEAD --providers glm,deepseek
 trinity review --pr 21 --preset deep-review
+trinity review --sop COR-1602 --rubric COR-1609 --scope <path-or-label>
+trinity review --sop COR-1602 --rubric COR-1609 --base main --head HEAD --preset fast-review
+trinity review --sop COR-1602 --rubric COR-1609 --pr 21 --preset deep-review
 ```
 
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
@@ -49,6 +52,10 @@ they lack config or a CLI, and skipped providers are recorded in
 command lookup, executable permissions, and timeout values without making network
 calls. Use the default review mode for dirty working-tree changes, `--base` /
 `--head` for committed branch reviews, and `--pr` for GitHub PR reviews.
+Pair `--sop` and `--rubric` for strict COR review mode. The first supported
+strict template is `COR-1602` with `COR-1609`; it asks reviewers for findings,
+a decision matrix, weighted average, and PASS/FIX, then records the selected
+SOP/rubric metadata in `metadata.json`.
 
 ## Host Boundary
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ trinity review --preset fast-review --scope spikes/hardline
 trinity review --preset dr --scope .
 trinity review --base main --head HEAD --providers glm,deepseek
 trinity review --pr 21 --preset deep-review
+trinity review --sop COR-1602 --rubric COR-1609 --scope rules/TRN-2016-CHG-COR-1602-Strict-Review-Mode.md
+trinity review --sop COR-1602 --rubric COR-1609 --base main --head HEAD --preset fast-review
+trinity review --sop COR-1602 --rubric COR-1609 --pr 21 --preset deep-review
 ```
 
 Without `--pr` or `--base/--head`, the review wrapper collects tracked and
@@ -271,6 +274,13 @@ directories are created. If a preset has optional providers that are not
 configured or have no CLI, they are skipped with a stderr warning and recorded
 in `metadata.json`; required providers still fail preflight when unavailable.
 This path does not require Claude Code worker-agent files.
+
+Strict COR review mode is enabled by pairing `--sop` and `--rubric`. The first
+supported template is `COR-1602` with the `COR-1609` CHG rubric. It prepends
+rubric weights, COR-1611 calibration guidance, the 9.0 PASS threshold, and the
+required findings / decision-matrix / weighted-average output schema to the
+normal review prompt. The selected SOP, rubric, threshold, and output schema
+are recorded in `metadata.json`.
 
 **Codex repo-local skill**
 

--- a/plugins/trinity/skills/trinity/SKILL.md
+++ b/plugins/trinity/skills/trinity/SKILL.md
@@ -32,6 +32,9 @@ trinity review --preset fast-review --scope <path-or-label>
 trinity review --preset dr --scope <path-or-label>
 trinity review --base main --head HEAD --providers glm,deepseek
 trinity review --pr 21 --preset deep-review
+trinity review --sop COR-1602 --rubric COR-1609 --scope <path-or-label>
+trinity review --sop COR-1602 --rubric COR-1609 --base main --head HEAD --preset fast-review
+trinity review --sop COR-1602 --rubric COR-1609 --pr 21 --preset deep-review
 ```
 
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
@@ -49,6 +52,10 @@ they lack config or a CLI, and skipped providers are recorded in
 command lookup, executable permissions, and timeout values without making network
 calls. Use the default review mode for dirty working-tree changes, `--base` /
 `--head` for committed branch reviews, and `--pr` for GitHub PR reviews.
+Pair `--sop` and `--rubric` for strict COR review mode. The first supported
+strict template is `COR-1602` with `COR-1609`; it asks reviewers for findings,
+a decision matrix, weighted average, and PASS/FIX, then records the selected
+SOP/rubric metadata in `metadata.json`.
 
 ## Host Boundary
 

--- a/rules/TRN-0000-REF-Document-Index.md
+++ b/rules/TRN-0000-REF-Document-Index.md
@@ -1,8 +1,8 @@
 # REF-0000: Document Index
 
 **Applies to:** TRN project
-**Last updated:** 2026-05-04
-**Last reviewed:** 2026-05-04
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
 **Status:** Active
 
 ---
@@ -33,6 +33,7 @@
 | 2013 | CHG | Trinity Review Presets |
 | 2014 | CHG | Provider Health Checks and DeepSeek Review Config |
 | 2015 | CHG | PR Base Head Review Mode |
+| 2016 | CHG | COR-1602 Strict Review Mode |
 
 ---
 
@@ -54,3 +55,4 @@
 | 2026-05-04 | Add TRN-2013 for Trinity Review Presets | Codex |
 | 2026-05-04 | Add TRN-2014 Provider Health Checks and DeepSeek Review Config | Codex |
 | 2026-05-04 | Add TRN-2015 PR Base Head Review Mode | Codex |
+| 2026-05-05 | Add TRN-2016 COR-1602 Strict Review Mode | Codex |

--- a/rules/TRN-2016-CHG-COR-1602-Strict-Review-Mode.md
+++ b/rules/TRN-2016-CHG-COR-1602-Strict-Review-Mode.md
@@ -1,0 +1,115 @@
+# CHG-2016: COR-1602 Strict Review Mode
+
+**Applies to:** Trinity project (`frankyxhl/trinity`)
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
+**Status:** Proposed
+**Date:** 2026-05-04
+**Requested by:** Frank
+**Implementer:** Codex
+**Priority:** Medium
+**Change Type:** Normal
+**Related:** TRN-1200, TRN-2011, TRN-2013, TRN-2015, COR-1101, COR-1500, COR-1602, COR-1609, COR-1613, COR-1615, COR-1612
+
+---
+
+## What
+
+Add a strict COR review mode to Codex-native Trinity review, for example:
+
+```bash
+trinity review --sop COR-1602 --rubric COR-1609 --pr 20
+```
+
+The mode should generate a rubric-specific prompt and require reviewers to
+return findings, decision matrix, weighted average, and PASS/FIX.
+
+This change covers prompt construction, command-line ergonomics, review
+metadata, and documentation. It does not introduce automated parsing or
+machine-scoring of reviewer outputs.
+
+---
+
+## Why
+
+COR-1602 review of PR #20 required hand-built prompts and manual reviewer
+coordination. This is repeatable enough to automate once TRN-2015 provides a
+reliable PR/base-head review input mode.
+
+---
+
+## Impact Analysis
+
+- **Systems affected:** `scripts/codex.py`, `.agents/trinity.codex.json`,
+  README, tests, and review prompt templates.
+- **Systems intentionally preserved:** default review prompt, provider
+  execution, raw outputs, and synthesis layout.
+- **Downtime required:** No.
+- **Dependencies:** Should follow TRN-2015 so strict reviews can target actual
+  PR/base-head diffs, not only uncommitted working-tree changes.
+- **Review workflow:** use COR-1602 with COR-1613 decision tracking before PR.
+  After PR creation, use COR-1615 for GitHub App review bot polling and
+  COR-1612 for fetched PR findings.
+- **Rollback plan:** remove `--sop`, `--rubric`, strict templates, tests, and
+  docs. Default `trinity review` remains unchanged.
+
+---
+
+## Implementation Plan
+
+1. Protect unrelated in-progress CHGs before branching for TRN-2016.
+2. RED: add tests for `--sop COR-1602 --rubric COR-1609` prompt generation.
+3. RED: add tests for unsupported SOP/rubric combinations and missing rubric
+   docs or templates.
+4. RED: add tests proving strict mode records SOP, rubric, PASS threshold, and
+   expected output schema in review metadata.
+5. RED: add compatibility tests for `--providers`, `--preset`,
+   `--base/--head`, and `--pr`; default review behavior must remain unchanged.
+6. GREEN: add a small registry of supported review templates, starting with
+   COR-1602 + COR-1609.
+7. GREEN: include required scoring instructions, PASS threshold, COR-1611
+   calibration guidance, and expected output sections in the generated prompt.
+8. GREEN: preserve existing provider dispatch, raw output, timeout, and
+   synthesis behavior.
+9. REFACTOR: keep prompt template assembly separate from provider dispatch.
+10. Docs: add examples for CHG review, branch review, and PR review.
+11. Review gate: run Trinity fast-review/deep-review on the CHG and
+    implementation; revise blockers before opening the PR.
+12. PR gate: after opening the PR, follow COR-1615 for any GitHub App review
+    bot pass and route actionable findings through COR-1612.
+
+---
+
+## Testing / Verification
+
+Expected evidence before marking complete:
+
+- `.venv/bin/pytest tests/test_codex_adapter.py -q`
+- prompt snapshot/substring tests for COR-1602 + COR-1609
+- `make test`
+- `make lint`
+- `af validate --root .`
+- mocked `trinity review --sop COR-1602 --rubric COR-1609 --base main --head HEAD`
+- Trinity review evidence from `glm` and `deepseek` at minimum, using the
+  configured fast-review preset unless a deeper pass is requested.
+- PR-stage COR-1615 evidence: current `headRefOid` recorded, one bot review
+  request per head when needed, current-head review result matched, and
+  COR-1612 used for actionable findings.
+
+---
+
+## Triage Evidence
+
+Trinity improvement triage on 2026-05-04:
+
+- GLM: CREATE_CHG
+- DeepSeek: CREATE_CHG, borderline but worth tracking after PR review mode
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-05 | Revised plan to add TDD, Trinity review gate, and COR-1615 PR bot review loop | Codex |
+| 2026-05-04 | Initial CHG for COR-1602 strict review mode | Codex |

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -24,6 +24,36 @@ DEFAULT_CONFIG_CANDIDATES = [
 DEFAULT_CONFIG_SECTIONS = ("providers", "review", "presets", "preset_aliases")
 PRESET_TASK_TYPES = {"tdd", "review", "prp", "general"}
 PRESET_ALIAS_RESERVED_WORDS = {"init-config", "doctor", "review", "help"}
+STRICT_REVIEW_OUTPUT_SCHEMA = [
+    "### Findings",
+    "### Decision Matrix",
+    "**Weighted Average: X.X/10 - PASS/FIX**",
+]
+STRICT_REVIEW_DECISION_RULE = (
+    "PASS when weighted_average >= 9.0 and no blocking findings remain; otherwise FIX."
+)
+STRICT_REVIEW_TEMPLATES = {
+    ("COR-1602", "COR-1609"): {
+        "pass_threshold": 9.0,
+        "calibration": "COR-1611",
+        "rubric_title": "CHG Review Scoring",
+        "criteria": [
+            ("Correctness", "25%", "Change is technically sound and feasible."),
+            ("Completeness", "25%", "CHG covers scope, risks, verification, and docs."),
+            (
+                "TDD Plan Quality",
+                "20%",
+                "Plan uses RED/GREEN/REFACTOR where code changes are involved.",
+            ),
+            ("Consistency", "15%", "Fits local conventions and related COR/TRN docs."),
+            ("Rollback Safety", "15%", "Rollback path and blast radius are clear."),
+        ],
+        "non_code_note": (
+            "For non-code CHGs where TDD is not applicable, redistribute the TDD "
+            "weight to Completeness (35%) and Consistency (25%)."
+        ),
+    }
+}
 
 
 def _load_version():
@@ -739,15 +769,110 @@ def resolve_review_input(args, root):
     return working_tree_review_input(root, args.scope)
 
 
-def render_prompt(config, root, scope, review_input):
+def normalize_review_doc_id(value, flag):
+    normalized = (value or "").strip().upper()
+    if not re.fullmatch(r"[A-Z]{3}-\d{4}", normalized):
+        raise SystemExit(f"trinity: {flag} must look like COR-1602")
+    return normalized
+
+
+def strict_review_metadata(sop, rubric, template):
+    return {
+        "enabled": True,
+        "sop": sop,
+        "rubric": rubric,
+        "pass_threshold": template["pass_threshold"],
+        "calibration": template["calibration"],
+        "decision_rule": STRICT_REVIEW_DECISION_RULE,
+        "output_schema": list(STRICT_REVIEW_OUTPUT_SCHEMA),
+    }
+
+
+def resolve_strict_review(args):
+    if bool(args.sop) != bool(args.rubric):
+        raise SystemExit("trinity: --sop and --rubric must be used together")
+    if not args.sop and not args.rubric:
+        return None
+
+    sop = normalize_review_doc_id(args.sop, "--sop")
+    rubric = normalize_review_doc_id(args.rubric, "--rubric")
+    template = STRICT_REVIEW_TEMPLATES.get((sop, rubric))
+    if template is None:
+        raise SystemExit(
+            f"trinity: unsupported strict review template: SOP {sop} with rubric {rubric}"
+        )
+    metadata = strict_review_metadata(sop, rubric, template)
+    return {**metadata, "template": template}
+
+
+def render_strict_review_instructions(strict_review):
+    template = strict_review["template"]
+    lines = [
+        "## Strict COR Review Mode",
+        "",
+        f"SOP: {strict_review['sop']}",
+        f"Rubric: {strict_review['rubric']} ({template['rubric_title']})",
+        f"Calibration: {strict_review['calibration']}",
+        f"PASS threshold: {strict_review['pass_threshold']:.1f}/10",
+        "",
+        "Follow the SOP workflow and score the artifact with this rubric:",
+        "",
+        "| Criterion | Weight | Scoring focus |",
+        "|-----------|--------|---------------|",
+    ]
+    for criterion, weight, focus in template["criteria"]:
+        lines.append(f"| {criterion} | {weight} | {focus} |")
+
+    matrix_rows = [
+        f"| {criterion} | {weight} | X.X | ... |"
+        for criterion, weight, _focus in template["criteria"]
+    ]
+    lines.extend(
+        [
+            "",
+            template["non_code_note"],
+            "",
+            "Use COR-1611 calibration: cite every deduction, distinguish blocking "
+            "findings from advisory improvements, and reserve 10/10 for zero "
+            "remaining improvements.",
+            "",
+            "Required output:",
+            "",
+            "### Findings",
+            "",
+            "- List each finding with severity, file/path reference when applicable, "
+            "and whether it is blocking or advisory.",
+            "",
+            "### Decision Matrix",
+            "",
+            "| Criterion | Weight | Score | Rationale |",
+            "|-----------|--------|-------|-----------|",
+            *matrix_rows,
+            "",
+            "**Weighted Average: X.X/10 - PASS/FIX**",
+            "",
+            STRICT_REVIEW_DECISION_RULE,
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_prompt(config, root, scope, review_input, strict_review=None):
     diff = review_input["diff"]
     files = review_input["files"]
     template = config.get("review", {}).get("prompt_template", "{diff}\n\n{files}\n")
-    return (
+    prompt = (
         template.replace("{scope}", scope or ".")
         .replace("{root}", str(root))
         .replace("{diff}", diff)
         .replace("{files}", files)
+    )
+    if strict_review is None:
+        return prompt
+    return (
+        render_strict_review_instructions(strict_review)
+        + "\n## Review Artifact\n\n"
+        + prompt
     )
 
 
@@ -871,6 +996,7 @@ def cmd_review(args):
     providers, preset_metadata, resolver_warnings = resolve_review_providers(
         args, config
     )
+    strict_review = resolve_strict_review(args)
     for warning in resolver_warnings:
         print(warning, file=sys.stderr)
     provider_configs = config.get("providers", {})
@@ -890,7 +1016,7 @@ def cmd_review(args):
     if not out_base.is_absolute():
         out_base = root / out_base
     review_dir = make_review_dir(out_base, args.scope)
-    prompt = render_prompt(config, root, args.scope, review_input)
+    prompt = render_prompt(config, root, args.scope, review_input, strict_review)
     prompt_path = review_dir / "prompt.md"
     prompt_path.write_text(prompt)
 
@@ -913,6 +1039,10 @@ def cmd_review(args):
         "input": review_input["metadata"],
         "results": results,
     }
+    if strict_review is not None:
+        metadata["strict_review"] = {
+            key: value for key, value in strict_review.items() if key != "template"
+        }
     (review_dir / "metadata.json").write_text(
         json.dumps(metadata, indent=2, ensure_ascii=False) + "\n"
     )
@@ -957,6 +1087,8 @@ def build_parser():
     review.add_argument("--pr", type=int)
     review.add_argument("--base")
     review.add_argument("--head")
+    review.add_argument("--sop")
+    review.add_argument("--rubric")
     return parser
 
 

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -755,6 +755,296 @@ def test_codex_review_uses_short_prompt_file_handoff_for_large_diffs(tmp_path):
     assert "large-prompt-file-ok" in raw
 
 
+def test_codex_review_strict_cor1602_cor1609_prompt_and_metadata(tmp_path):
+    repo = simple_repo(tmp_path)
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--providers",
+            "glm",
+            "--sop",
+            "COR-1602",
+            "--rubric",
+            "COR-1609",
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert rc == 0, err
+    review_dir = Path(out)
+    prompt = (review_dir / "prompt.md").read_text()
+    assert "## Strict COR Review Mode" in prompt
+    assert "SOP: COR-1602" in prompt
+    assert "Rubric: COR-1609" in prompt
+    assert "PASS threshold: 9.0/10" in prompt
+    assert "Correctness | 25%" in prompt
+    assert "Completeness | 25%" in prompt
+    assert "TDD Plan Quality | 20%" in prompt
+    assert "Rollback Safety | 15%" in prompt
+    assert "### Decision Matrix" in prompt
+    assert "**Weighted Average: X.X/10 - PASS/FIX**" in prompt
+    assert "COR-1611" in prompt
+    assert "after" in prompt
+
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["strict_review"] == {
+        "enabled": True,
+        "sop": "COR-1602",
+        "rubric": "COR-1609",
+        "pass_threshold": 9.0,
+        "calibration": "COR-1611",
+        "decision_rule": (
+            "PASS when weighted_average >= 9.0 and no blocking findings remain; "
+            "otherwise FIX."
+        ),
+        "output_schema": [
+            "### Findings",
+            "### Decision Matrix",
+            "**Weighted Average: X.X/10 - PASS/FIX**",
+        ],
+    }
+
+
+def test_codex_review_strict_mode_requires_sop_and_rubric_pair(tmp_path):
+    repo = simple_repo(tmp_path)
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+
+    cases = [
+        ("sop-only", ["--sop", "COR-1602"]),
+        ("rubric-only", ["--rubric", "COR-1609"]),
+    ]
+    for label, flags in cases:
+        out_dir = tmp_path / f"reviews-{label}"
+        rc, out, err = run_codex(
+            [
+                "review",
+                "--root",
+                str(repo),
+                "--config",
+                str(config),
+                "--providers",
+                "glm",
+                *flags,
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+
+        assert rc == 1
+        assert out == ""
+        assert "trinity: --sop and --rubric must be used together" in err
+        assert not out_dir.exists()
+
+
+def test_codex_review_strict_mode_rejects_invalid_doc_id_format(tmp_path):
+    repo = simple_repo(tmp_path)
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--providers",
+            "glm",
+            "--sop",
+            "COR1602",
+            "--rubric",
+            "COR-1609",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert "trinity: --sop must look like COR-1602" in err
+    assert not out_dir.exists()
+
+
+def test_codex_review_strict_mode_rejects_unsupported_template(tmp_path):
+    repo = simple_repo(tmp_path)
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+    out_dir = tmp_path / "reviews"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--providers",
+            "glm",
+            "--sop",
+            "COR-1602",
+            "--rubric",
+            "COR-1610",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 1
+    assert out == ""
+    assert (
+        "trinity: unsupported strict review template: SOP COR-1602 with rubric COR-1610"
+        in err
+    )
+    assert not out_dir.exists()
+
+
+def test_codex_review_strict_mode_combines_with_pr_and_preset(tmp_path):
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    tracked = repo / "review.txt"
+    tracked.write_text("base version\n")
+    commit_all(repo, "base")
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=repo, check=True)
+    tracked.write_text("strict pr head snapshot\n")
+    commit_all(repo, "feature change")
+    head_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    fake_bin = tmp_path / "bin"
+    write_named_fake_providers(fake_bin, ["glm", "deepseek"])
+    gh = fake_bin / "gh"
+    gh.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "args = sys.argv[1:]\n"
+        "if args[:3] == ['pr', 'diff', '456']:\n"
+        "    print('diff --git a/review.txt b/review.txt')\n"
+        "    print('+from mocked strict gh pr diff')\n"
+        "elif args[:3] == ['pr', 'view', '456']:\n"
+        "    print(json.dumps({\n"
+        "        'number': 456,\n"
+        "        'url': 'https://github.example/pr/456',\n"
+        "        'baseRefName': 'main',\n"
+        "        'headRefName': 'feature',\n"
+        f"        'headRefOid': '{head_oid}',\n"
+        "        'files': [{'path': 'review.txt', 'changeType': 'MODIFIED'}],\n"
+        "    }))\n"
+        "else:\n"
+        "    raise SystemExit(f'unexpected gh args: {args}')\n"
+    )
+    gh.chmod(0o755)
+    config = tmp_path / "codex.json"
+    preset_review_config(config, fake_bin)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--preset",
+            "fr",
+            "--pr",
+            "456",
+            "--sop",
+            "COR-1602",
+            "--rubric",
+            "COR-1609",
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ],
+        env=env,
+    )
+
+    assert rc == 0, err
+    review_dir = Path(out)
+    prompt = (review_dir / "prompt.md").read_text()
+    assert "from mocked strict gh pr diff" in prompt
+    assert "strict pr head snapshot" in prompt
+    assert "## Strict COR Review Mode" in prompt
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["providers"] == ["glm", "deepseek"]
+    assert metadata["preset"]["resolved"] == "fast-review"
+    assert metadata["input"]["pr"] == 456
+    assert metadata["input"]["head_oid"] == head_oid
+    assert metadata["strict_review"]["sop"] == "COR-1602"
+    assert metadata["strict_review"]["rubric"] == "COR-1609"
+
+
+def test_codex_review_strict_mode_combines_with_base_head(tmp_path):
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    tracked = repo / "review.txt"
+    tracked.write_text("base version\n")
+    commit_all(repo, "base")
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=repo, check=True)
+    tracked.write_text("strict base-head snapshot\n")
+    commit_all(repo, "feature change")
+
+    provider = tmp_path / "provider"
+    write_fake_provider(provider)
+    config = tmp_path / "codex.json"
+    simple_review_config(config, provider)
+
+    rc, out, err = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--base",
+            "main",
+            "--head",
+            "feature",
+            "--sop",
+            "COR-1602",
+            "--rubric",
+            "COR-1609",
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert rc == 0, err
+    review_dir = Path(out)
+    prompt = (review_dir / "prompt.md").read_text()
+    assert "strict base-head snapshot" in prompt
+    assert "## Strict COR Review Mode" in prompt
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["input"]["mode"] == "base-head"
+    assert metadata["input"]["base"] == "main"
+    assert metadata["input"]["head"] == "feature"
+    assert metadata["strict_review"]["sop"] == "COR-1602"
+    assert metadata["strict_review"]["rubric"] == "COR-1609"
+
+
 def test_codex_review_base_head_collects_committed_diff_and_head_snapshots(tmp_path):
     repo = tmp_path / "repo"
     init_repo(repo)

--- a/tests/test_codex_compat.py
+++ b/tests/test_codex_compat.py
@@ -87,6 +87,8 @@ def test_readme_documents_claude_and_codex_load_smoke_checks():
     assert "trinity doctor --preset fast-review" in text
     assert "trinity review --preset fast-review" in text
     assert "trinity review --pr 21 --preset deep-review" in text
+    assert "trinity review --sop COR-1602 --rubric COR-1609" in text
+    assert "Strict COR review mode" in text
     assert ".agents/trinity.codex.json" in text
     assert "| `fast-review` | `glm`, `deepseek` | none |" in text
     assert "explicit `--providers`, explicit `--preset`" in text
@@ -97,6 +99,8 @@ def test_codex_skill_documents_preset_resolution():
 
     assert "trinity doctor --preset fast-review" in text
     assert "trinity review --preset fast-review" in text
+    assert "trinity review --sop COR-1602 --rubric COR-1609" in text
+    assert "strict template is `COR-1602` with `COR-1609`" in text
     assert "`fast-review` expands to `glm` and `deepseek`" in text
     assert "review.default_preset" in text
     assert "skipped providers are recorded" in text


### PR DESCRIPTION
## Summary

- Add `trinity review --sop COR-1602 --rubric COR-1609` strict review mode.
- Prepend COR-1609 rubric weights, COR-1611 calibration guidance, PASS threshold, and required output schema to the normal review prompt.
- Record strict review SOP/rubric/threshold/schema metadata while preserving default review behavior.
- Document strict mode examples in README and Codex skill docs.

## Verification

- `make test`
- `make lint`
- `af validate --root .`
- temporary-home `make install-codex` smoke with strict review invocation
- Trinity fast-review: GLM PASS 9.2/10; DeepSeek PASS, no blockers

## Notes

- Provider dispatch, raw outputs, synthesis layout, and config schema remain unchanged.
- This PR does not add automated score parsing; strict mode instructs reviewers and records metadata.
