### PR TITLE
TRN-2017: Add PR update helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup build verify-built install-hooks test lint install install-codex bump release-prep
+.PHONY: setup build verify-built install-hooks test lint install install-codex pr-update bump release-prep
 
 # Read VERSION at make invocation time
 CURRENT_VERSION := $(shell cat VERSION 2>/dev/null || echo "0.0.0")
@@ -29,8 +29,8 @@ test:           ## Run all tests (TRN-1001 + TRN-2004 build tests + TRN-2006 rel
 	bash tests/test_make_bump.sh
 
 lint:           ## Check and format code (TRN-1002)
-	.venv/bin/ruff check scripts/ tests/
-	.venv/bin/ruff format --check scripts/ tests/
+	.venv/bin/ruff check dev/ scripts/ tests/
+	.venv/bin/ruff format --check dev/ scripts/ tests/
 
 install:        ## Install Trinity to ~/.claude/ (TRN-1005)
 	@mkdir -p ~/.claude/skills/trinity/scripts
@@ -76,6 +76,23 @@ install-codex:  ## Install Trinity Codex adapter to ~/.codex/ and ~/.local/bin
 	python3 ~/.codex/skills/trinity/scripts/codex.py init-config \
 		--global-config ~/.codex/trinity.json
 	@echo "Installed Trinity Codex adapter $(CURRENT_VERSION)"
+
+MODE ?= amend
+TRINITY_PR_UPDATE_PR := $(value PR)
+TRINITY_PR_UPDATE_MODE := $(value MODE)
+TRINITY_PR_UPDATE_MESSAGE := $(value MESSAGE)
+TRINITY_PR_UPDATE_REVIEW := $(value REVIEW)
+export TRINITY_PR_UPDATE_PR
+export TRINITY_PR_UPDATE_MODE
+export TRINITY_PR_UPDATE_MESSAGE
+export TRINITY_PR_UPDATE_REVIEW
+
+pr-update:      ## Validate, update current PR branch, push, and comment: make pr-update PR=20 MESSAGE="..."
+	@test -n "$$TRINITY_PR_UPDATE_PR" || (echo "Usage: make pr-update PR=<num> MESSAGE=\"...\" [MODE=amend|commit|comment-only] [DRY_RUN=1] [REVIEW=\"...\"]"; exit 1)
+	@test -n "$$TRINITY_PR_UPDATE_MESSAGE" || (echo "Usage: make pr-update PR=<num> MESSAGE=\"...\" [MODE=amend|commit|comment-only] [DRY_RUN=1] [REVIEW=\"...\"]"; exit 1)
+	python3 dev/pr_update.py --pr "$$TRINITY_PR_UPDATE_PR" --message "$$TRINITY_PR_UPDATE_MESSAGE" --mode "$$TRINITY_PR_UPDATE_MODE" \
+		$(if $(filter 1 true yes,$(DRY_RUN)),--dry-run,) \
+		$(if $(strip $(value REVIEW)),--review "$$TRINITY_PR_UPDATE_REVIEW",)
 
 bump:           ## Bump version (TRN-1003): make bump VERSION=x.y.z
 	@test -n "$(VERSION)" || (echo "Usage: make bump VERSION=x.y.z"; exit 1)

--- a/README.md
+++ b/README.md
@@ -282,6 +282,42 @@ required findings / decision-matrix / weighted-average output schema to the
 normal review prompt. The selected SOP, rubric, threshold, and output schema
 are recorded in `metadata.json`.
 
+**Update a PR after review fixes**
+
+```bash
+make pr-update PR=26 MESSAGE="Address review feedback" DRY_RUN=1
+make pr-update PR=26 MESSAGE="Address review feedback" REVIEW="Trinity fast-review PASS"
+make pr-update PR=26 MESSAGE="Add follow-up fix" MODE=commit REVIEW="Codex connector found no major issues"
+make pr-update PR=26 MESSAGE="Post validation evidence" MODE=comment-only REVIEW="No actionable findings"
+```
+
+`make pr-update` wraps `dev/pr_update.py`. It requires no unstaged or
+untracked files, a configured upstream branch, and staged changes for
+`MODE=amend` or `MODE=commit`. The default mode is `amend`, which runs
+`git commit --amend --no-edit` and pushes with `--force-with-lease` to the
+explicit configured upstream ref. `MODE=commit` creates a new commit and uses a
+plain explicit-refspec `git push`. `MODE=comment-only` only runs validation and
+posts the PR comment. The helper runs `make test`, `make lint`, and
+`af validate --root .` before any push/comment side effects.
+When `MESSAGE` or `REVIEW` contains `$`, quote the value for your shell, for
+example `MESSAGE='Preserve $VAR literally'`; the Make wrapper passes that text
+through without re-expanding it.
+
+Always run with `DRY_RUN=1` first and inspect the command preview plus comment
+body. Do not use the helper when unrelated local files are dirty, when the PR
+head has changed unexpectedly, when you need a custom push target, or when the
+manual COR-1612/COR-1615 review-response flow requires more precise comments.
+Manual fallback:
+
+```bash
+make test
+make lint
+af validate --root .
+git commit --amend --no-edit
+git push --force-with-lease fork HEAD:codex/example-branch
+gh pr comment 26 --body-file comment.md
+```
+
 **Codex repo-local skill**
 
 The repo-local Codex skill lives at:

--- a/dev/pr_update.py
+++ b/dev/pr_update.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Safely update a pull request after local review fixes."""
+
+import argparse
+import subprocess
+import sys
+
+
+VALIDATION_COMMANDS = [
+    ("make test", ["make", "test"]),
+    ("make lint", ["make", "lint"]),
+    ("af validate --root .", ["af", "validate", "--root", "."]),
+]
+
+
+def run_command(command, *, input_text=None):
+    return subprocess.run(
+        command,
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def shell_join(command):
+    return " ".join(shell_quote(part) for part in command)
+
+
+def shell_quote(value):
+    if not value:
+        return "''"
+    safe = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@%_+=:,./-"
+    if all(char in safe for char in value):
+        return value
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def fail(message):
+    print(f"pr-update: {message}", file=sys.stderr)
+    return 1
+
+
+def git_stdout(args, error_message):
+    result = run_command(["git"] + args)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if detail:
+            return None, f"{error_message}: {detail}"
+        return None, error_message
+    return result.stdout.strip(), None
+
+
+def unstaged_paths():
+    result = run_command(["git", "diff", "--quiet"])
+    if result.returncode == 0:
+        return [], None
+    if result.returncode != 1:
+        detail = (result.stderr or result.stdout).strip()
+        return None, detail or "unable to inspect unstaged changes"
+    output, error = git_stdout(
+        ["diff", "--name-only"], "unable to list unstaged changes"
+    )
+    if error:
+        return None, error
+    return [line for line in output.splitlines() if line.strip()], None
+
+
+def untracked_paths():
+    output, error = git_stdout(
+        ["ls-files", "--others", "--exclude-standard"],
+        "unable to inspect untracked files",
+    )
+    if error:
+        return None, error
+    return [line for line in output.splitlines() if line.strip()], None
+
+
+def git_lines(args, error_message):
+    output, error = git_stdout(args, error_message)
+    if error:
+        return None, error
+    return [line for line in output.splitlines() if line.strip()], None
+
+
+def dirty_worktree_paths():
+    unstaged, error = unstaged_paths()
+    if error:
+        return None, error
+    untracked, error = untracked_paths()
+    if error:
+        return None, error
+    return unstaged + untracked, None
+
+
+def branch_context():
+    branch, error = git_stdout(
+        ["rev-parse", "--abbrev-ref", "HEAD"], "unable to resolve current branch"
+    )
+    if error:
+        return None, None, None, None, error
+    upstream, error = git_stdout(
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        "current branch has no upstream",
+    )
+    if error:
+        return branch, None, None, None, error
+    upstream_ref, error = git_stdout(
+        ["rev-parse", "--symbolic-full-name", "@{u}"],
+        "current branch has no upstream",
+    )
+    if error:
+        return branch, upstream, None, None, error
+    remotes, error = git_lines(["remote"], "unable to list git remotes")
+    if error:
+        return branch, upstream, upstream_ref, None, error
+    return branch, upstream, upstream_ref, remotes, None
+
+
+def push_target(upstream_ref, remotes):
+    prefix = "refs/remotes/"
+    if not upstream_ref or not upstream_ref.startswith(prefix):
+        return None, None, f"invalid upstream branch: {upstream_ref}"
+    relative_ref = upstream_ref[len(prefix) :]
+    matches = []
+    for remote in remotes:
+        remote_prefix = f"{remote}/"
+        if relative_ref.startswith(remote_prefix):
+            branch = relative_ref[len(remote_prefix) :]
+            if branch:
+                matches.append((remote, branch))
+    if not matches:
+        return None, None, f"invalid upstream branch: {upstream_ref}"
+    remote, branch = max(matches, key=lambda item: len(item[0]))
+    return remote, branch, None
+
+
+def has_staged_changes():
+    result = run_command(["git", "diff", "--cached", "--quiet"])
+    if result.returncode == 0:
+        return False, None
+    if result.returncode == 1:
+        return True, None
+    detail = (result.stderr or result.stdout).strip()
+    return None, detail or "unable to inspect staged changes"
+
+
+def validate_safety(args):
+    dirty_paths, error = dirty_worktree_paths()
+    if error:
+        return None, error
+    if dirty_paths:
+        return None, "refusing to run with dirty working tree:\n" + "\n".join(
+            dirty_paths
+        )
+
+    branch, upstream, upstream_ref, remotes, error = branch_context()
+    if error:
+        return None, error
+    remote, upstream_branch, error = push_target(upstream_ref, remotes)
+    if error:
+        return None, error
+
+    if args.mode in {"amend", "commit"}:
+        staged, error = has_staged_changes()
+        if error:
+            return None, error
+        if not staged:
+            action = "amend" if args.mode == "amend" else "commit"
+            return None, f"no staged changes to {action}"
+
+    return {
+        "branch": branch,
+        "upstream": upstream,
+        "remote": remote,
+        "upstream_branch": upstream_branch,
+    }, None
+
+
+def validation_evidence(dry_run):
+    evidence = []
+    for label, command in VALIDATION_COMMANDS:
+        if dry_run:
+            evidence.append((label, "DRY-RUN"))
+            continue
+        result = run_command(command)
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip()
+            raise RuntimeError(f"{label} failed" + (f": {detail}" if detail else ""))
+        evidence.append((label, "PASS"))
+    return evidence
+
+
+def git_update_command(args):
+    if args.mode == "amend":
+        return ["git", "commit", "--amend", "--no-edit"]
+    if args.mode == "commit":
+        return ["git", "commit", "-m", args.message]
+    return None
+
+
+def git_push_command(args, context):
+    remote = context["remote"]
+    refspec = f"HEAD:{context['upstream_branch']}"
+    if args.mode == "amend":
+        return ["git", "push", "--force-with-lease", remote, refspec]
+    if args.mode == "commit":
+        return ["git", "push", remote, refspec]
+    return None
+
+
+def build_comment(args, evidence, context):
+    lines = [
+        args.message,
+        "",
+        "Validation:",
+    ]
+    for label, status in evidence:
+        lines.append(f"- `{label}`: {status}")
+    if args.review:
+        lines.extend(["", "Review evidence:"])
+        for item in args.review:
+            lines.append(f"- {item}")
+    lines.extend(
+        [
+            "",
+            "Update:",
+            f"- mode: `{args.mode}`",
+        ]
+    )
+    push = git_push_command(args, context)
+    if push:
+        lines.append(f"- push: `{shell_join(push)}`")
+    else:
+        lines.append("- push: not requested")
+    return "\n".join(lines) + "\n"
+
+
+def preview(args, evidence, comment, context):
+    commands = [command for _label, command in VALIDATION_COMMANDS]
+    update = git_update_command(args)
+    push = git_push_command(args, context)
+    if update:
+        commands.append(update)
+    if push:
+        commands.append(push)
+    commands.append(["gh", "pr", "comment", str(args.pr), "--body-file", "-"])
+
+    lines = ["DRY RUN", "", "Commands:"]
+    for command in commands:
+        lines.append(f"- {shell_join(command)}")
+    lines.extend(["", "Comment body:", "", comment])
+    return "\n".join(lines)
+
+
+def execute_or_fail(command, *, input_text=None):
+    result = run_command(command, input_text=input_text)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise RuntimeError(
+            shell_join(command) + " failed" + (f": {detail}" if detail else "")
+        )
+
+
+def cmd_pr_update(args):
+    context, error = validate_safety(args)
+    if error:
+        return fail(error)
+
+    try:
+        evidence = validation_evidence(args.dry_run)
+    except RuntimeError as exc:
+        return fail(str(exc))
+
+    comment = build_comment(args, evidence, context)
+    if args.dry_run:
+        print(preview(args, evidence, comment, context))
+        return 0
+
+    try:
+        update = git_update_command(args)
+        if update:
+            execute_or_fail(update)
+        push = git_push_command(args, context)
+        if push:
+            execute_or_fail(push)
+        execute_or_fail(
+            ["gh", "pr", "comment", str(args.pr), "--body-file", "-"],
+            input_text=comment,
+        )
+    except RuntimeError as exc:
+        return fail(str(exc))
+
+    print(f"Updated PR #{args.pr}")
+    return 0
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="pr_update.py",
+        description="Validate, update, push, and comment on a PR safely.",
+        allow_abbrev=False,
+    )
+    parser.add_argument("--pr", required=True, help="GitHub pull request number")
+    parser.add_argument("--message", required=True, help="Concise PR update message")
+    parser.add_argument(
+        "--mode",
+        choices=["amend", "commit", "comment-only"],
+        default="amend",
+        help="Git update mode before posting the PR comment",
+    )
+    parser.add_argument(
+        "--review",
+        action="append",
+        default=[],
+        help="Review evidence line to include in the PR comment; may be repeated",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands and comment preview without running validation, push, or comment side effects",
+    )
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return cmd_pr_update(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rules/TRN-0000-REF-Document-Index.md
+++ b/rules/TRN-0000-REF-Document-Index.md
@@ -34,6 +34,7 @@
 | 2014 | CHG | Provider Health Checks and DeepSeek Review Config |
 | 2015 | CHG | PR Base Head Review Mode |
 | 2016 | CHG | COR-1602 Strict Review Mode |
+| 2017 | CHG | PR Update Helper |
 
 ---
 
@@ -56,3 +57,4 @@
 | 2026-05-04 | Add TRN-2014 Provider Health Checks and DeepSeek Review Config | Codex |
 | 2026-05-04 | Add TRN-2015 PR Base Head Review Mode | Codex |
 | 2026-05-05 | Add TRN-2016 COR-1602 Strict Review Mode | Codex |
+| 2026-05-05 | Add TRN-2017 PR Update Helper | Codex |

--- a/rules/TRN-2017-CHG-PR-Update-Helper.md
+++ b/rules/TRN-2017-CHG-PR-Update-Helper.md
@@ -1,0 +1,105 @@
+# CHG-2017: PR Update Helper
+
+**Applies to:** Trinity project (`frankyxhl/trinity`)
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
+**Status:** Proposed
+**Date:** 2026-05-04
+**Requested by:** Frank
+**Implementer:** Codex
+**Priority:** Low
+**Change Type:** Normal
+**Related:** TRN-1200, TRN-2013, COR-1101, COR-1500, COR-1612, COR-1615
+
+---
+
+## What
+
+Add a small helper for the recurring amended-PR update flow used during CHG
+review rounds: validate, amend or commit, force-push with lease when needed, and
+post a concise PR comment with review/validation evidence.
+
+Candidate interface:
+
+```bash
+make pr-update PR=20 MESSAGE="Address COR-1602 review"
+```
+
+The helper should also support dry-run preview and explicit mode selection:
+
+```bash
+make pr-update PR=20 MESSAGE="Address COR-1602 review" DRY_RUN=1
+make pr-update PR=20 MESSAGE="Address COR-1602 review" MODE=commit
+make pr-update PR=20 MESSAGE="Post validation evidence" MODE=comment-only
+```
+
+---
+
+## Why
+
+During PR #20, the same workflow repeated manually: amend the CHG commit,
+force-push to the fork branch, and comment with COR-1602 results. This is
+low-risk to document or automate, but lower priority than provider health and
+PR-diff review support.
+
+---
+
+## Impact Analysis
+
+- **Systems affected:** Makefile, `dev/`, README/developer docs, and tests
+  for command construction.
+- **Systems intentionally preserved:** normal manual Git/GitHub workflow,
+  draft PR defaults, and branch safety.
+- **Downtime required:** No.
+- **Safety model:** refuse unstaged or untracked files, missing upstream
+  branches, and commit/amend modes with no staged changes. Use
+  `--force-with-lease` only for amend mode, and always push to an explicit
+  upstream refspec.
+- **Rollback plan:** remove helper target/script/docs/tests. Manual git and
+  `gh pr comment` remain available.
+
+---
+
+## Implementation Plan
+
+1. RED: add tests for helper dry-run output with fake `git` and `gh`.
+2. RED: add safety tests: refuses dirty unrelated files, refuses missing PR
+   number, refuses branch without upstream, and uses `--force-with-lease` only
+   after an amend.
+3. GREEN: add helper as a script plus Makefile target with dry-run support.
+4. GREEN: require explicit file staging or clean scope before commit/amend.
+5. GREEN: post PR comment from a template that includes validation and review
+   evidence.
+6. Docs: document manual fallback and when not to use the helper.
+
+---
+
+## Testing / Verification
+
+Expected evidence before marking complete:
+
+- focused fake-git/fake-gh tests
+- dry-run preview of validation, commit/amend, push, and PR comment commands
+- `make test`
+- `make lint`
+- `af validate --root .`
+- dry-run command output inspected before any real push/comment use
+
+---
+
+## Triage Evidence
+
+Trinity improvement triage on 2026-05-04:
+
+- GLM: CREATE_CHG due low implementation cost
+- DeepSeek: CREATE_CHG but low urgency; implement after higher-priority review
+  reliability work
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-05 | Revised CHG with concrete Makefile/script interface, dry-run mode, safety model, and COR-1615/COR-1612 relationship | Codex |
+| 2026-05-04 | Initial CHG for PR update helper | Codex |

--- a/tests/test_pr_update.py
+++ b/tests/test_pr_update.py
@@ -1,0 +1,446 @@
+"""Tests for the TRN-2017 PR update helper."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent.parent
+SCRIPT = ROOT / "dev" / "pr_update.py"
+MAKEFILE = ROOT / "Makefile"
+
+
+def write_fake_commands(fake_bin):
+    fake_bin.mkdir()
+    fake = """#!/usr/bin/env python3
+import os
+import pathlib
+import sys
+
+name = pathlib.Path(sys.argv[0]).name
+args = sys.argv[1:]
+log = pathlib.Path(os.environ["FAKE_COMMAND_LOG"])
+with log.open("a") as handle:
+    handle.write(name + " " + repr(args) + "\\n")
+
+if name == "git":
+    if args == ["diff", "--quiet"]:
+        raise SystemExit(1 if os.environ.get("FAKE_UNSTAGED", "0") == "1" else 0)
+    if args == ["diff", "--name-only"]:
+        sys.stdout.write(os.environ.get("FAKE_UNSTAGED_PATHS", "review.txt\\n"))
+        raise SystemExit(0)
+    if args == ["ls-files", "--others", "--exclude-standard"]:
+        sys.stdout.write(os.environ.get("FAKE_UNTRACKED_PATHS", ""))
+        raise SystemExit(0)
+    if args == ["diff", "--cached", "--quiet"]:
+        raise SystemExit(1 if os.environ.get("FAKE_STAGED", "1") == "1" else 0)
+    if args == ["rev-parse", "--abbrev-ref", "HEAD"]:
+        print(os.environ.get("FAKE_BRANCH", "feature"))
+        raise SystemExit(0)
+    if args == ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]:
+        if os.environ.get("FAKE_UPSTREAM", "1") != "1":
+            print("fatal: no upstream configured", file=sys.stderr)
+            raise SystemExit(128)
+        print(os.environ.get("FAKE_UPSTREAM_NAME", "fork/feature"))
+        raise SystemExit(0)
+    if args == ["rev-parse", "--symbolic-full-name", "@{u}"]:
+        if os.environ.get("FAKE_UPSTREAM", "1") != "1":
+            print("fatal: no upstream configured", file=sys.stderr)
+            raise SystemExit(128)
+        print(os.environ.get("FAKE_UPSTREAM_REF", "refs/remotes/fork/feature"))
+        raise SystemExit(0)
+    if args == ["remote"]:
+        print(os.environ.get("FAKE_REMOTES", "fork"))
+        raise SystemExit(0)
+    if args[:1] in (["commit"], ["push"]):
+        raise SystemExit(0)
+    print(f"unexpected git args: {args}", file=sys.stderr)
+    raise SystemExit(99)
+
+if name == "make":
+    if os.environ.get("FAKE_VALIDATION_FAIL") == "make":
+        raise SystemExit(2)
+    raise SystemExit(0)
+
+if name == "af":
+    if os.environ.get("FAKE_VALIDATION_FAIL") == "af":
+        raise SystemExit(3)
+    raise SystemExit(0)
+
+if name == "gh":
+    if args[:2] == ["pr", "comment"] and "--body-file" in args:
+        body = sys.stdin.read()
+        body_path = pathlib.Path(os.environ["FAKE_COMMENT_BODY"])
+        body_path.write_text(body)
+        raise SystemExit(0)
+    print(f"unexpected gh args: {args}", file=sys.stderr)
+    raise SystemExit(99)
+
+print(f"unexpected command: {name}", file=sys.stderr)
+raise SystemExit(99)
+"""
+    for name in ["git", "make", "af", "gh"]:
+        path = fake_bin / name
+        path.write_text(fake)
+        path.chmod(0o755)
+
+
+def run_helper(tmp_path, args, **env_overrides):
+    fake_bin = tmp_path / "bin"
+    write_fake_commands(fake_bin)
+    log = tmp_path / "commands.log"
+    comment_body = tmp_path / "comment.md"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "FAKE_COMMAND_LOG": str(log),
+            "FAKE_COMMENT_BODY": str(comment_body),
+        }
+    )
+    env.update(env_overrides)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)] + args,
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    log_text = log.read_text() if log.exists() else ""
+    body_text = comment_body.read_text() if comment_body.exists() else ""
+    return result, log_text, body_text
+
+
+def test_pr_update_dry_run_previews_validate_amend_push_and_comment(tmp_path):
+    result, log, body = run_helper(
+        tmp_path,
+        [
+            "--pr",
+            "20",
+            "--message",
+            "Address COR-1602 review",
+            "--review",
+            "Trinity fast-review PASS",
+            "--dry-run",
+        ],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "DRY RUN" in result.stdout
+    assert "make test" in result.stdout
+    assert "make lint" in result.stdout
+    assert "af validate --root ." in result.stdout
+    assert "git commit --amend --no-edit" in result.stdout
+    assert "git push --force-with-lease fork HEAD:feature" in result.stdout
+    assert "gh pr comment 20 --body-file -" in result.stdout
+    assert "Address COR-1602 review" in result.stdout
+    assert "Trinity fast-review PASS" in result.stdout
+    assert "git ['diff', '--quiet']" in log
+    assert body == ""
+
+
+def test_pr_update_refuses_dirty_worktree_before_side_effects(tmp_path):
+    result, log, body = run_helper(
+        tmp_path,
+        ["--pr", "20", "--message", "Address review", "--dry-run"],
+        FAKE_UNTRACKED_PATHS="tmp/local.txt\n",
+    )
+
+    assert result.returncode == 1
+    assert "refusing to run with dirty working tree" in result.stderr
+    assert "tmp/local.txt" in result.stderr
+    assert "git ['commit'" not in log
+    assert "gh ['pr', 'comment'" not in log
+    assert body == ""
+
+
+def test_pr_update_refuses_missing_upstream_before_side_effects(tmp_path):
+    result, log, body = run_helper(
+        tmp_path,
+        ["--pr", "20", "--message", "Address review", "--dry-run"],
+        FAKE_UPSTREAM="0",
+    )
+
+    assert result.returncode == 1
+    assert "current branch has no upstream" in result.stderr
+    assert "git ['commit'" not in log
+    assert "gh ['pr', 'comment'" not in log
+    assert body == ""
+
+
+def test_pr_update_refuses_missing_staged_changes_for_amend(tmp_path):
+    result, log, body = run_helper(
+        tmp_path,
+        ["--pr", "20", "--message", "Address review", "--dry-run"],
+        FAKE_STAGED="0",
+    )
+
+    assert result.returncode == 1
+    assert "no staged changes to amend" in result.stderr
+    assert "git ['commit'" not in log
+    assert "gh ['pr', 'comment'" not in log
+    assert body == ""
+
+
+def test_pr_update_refuses_missing_staged_changes_for_commit(tmp_path):
+    result, log, body = run_helper(
+        tmp_path,
+        [
+            "--pr",
+            "20",
+            "--message",
+            "Address review",
+            "--mode",
+            "commit",
+            "--dry-run",
+        ],
+        FAKE_STAGED="0",
+    )
+
+    assert result.returncode == 1
+    assert "no staged changes to commit" in result.stderr
+    assert "git ['commit'" not in log
+    assert "gh ['pr', 'comment'" not in log
+    assert body == ""
+
+
+def test_pr_update_uses_plain_push_for_new_commit_mode(tmp_path):
+    result, _log, _body = run_helper(
+        tmp_path,
+        [
+            "--pr",
+            "20",
+            "--message",
+            "Address review",
+            "--mode",
+            "commit",
+            "--dry-run",
+        ],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "git commit -m 'Address review'" in result.stdout
+    assert "git push fork HEAD:feature\n" in result.stdout
+    assert "git push --force-with-lease" not in result.stdout
+
+
+def test_pr_update_parses_upstream_when_remote_name_contains_slash(tmp_path):
+    result, _log, _body = run_helper(
+        tmp_path,
+        [
+            "--pr",
+            "20",
+            "--message",
+            "Address review",
+            "--dry-run",
+        ],
+        FAKE_REMOTES="foo\nfoo/bar\n",
+        FAKE_UPSTREAM_NAME="foo/bar/main",
+        FAKE_UPSTREAM_REF="refs/remotes/foo/bar/main",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "git push --force-with-lease foo/bar HEAD:main" in result.stdout
+
+
+def test_pr_update_executes_fake_commands_and_posts_comment_body(tmp_path):
+    result, log, body = run_helper(
+        tmp_path,
+        [
+            "--pr",
+            "20",
+            "--message",
+            "Address review",
+            "--review",
+            "GLM PASS 9.2/10",
+        ],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "make ['test']" in log
+    assert "make ['lint']" in log
+    assert "af ['validate', '--root', '.']" in log
+    assert "git ['commit', '--amend', '--no-edit']" in log
+    assert "git ['push', '--force-with-lease', 'fork', 'HEAD:feature']" in log
+    assert "gh ['pr', 'comment', '20', '--body-file', '-']" in log
+    assert "Address review" in body
+    assert "- `make test`: PASS" in body
+    assert "- `make lint`: PASS" in body
+    assert "- `af validate --root .`: PASS" in body
+    assert "GLM PASS 9.2/10" in body
+
+
+def test_pr_update_comment_only_skips_commit_and_push_but_posts_comment(tmp_path):
+    result, log, body = run_helper(
+        tmp_path,
+        [
+            "--pr",
+            "20",
+            "--message",
+            "Post validation evidence",
+            "--mode",
+            "comment-only",
+            "--review",
+            "No actionable findings",
+        ],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "make ['test']" in log
+    assert "make ['lint']" in log
+    assert "af ['validate', '--root', '.']" in log
+    assert "git ['commit'" not in log
+    assert "git ['push'" not in log
+    assert "gh ['pr', 'comment', '20', '--body-file', '-']" in log
+    assert "Post validation evidence" in body
+    assert "- mode: `comment-only`" in body
+    assert "- push: not requested" in body
+    assert "No actionable findings" in body
+
+
+def test_pr_update_preserves_special_characters_in_comment_body(tmp_path):
+    message = "Fix `null` deref: keep $VAR literal"
+    result, _log, body = run_helper(
+        tmp_path,
+        [
+            "--pr",
+            "20",
+            "--message",
+            message,
+            "--mode",
+            "comment-only",
+        ],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert message in body
+
+
+def test_pr_update_includes_multiple_review_lines(tmp_path):
+    result, _log, body = run_helper(
+        tmp_path,
+        [
+            "--pr",
+            "20",
+            "--message",
+            "Post validation evidence",
+            "--mode",
+            "comment-only",
+            "--review",
+            "GLM PASS",
+            "--review",
+            "DeepSeek PASS",
+        ],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "- GLM PASS" in body
+    assert "- DeepSeek PASS" in body
+
+
+def test_pr_update_stops_on_validation_failure_before_push_or_comment(tmp_path):
+    result, log, body = run_helper(
+        tmp_path,
+        ["--pr", "20", "--message", "Address review"],
+        FAKE_VALIDATION_FAIL="make",
+    )
+
+    assert result.returncode == 1
+    assert "make test failed" in result.stderr
+    assert "make ['test']" in log
+    assert "git ['commit'" not in log
+    assert "git ['push'" not in log
+    assert "gh ['pr', 'comment'" not in log
+    assert body == ""
+
+
+def test_pr_update_requires_pr_number(tmp_path):
+    result, _log, _body = run_helper(
+        tmp_path,
+        ["--message", "Address review", "--dry-run"],
+    )
+
+    assert result.returncode == 2
+    assert "the following arguments are required: --pr" in result.stderr
+
+
+def test_makefile_documents_pr_update_target():
+    text = MAKEFILE.read_text()
+
+    assert ".PHONY:" in text
+    assert "pr-update" in text
+    assert "dev/pr_update.py" in text
+    assert "scripts/pr_update.py" not in text
+    assert "MODE ?= amend" in text
+    assert "DRY_RUN=1" in text
+    assert "$(filter 1 true yes,$(DRY_RUN))" in text
+    assert ".venv/bin/ruff check dev/ scripts/ tests/" in text
+    assert ".venv/bin/ruff format --check dev/ scripts/ tests/" in text
+
+
+def test_makefile_dry_run_zero_does_not_enable_dry_run():
+    result = subprocess.run(
+        ["make", "-n", "pr-update", "PR=20", "MESSAGE=Address review", "DRY_RUN=0"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--dry-run" not in result.stdout
+
+    enabled = subprocess.run(
+        ["make", "-n", "pr-update", "PR=20", "MESSAGE=Address review", "DRY_RUN=1"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert enabled.returncode == 0, enabled.stderr
+    assert "--dry-run" in enabled.stdout
+
+
+def test_makefile_pr_update_preserves_literal_dollars_in_text_args(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log = tmp_path / "python.log"
+    fake_python = fake_bin / "python3"
+    fake_python.write_text(
+        f"""#!{sys.executable}
+import os
+import pathlib
+import sys
+
+pathlib.Path(os.environ["FAKE_PYTHON_LOG"]).write_text(repr(sys.argv[1:]))
+"""
+    )
+    fake_python.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "FAKE_PYTHON_LOG": str(log),
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+        }
+    )
+    result = subprocess.run(
+        [
+            "make",
+            "pr-update",
+            "PR=20",
+            "MESSAGE=Fix $VAR and $(MODEL) literal",
+            "REVIEW=Keep ${TEMPLATE} literal",
+            "MODE=comment-only",
+            "DRY_RUN=1",
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    args = log.read_text()
+    assert "'--message', 'Fix $VAR and $(MODEL) literal'" in args
+    assert "'--review', 'Keep ${TEMPLATE} literal'" in args


### PR DESCRIPTION
## Summary
- Add `dev/pr_update.py`, a guarded helper for validating, updating, pushing, and commenting on PRs.
- Add `make pr-update` with dry-run support and explicit amend/commit/comment-only modes.
- Document the helper workflow and add CHG/index coverage for TRN-2017.
- Add focused tests for dry-run previews, dirty worktree refusal, upstream/staged-change guards, validation failure handling, push mode behavior, and PR comment content.

## Validation
- `make test`
- `make lint`
- `af validate --root .`
- `git diff --check`
- Temp-repo dry-run smoke for real git upstream/push preview behavior

## Review Evidence
- Trinity fast-review with `glm`: PASS, no blocking issues.
- Trinity fast-review with `deepseek`: PASS, no blocking issues.
