### PR TITLE
TRN-2019 fast review parallel progress

### DIFF
--- a/.agents/skills/trinity/SKILL.md
+++ b/.agents/skills/trinity/SKILL.md
@@ -40,6 +40,11 @@ trinity review --sop COR-1602 --rubric COR-1609 --pr 21 --preset deep-review
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
 `.agents/trinity.codex.json`. It calls provider CLIs directly, saves raw outputs,
 and writes a deterministic synthesis markdown under `.trinity/reviews/`.
+Review providers run concurrently up to `review.max_parallel_providers`
+(default: selected provider count). Progress is written to stderr; stdout
+remains the review directory path. Interrupted reviews that cannot write final
+metadata and synthesis are marked with `incomplete.json` in the review
+directory.
 The review preset resolver selects providers from explicit `--providers`,
 explicit `--preset`, `review.default_preset`, then legacy
 `review.default_providers`. `review` expands to `glm`, `gemini`, and

--- a/README.md
+++ b/README.md
@@ -268,12 +268,17 @@ branch changes from `git diff base...head` and snapshots changed files from the
 head commit. With `--pr`, it uses `gh pr view` / `gh pr diff` for the GitHub PR
 patch and metadata, then snapshots changed files from the PR head commit when
 that commit is locally available. All modes call each provider CLI directly,
-store raw provider outputs, and write a deterministic `synthesis.md` under
-`.trinity/reviews/`. Selected providers are preflighted before output
-directories are created. If a preset has optional providers that are not
-configured or have no CLI, they are skipped with a stderr warning and recorded
-in `metadata.json`; required providers still fail preflight when unavailable.
-This path does not require Claude Code worker-agent files.
+run selected providers concurrently up to
+`review.max_parallel_providers` (default: selected provider count), store raw
+provider outputs, and write a deterministic `synthesis.md` under
+`.trinity/reviews/`. Progress is logged to stderr, while stdout remains the
+review directory path. If a review is interrupted before final artifacts are
+written, the review directory contains `incomplete.json` with cleanup details.
+Selected providers are preflighted before output directories are created. If a
+preset has optional providers that are not configured or have no CLI, they are
+skipped with a stderr warning and recorded in `metadata.json`; required
+providers still fail preflight when unavailable. This path does not require
+Claude Code worker-agent files.
 
 Strict COR review mode is enabled by pairing `--sop` and `--rubric`. The first
 supported template is `COR-1602` with the `COR-1609` CHG rubric. It prepends

--- a/plugins/trinity/skills/trinity/SKILL.md
+++ b/plugins/trinity/skills/trinity/SKILL.md
@@ -40,6 +40,11 @@ trinity review --sop COR-1602 --rubric COR-1609 --pr 21 --preset deep-review
 The wrapper loads `~/.codex/trinity.json`, whose repo default lives at
 `.agents/trinity.codex.json`. It calls provider CLIs directly, saves raw outputs,
 and writes a deterministic synthesis markdown under `.trinity/reviews/`.
+Review providers run concurrently up to `review.max_parallel_providers`
+(default: selected provider count). Progress is written to stderr; stdout
+remains the review directory path. Interrupted reviews that cannot write final
+metadata and synthesis are marked with `incomplete.json` in the review
+directory.
 The review preset resolver selects providers from explicit `--providers`,
 explicit `--preset`, `review.default_preset`, then legacy
 `review.default_providers`. `review` expands to `glm`, `gemini`, and

--- a/rules/TRN-0000-REF-Document-Index.md
+++ b/rules/TRN-0000-REF-Document-Index.md
@@ -35,6 +35,7 @@
 | 2015 | CHG | PR Base Head Review Mode |
 | 2016 | CHG | COR-1602 Strict Review Mode |
 | 2017 | CHG | PR Update Helper |
+| 2019 | CHG | Fast Review Parallelism and Progress |
 
 ---
 
@@ -58,3 +59,4 @@
 | 2026-05-04 | Add TRN-2015 PR Base Head Review Mode | Codex |
 | 2026-05-05 | Add TRN-2016 COR-1602 Strict Review Mode | Codex |
 | 2026-05-05 | Add TRN-2017 PR Update Helper | Codex |
+| 2026-05-05 | Add TRN-2019 Fast Review Parallelism and Progress | Codex |

--- a/rules/TRN-2019-CHG-Fast-Review-Parallelism-and-Progress.md
+++ b/rules/TRN-2019-CHG-Fast-Review-Parallelism-and-Progress.md
@@ -1,0 +1,486 @@
+# CHG-2019: Fast Review Parallelism and Progress
+
+**Applies to:** Trinity project (`frankyxhl/trinity`)
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
+**Status:** Proposed
+**Date:** 2026-05-05
+**Requested by:** Frank
+**Implementer:** Codex
+**Priority:** High
+**Change Type:** Normal
+**Related:** GitHub issue #27, TRN-2011, TRN-2013, TRN-2015, TRN-2017, COR-1202, COR-1615
+
+---
+
+## What
+
+Improve Codex-native `trinity review` so independent review providers can run
+concurrently and operators can see progress while reviews are running.
+
+Target user-facing behavior:
+
+```bash
+trinity review --preset fast-review --scope TRN-2019
+```
+
+For a preset such as `fast-review` that expands to `glm` and `deepseek`, Trinity
+should start both providers in the same review run, wait for both results, and
+write the same final artifacts it writes today:
+
+- `prompt.md`
+- `raw/<provider>.txt`
+- `metadata.json`
+- `synthesis.md`
+
+The change also adds explicit progress logging and safer process cleanup for
+provider CLIs that spawn child processes.
+
+---
+
+## Why
+
+Issue #27 reports that `fast-review` is slow because provider execution is
+sequential. Recent review metadata confirms the behavior: GLM finished at
+`2026-05-05T21:29:45`, and DeepSeek started at exactly
+`2026-05-05T21:29:45`. That makes wall-clock time roughly
+`glm_time + deepseek_time` instead of `max(glm_time, deepseek_time)`.
+
+The same issue makes operator feedback worse. A review can sit silently for
+several minutes, and a timeout or interrupt may only affect the direct wrapper
+process while provider child processes keep running.
+
+---
+
+## Current Evidence
+
+Implementation evidence from `scripts/codex.py`:
+
+- `cmd_review()` iterates providers with `for provider in providers`.
+- Each iteration calls `run_provider()` and waits for completion before the next
+  provider starts.
+- `run_provider()` uses `subprocess.run(..., timeout=timeout)`, which does not
+  create a dedicated process group/session for provider wrappers.
+- `metadata.json` and `synthesis.md` are written only after every selected
+  provider has returned.
+
+Observed metadata from final TRN-2017 review:
+
+```text
+glm      started 2026-05-05T21:26:47  finished 2026-05-05T21:29:45
+deepseek started 2026-05-05T21:29:45  finished 2026-05-05T21:32:19
+```
+
+Numbering note: TRN-2018 is intentionally not reused here because a separate
+review observability draft exists outside `main`. This issue #27 plan uses
+TRN-2019 to avoid overwriting that earlier work.
+
+---
+
+## Scope
+
+### In Scope
+
+1. Run selected review providers concurrently when `trinity review` dispatches
+   independent provider CLIs.
+2. Preserve deterministic result ordering in `metadata.json` and `synthesis.md`
+   according to the resolved provider order, even if providers finish in a
+   different order.
+3. Add progress logging to stderr, at minimum:
+   - preparing prompt
+   - writing prompt
+   - starting each provider with timeout
+   - provider finished / failed / timed out
+   - writing metadata and synthesis
+4. Write an incomplete marker when a review exits before final metadata or
+   synthesis is written.
+5. Run provider subprocesses in their own process group/session and kill the
+   whole process group on timeout or interruption.
+6. Add a review-only prompt instruction that tells providers not to run tests or
+   shell commands unless explicitly requested by the review prompt.
+
+### Out of Scope
+
+- Detached/background review mode.
+- `trinity status --latest`.
+- Watch mode.
+- Provider result streaming into live UI.
+- Changing provider presets or provider model configuration.
+- Parsing reviewer PASS/FIX semantics from raw output.
+
+These are valuable, but they should remain separate from the latency and
+cleanup fix so this change stays reviewable.
+
+---
+
+## Design Notes
+
+### Concurrency Model
+
+Use a small standard-library concurrency layer around provider execution. The
+preferred implementation is `concurrent.futures.ThreadPoolExecutor` because
+provider work is subprocess-bound, not CPU-bound.
+
+Concurrency limit:
+
+- default: number of selected providers
+- optional config key: `config["review"]["max_parallel_providers"]`
+- minimum accepted value: `1`
+- when omitted or `null`, use the number of selected providers
+- reject `0`, negative numbers, non-integers, booleans, and values larger than
+  the number of selected providers
+
+Provider results should be collected by future completion, then sorted back into
+the resolved provider order before writing metadata and synthesis.
+
+Dispatch should be bounded to the current concurrency limit. Submit only the
+currently running provider window, then submit the next provider after one
+result completes. Do not queue every selected provider up front; on an interrupt
+or orchestration error, queued providers must not start after cleanup has
+already been snapshotted.
+
+Use `ThreadPoolExecutor` without relying on its default context-manager shutdown
+behavior for interrupt cleanup. The implementation must keep explicit handles to
+active provider processes and must run cleanup from a `finally` block:
+
+1. On normal completion, wait for all futures.
+2. On `KeyboardInterrupt` or fatal orchestration error, cancel not-yet-started
+   futures, terminate/kill all active provider process groups, then shut down
+   the executor without waiting for natural provider completion.
+3. Return only after active provider process groups have been cleaned up or the
+   kill grace period has expired.
+
+Thread-to-process ownership must be explicit. Provider workers create `Popen`
+objects, but cleanup is orchestrated from the main thread. Track active
+processes in a small shared registry guarded by `threading.Lock`:
+
+- worker adds `(provider, popen, started_at)` immediately after successful
+  `Popen()` creation;
+- registry also records a provider in a monotonic started-provider set that is
+  not removed when the provider finishes;
+- worker removes that entry in its own `finally` block after `communicate()` or
+  cleanup finishes;
+- main-thread cleanup copies the active entries while holding the lock, releases
+  the lock, then signals process groups from that snapshot.
+
+Do not hold the lock while waiting for process termination. That avoids blocking
+workers that are trying to remove completed process handles.
+
+Running futures cannot be cancelled by `Future.cancel()` once their provider
+process has started, and workers may be blocked in `Popen.communicate()`. On
+interrupt, cleanup must therefore kill active process groups first, which
+unblocks `communicate()`, and only then shut down the executor.
+
+Provider failures are independent. If one provider times out or returns a
+non-zero exit code while another provider is still running, Trinity should let
+the other running provider finish or hit its own timeout. Final artifacts should
+include every provider result that reached a terminal state. The command returns
+`0` only when all selected providers return `0`; otherwise it returns non-zero.
+This is a completed review with failed provider results, not an incomplete
+review. `incomplete.json` is reserved for orchestration failures or interrupts
+that prevent final `metadata.json` or `synthesis.md` from being written.
+
+### Process Group Cleanup
+
+Replace direct `subprocess.run()` provider execution with explicit `Popen`
+management:
+
+- POSIX/macOS: start provider with `start_new_session=True`.
+- On timeout: terminate the provider process group first, wait up to 5 seconds,
+  then kill the process group if it does not exit.
+- On `KeyboardInterrupt` or wrapper interruption: terminate/kill every still
+  running provider process group before returning.
+- Treat an already-exited process group as successful cleanup, and record
+  cleanup errors such as `permission_denied` instead of masking them.
+- Preserve return code `124` for timeouts.
+- Preserve return code `127` for command-not-found.
+- Windows process-group behavior is out of scope for this CHG. Trinity's current
+  supported operator environment is macOS/POSIX; a future CHG can add Windows
+  process group support if needed.
+- Process-group cleanup relies on provider wrappers and their children staying
+  in the session started by Trinity. A wrapper that deliberately starts its own
+  detached session may need its own cleanup logic or a future doctor smoke test.
+
+Raw provider file writes may remain inside the provider worker because each
+provider writes to a unique `raw/<provider>.txt` path. Main-process writes are
+required for shared artifacts only: `metadata.json`, `synthesis.md`, and
+`incomplete.json`.
+
+### Progress Logging
+
+Progress messages go to stderr so stdout can remain the review directory path
+on success. If an interrupt or orchestration failure happens after the review
+directory exists, stdout still prints that review directory so operators and
+scripts can inspect `incomplete.json`. Preflight/config failures before
+directory creation keep stdout empty.
+
+Provider stdout/stderr should not be forwarded live to the operator terminal in
+this CHG. Concurrent provider logs can interleave and become noisy; raw provider
+output remains available in `raw/<provider>.txt`.
+
+Example:
+
+```text
+trinity: preparing review prompt
+trinity: starting provider glm timeout=360s
+trinity: starting provider deepseek timeout=600s
+trinity: provider glm finished returncode=0 elapsed=126s
+trinity: provider deepseek finished returncode=0 elapsed=185s
+trinity: writing metadata
+trinity: writing synthesis
+```
+
+### Incomplete Marker
+
+Create `incomplete.json` only when the review is interrupted or an orchestration
+failure prevents final artifacts from being written. Avoid creating it on the
+success path; do not write and then delete a transient incomplete marker during
+normal execution.
+
+Minimum contents:
+
+- status: `interrupted`, `failed`, or `timed_out`
+- timestamp
+- review directory path
+- selected providers
+- providers already started
+- providers still running when cleanup began
+- cleanup result
+
+Example:
+
+```json
+{
+  "status": "interrupted",
+  "timestamp": "2026-05-05T22:30:00",
+  "review_dir": ".trinity/reviews/20260505-223000-TRN-2019",
+  "providers_selected": ["glm", "deepseek"],
+  "providers_started": ["glm", "deepseek"],
+  "providers_running_at_cleanup": ["deepseek"],
+  "cleanup": {
+    "deepseek": {
+      "pid": 12345,
+      "result": "terminated"
+    }
+  }
+}
+```
+
+Successful reviews must not leave the incomplete marker behind.
+
+### Review-Only Prompt Mode
+
+Add a concise instruction to the review prompt:
+
+```text
+Review-only mode: do not run tests, shell commands, network calls, or mutate
+files unless the instructions in this review prompt explicitly ask you to. Base
+findings only on the provided diff, file snapshots, and review context.
+```
+
+This should be default behavior for `trinity review`. A future CHG can add an
+explicit opt-in for tool-running reviewers if needed.
+
+This changes prompt content but does not change prompt input modes. Existing
+working-tree, `--base/--head`, and `--pr` review inputs remain supported.
+
+---
+
+## Milestones
+
+### Milestone 1: Parallel Provider Dispatch
+
+Goal: reduce `fast-review` wall-clock time from additive provider latency to
+approximately the slowest provider latency.
+
+Tasks:
+
+1. RED: add a fake-provider test where `glm` and `deepseek` each sleep, proving
+   wall-clock duration is less than their summed sleeps.
+2. RED: assert both providers are started before either slow provider completes.
+3. GREEN: add concurrent provider dispatch with deterministic result ordering.
+4. GREEN: add `config["review"]["max_parallel_providers"]` parsing and tests,
+   defaulting to the number of selected providers when unset.
+5. RED: add a mixed-success test where one provider succeeds and one provider
+   fails or times out; assert deterministic result ordering and non-zero command
+   return.
+6. RED/GREEN: reject duplicate explicit or legacy default provider selections
+   before creating a review directory so one provider result cannot overwrite
+   another result keyed by the same provider name.
+7. GREEN: preserve existing raw output, metadata, synthesis, and return-code
+   behavior.
+8. REFACTOR: keep prompt/rendering code separate from dispatch code.
+
+### Milestone 2: Progress Logging
+
+Goal: make long-running reviews visibly alive.
+
+Tasks:
+
+1. RED: add tests for stderr progress messages.
+2. GREEN: log prompt preparation, provider start, provider finish/fail/timeout,
+   and final artifact writes.
+3. GREEN: ensure stdout remains stable enough for scripts that expect the final
+   review directory path.
+4. Docs: document progress logs in README and the Codex Trinity skill.
+
+### Milestone 3: Process Group Timeout and Interrupt Cleanup
+
+Goal: prevent provider wrapper children from surviving timeouts or interrupts.
+
+Tasks:
+
+1. RED: add fake wrapper tests that spawn a child process and then sleep.
+2. RED: prove timeout cleanup terminates the child process group.
+3. RED: prove interrupt cleanup does not wait for providers to finish
+   naturally. Preferred test approach: launch the Trinity review command in a
+   subprocess with fake providers, send SIGINT to the Trinity process, and
+   assert provider child processes are terminated and `providers_started`
+   remains distinct from `providers_running_at_cleanup`.
+4. GREEN: start providers in new sessions/process groups.
+5. GREEN: terminate then kill remaining provider groups on timeout.
+6. GREEN: cleanup all active providers on `KeyboardInterrupt`.
+7. GREEN: preserve `124` for provider timeouts and `127` for command-not-found
+   while using `Popen`.
+
+### Milestone 4: Incomplete Review Artifacts
+
+Goal: make partial review directories self-describing.
+
+Tasks:
+
+1. RED: add tests for interrupted and pre-synthesis failure cases, including an
+   interruption after review directory creation but before provider dispatch.
+2. GREEN: write `incomplete.json` before cleanup returns failure.
+3. GREEN: remove or avoid writing `incomplete.json` on successful reviews.
+4. GREEN: catch `KeyboardInterrupt` after review directory creation but before
+   provider dispatch, write `incomplete.json`, and print the review directory.
+5. GREEN: catch `KeyboardInterrupt` or final artifact write failures during
+   `metadata.json` / `synthesis.md` creation, mark the review incomplete, and
+   print the review directory.
+6. Docs: explain how to inspect incomplete review directories.
+
+### Milestone 5: Review-Only Prompt Instruction
+
+Goal: make review provider behavior explicit and low-risk.
+
+Tasks:
+
+1. RED: add prompt tests proving review-only instruction is present.
+2. GREEN: add instruction to review prompt construction.
+3. Docs: document when reviewers should not run commands and how future opt-in
+   could work.
+
+---
+
+## Implementation Plan
+
+1. Branch from current `main` after TRN-2017 is merged.
+2. Add tests first for concurrency, progress logging, process group cleanup,
+   incomplete markers, and prompt text.
+3. Put the concurrency/process-management tests in a new module,
+   `tests/test_codex_review_dispatch.py`, while keeping prompt/input-mode tests
+   in `tests/test_codex_adapter.py` when they reuse existing helpers.
+   Put `incomplete.json` orchestration tests in
+   `tests/test_codex_review_dispatch.py`.
+4. Implement provider dispatch as a small orchestration layer around existing
+   `run_provider()` behavior.
+5. Preserve provider health checks and review input collection before dispatch.
+6. Preserve current artifact compatibility:
+   - `metadata.providers` remains a list.
+   - `metadata.results[]` entries keep `provider`, `returncode`, `raw`,
+     `started_at`, and `finished_at`.
+   - `raw/<provider>.txt` still contains stdout followed by optional
+     `\n[stderr]\n`.
+   - `synthesis.md` remains deterministic.
+7. Add docs for progress logs, `incomplete.json`, and expected fast-review
+   latency behavior.
+8. Review the CHG and implementation with Trinity fast-review before PR.
+9. After PR creation, follow COR-1615 for GitHub connector review and route
+   actionable findings through COR-1612.
+
+---
+
+## Testing / Verification
+
+Expected evidence before marking implementation complete:
+
+- Focused pytest tests for concurrent dispatch with fake providers.
+- Focused pytest tests for deterministic result ordering.
+- Focused pytest tests for mixed provider success/failure behavior.
+- Focused pytest tests for progress messages on stderr.
+- Focused pytest tests for timeout cleanup of provider child processes.
+- Focused pytest tests for incomplete marker creation and successful cleanup.
+- Focused pytest tests for pre-dispatch interrupts after review directory
+  creation.
+- Focused pytest tests for late interrupts during final artifact writes.
+- Focused pytest tests proving queued providers do not start after orchestration
+  failure when `max_parallel_providers` is smaller than selected providers.
+- Prompt test for review-only instruction.
+- Config test for `config["review"]["max_parallel_providers"]`.
+- Config validation tests for invalid parallelism values.
+- Duplicate selected-provider validation tests for explicit `--providers` and
+  legacy `review.default_providers`.
+- `incomplete.json` schema assertions for status, review directory, selected
+  providers, running providers, and cleanup map.
+- `.venv/bin/pytest tests/test_codex_adapter.py -q`
+- `.venv/bin/pytest tests/test_codex_compat.py -q`
+- `.venv/bin/pytest tests/test_codex_review_dispatch.py -q`
+- `make test`
+- `make lint`
+- `af validate --root .`
+- `trinity doctor --preset fast-review`
+- A low-risk `trinity review --preset fast-review --base main --head HEAD`
+  smoke run showing providers start together.
+
+---
+
+## Impact Analysis
+
+- **Systems affected:** `scripts/codex.py`, review artifact creation,
+  `trinity review` runtime behavior, README/Codex skill docs, and tests.
+- **Systems intentionally preserved:** preset resolution, provider health
+  checks, prompt input modes, raw output paths, metadata compatibility, and
+  synthesis format.
+- **Downtime required:** No.
+- **Backward compatibility:** Existing successful review artifacts remain
+  readable. New artifacts may include additional progress/incomplete metadata,
+  but existing top-level metadata keys must remain compatible.
+- **Prompt behavior:** Review prompt content changes by adding review-only
+  no-command guidance. This is intentional and applies to all `trinity review`
+  input modes unless a future CHG adds an opt-out.
+- **Main risks:** concurrency introduces race conditions, timeout cleanup can be
+  platform-sensitive, progress logging may break scripts if written to stdout,
+  prompt behavior may change reviewer habits, and process-group cleanup could
+  terminate too broadly if scoped incorrectly.
+- **Risk controls:** use stderr for progress, isolate provider process groups,
+  keep shared artifact writes in the main process, add fake-provider tests for
+  edge cases, and preserve deterministic output ordering.
+- **Rollback plan:** revert dispatch/progress/cleanup changes and restore
+  sequential `run_provider()` loop. Existing provider configs and artifacts do
+  not require migration.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `fast-review` starts required providers concurrently.
+- [ ] Wall-clock time for fake slow providers is closer to max latency than sum
+      latency.
+- [ ] Progress messages identify provider start and completion/failure/timeout.
+- [ ] Timeout cleanup terminates provider child processes.
+- [ ] Interrupted or failed partial reviews are marked incomplete.
+- [ ] Successful reviews keep existing `metadata.json`, `raw/`, and
+      `synthesis.md` compatibility.
+- [ ] Review prompt includes review-only no-command guidance.
+- [ ] Tests, lint, `af validate`, and Trinity fast-review pass.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-05 | Revised after second Trinity fast-review to define active `Popen` registry locking, independent provider failure semantics, cleanup ordering rationale, stderr handling, config validation, and incomplete-marker test scope | Codex |
+| 2026-05-05 | Revised after Trinity fast-review to specify `incomplete.json`, interrupt-safe executor shutdown, 5-second process-group kill grace, POSIX scope, config/test locations, and prompt impact | Codex |
+| 2026-05-05 | Initial CHG for issue #27 fast-review parallelism, progress, incomplete markers, process-group cleanup, and review-only prompt mode | Codex |

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -2,6 +2,7 @@
 """Codex-native Trinity command wrapper."""
 
 import argparse
+import concurrent.futures
 import datetime as dt
 import difflib
 import importlib.util
@@ -11,8 +12,11 @@ from pathlib import Path
 import re
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
+import threading
+import time
 
 
 DEFAULT_CONFIG = Path("~/.codex/trinity.json").expanduser()
@@ -32,6 +36,13 @@ STRICT_REVIEW_OUTPUT_SCHEMA = [
 STRICT_REVIEW_DECISION_RULE = (
     "PASS when weighted_average >= 9.0 and no blocking findings remain; otherwise FIX."
 )
+REVIEW_ONLY_INSTRUCTION = (
+    "## Review-Only Mode\n\n"
+    "Do not run tests, shell commands, network calls, or mutate files unless the "
+    "instructions in this review prompt explicitly ask you to. Base findings only "
+    "on the provided diff, file snapshots, and review context.\n"
+)
+PROCESS_GROUP_KILL_GRACE_SECONDS = 5
 STRICT_REVIEW_TEMPLATES = {
     ("COR-1602", "COR-1609"): {
         "pass_threshold": 9.0,
@@ -203,6 +214,20 @@ def append_unique(items, value):
         items.append(value)
 
 
+def reject_duplicate_providers(providers):
+    seen = set()
+    duplicates = []
+    for provider in providers:
+        if provider in seen and provider not in duplicates:
+            duplicates.append(provider)
+        seen.add(provider)
+    if duplicates:
+        raise SystemExit(
+            "trinity: duplicate provider selected: " + ", ".join(duplicates)
+        )
+    return providers
+
+
 def resolve_preset_providers(config, requested, source):
     resolved, preset = resolve_preset_name(config, requested, source)
     if not isinstance(preset, dict):
@@ -266,6 +291,7 @@ def resolve_review_providers(args, config):
         providers = split_provider_csv(args.providers)
         if not providers:
             raise SystemExit("trinity-codex: no providers selected")
+        reject_duplicate_providers(providers)
         warnings = []
         if args.preset:
             warnings.append(
@@ -294,6 +320,7 @@ def resolve_review_providers(args, config):
     providers = review_config.get("default_providers", [])
     if not providers:
         raise SystemExit("trinity-codex: no providers selected")
+    reject_duplicate_providers(providers)
     return (
         providers,
         {
@@ -868,9 +895,11 @@ def render_prompt(config, root, scope, review_input, strict_review=None):
         .replace("{files}", files)
     )
     if strict_review is None:
-        return prompt
+        return REVIEW_ONLY_INSTRUCTION + "\n" + prompt
     return (
         render_strict_review_instructions(strict_review)
+        + "\n"
+        + REVIEW_ONLY_INSTRUCTION
         + "\n## Review Artifact\n\n"
         + prompt
     )
@@ -913,7 +942,143 @@ def build_prompt_handoff(prompt_path):
     )
 
 
-def run_provider(provider, provider_config, prompt_path, review_dir, root):
+def progress(message):
+    print(f"trinity: {message}", file=sys.stderr, flush=True)
+
+
+def timestamp():
+    return dt.datetime.now().isoformat(timespec="seconds")
+
+
+def elapsed_seconds(started):
+    return max(0, int(time.monotonic() - started))
+
+
+class ActiveProcessRegistry:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._items = {}
+        self._started = set()
+
+    def add(self, provider, popen, started_at):
+        with self._lock:
+            self._started.add(provider)
+            self._items[provider] = {
+                "provider": provider,
+                "pid": popen.pid,
+                "popen": popen,
+                "started_at": started_at,
+            }
+
+    def remove(self, provider, popen):
+        with self._lock:
+            current = self._items.get(provider)
+            if current is not None and current["popen"] is popen:
+                self._items.pop(provider, None)
+
+    def snapshot(self):
+        with self._lock:
+            return list(self._items.values())
+
+    def started_providers(self):
+        with self._lock:
+            return set(self._started)
+
+
+class ReviewInterrupted(Exception):
+    def __init__(self, cleanup, started_providers):
+        super().__init__("review interrupted")
+        self.cleanup = cleanup
+        self.started_providers = started_providers
+
+
+class ReviewOrchestrationError(Exception):
+    def __init__(self, message, cleanup, started_providers):
+        super().__init__(message)
+        self.cleanup = cleanup
+        self.started_providers = started_providers
+
+
+def process_group_id(popen):
+    try:
+        return os.getpgid(popen.pid)
+    except ProcessLookupError:
+        return None
+    except PermissionError:
+        return "permission_denied"
+
+
+def signal_process_group(popen, sig):
+    pgid = process_group_id(popen)
+    if pgid is None:
+        return "already_exited"
+    if pgid == "permission_denied":
+        return pgid
+    try:
+        os.killpg(pgid, sig)
+        return "signaled"
+    except ProcessLookupError:
+        return "already_exited"
+    except PermissionError:
+        return "permission_denied"
+
+
+def terminate_process_group(popen, grace_seconds=PROCESS_GROUP_KILL_GRACE_SECONDS):
+    if popen.poll() is not None:
+        return "already_exited"
+    term_status = signal_process_group(popen, signal.SIGTERM)
+    if term_status == "already_exited":
+        return term_status
+    if term_status != "signaled":
+        return term_status
+    try:
+        popen.wait(timeout=grace_seconds)
+        return "terminated"
+    except subprocess.TimeoutExpired:
+        kill_status = signal_process_group(popen, signal.SIGKILL)
+        if kill_status == "already_exited":
+            return kill_status
+        if kill_status != "signaled":
+            return kill_status
+        try:
+            popen.wait(timeout=grace_seconds)
+        except subprocess.TimeoutExpired:
+            return "kill_timeout"
+        return "killed"
+
+
+def cleanup_active_processes(registry):
+    cleanup = {}
+    for item in registry.snapshot():
+        cleanup[item["provider"]] = {
+            "pid": item["pid"],
+            "result": terminate_process_group(item["popen"]),
+        }
+    return cleanup
+
+
+def raw_output(stdout, stderr):
+    output = stdout or ""
+    if stderr:
+        output += "\n[stderr]\n" + stderr
+    return output
+
+
+def timeout_partial_output(exc, stdout=None, stderr=None):
+    def normalize(value):
+        if value is None:
+            return ""
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        return value
+
+    return raw_output(
+        normalize(stdout) or normalize(exc.stdout),
+        normalize(stderr) or normalize(exc.stderr),
+    )
+
+
+def run_provider(provider, provider_config, prompt_path, review_dir, root, registry):
     raw_path = review_dir / "raw" / f"{provider}.txt"
     cmd = provider_command(provider, provider_config) + [
         build_prompt_handoff(prompt_path)
@@ -922,45 +1087,197 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root):
         timeout = provider_timeout(provider, provider_config)
     except ValueError as exc:
         raise SystemExit(f"trinity-codex: provider {provider} {exc}") from exc
-    started = dt.datetime.now().isoformat(timespec="seconds")
+    started = timestamp()
+    started_monotonic = time.monotonic()
+    progress(f"starting provider {provider} timeout={timeout}s")
+    popen = None
     try:
-        result = subprocess.run(
+        popen = subprocess.Popen(
             cmd,
             cwd=str(root),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True,
-            timeout=timeout,
+            text=True,
+            start_new_session=True,
         )
-        output = result.stdout
-        if result.stderr:
-            output += "\n[stderr]\n" + result.stderr
-        raw_path.write_text(output)
+        registry.add(provider, popen, started)
+        stdout, stderr = popen.communicate(timeout=timeout)
+        raw_path.write_text(raw_output(stdout, stderr))
+        finished = timestamp()
+        progress(
+            f"provider {provider} finished returncode={popen.returncode} "
+            f"elapsed={elapsed_seconds(started_monotonic)}s"
+        )
         return {
             "provider": provider,
-            "returncode": result.returncode,
+            "returncode": popen.returncode,
             "raw": str(raw_path.relative_to(review_dir)),
             "started_at": started,
-            "finished_at": dt.datetime.now().isoformat(timespec="seconds"),
+            "finished_at": finished,
         }
     except FileNotFoundError as exc:
         raw_path.write_text(f"ERROR: command not found: {exc}\n")
+        progress(
+            f"provider {provider} failed returncode=127 "
+            f"elapsed={elapsed_seconds(started_monotonic)}s"
+        )
         return {
             "provider": provider,
             "returncode": 127,
             "raw": str(raw_path.relative_to(review_dir)),
             "started_at": started,
-            "finished_at": dt.datetime.now().isoformat(timespec="seconds"),
+            "finished_at": timestamp(),
         }
     except subprocess.TimeoutExpired as exc:
-        raw_path.write_text(f"ERROR: timeout after {timeout}s\n{exc}\n")
+        cleanup_result = terminate_process_group(popen)
+        stdout = None
+        stderr = None
+        try:
+            stdout, stderr = popen.communicate(timeout=1)
+        except (subprocess.TimeoutExpired, ValueError):
+            pass
+        partial = timeout_partial_output(exc, stdout, stderr)
+        output = f"ERROR: timeout after {timeout}s\n{exc}\n"
+        if partial:
+            output += "\n[partial output]\n" + partial
+        raw_path.write_text(output)
+        progress(
+            f"provider {provider} timed out returncode=124 "
+            f"cleanup={cleanup_result} elapsed={elapsed_seconds(started_monotonic)}s"
+        )
         return {
             "provider": provider,
             "returncode": 124,
             "raw": str(raw_path.relative_to(review_dir)),
             "started_at": started,
-            "finished_at": dt.datetime.now().isoformat(timespec="seconds"),
+            "finished_at": timestamp(),
         }
+    except Exception:
+        if popen is not None and popen.poll() is None:
+            terminate_process_group(popen)
+        raise
+    finally:
+        if popen is not None:
+            registry.remove(provider, popen)
+
+
+def review_parallelism(config, providers):
+    review_config = review_section(config)
+    raw_value = review_config.get("max_parallel_providers")
+    if raw_value is None:
+        return len(providers)
+    if isinstance(raw_value, bool) or not isinstance(raw_value, int):
+        raise SystemExit(
+            "trinity: review.max_parallel_providers must be an integer "
+            f"between 1 and {len(providers)}"
+        )
+    if raw_value < 1 or raw_value > len(providers):
+        raise SystemExit(
+            f"trinity: review.max_parallel_providers must be between 1 and {len(providers)}"
+        )
+    return raw_value
+
+
+def run_providers(
+    max_workers,
+    providers,
+    provider_configs,
+    prompt_path,
+    review_dir,
+    root,
+):
+    registry = ActiveProcessRegistry()
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+    provider_iter = iter(providers)
+    futures = {}
+    results = {}
+
+    def submit_provider(provider):
+        future = executor.submit(
+            run_provider,
+            provider,
+            provider_configs[provider],
+            prompt_path,
+            review_dir,
+            root,
+            registry,
+        )
+        futures[future] = provider
+
+    try:
+        for provider in provider_iter:
+            submit_provider(provider)
+            if len(futures) >= max_workers:
+                break
+        while futures:
+            done, _ = concurrent.futures.wait(
+                futures, return_when=concurrent.futures.FIRST_COMPLETED
+            )
+            for future in done:
+                provider = futures.pop(future)
+                results[provider] = future.result()
+                try:
+                    submit_provider(next(provider_iter))
+                except StopIteration:
+                    pass
+    except KeyboardInterrupt as exc:
+        for future in futures:
+            future.cancel()
+        started_providers = registry.started_providers()
+        cleanup = cleanup_active_processes(registry)
+        executor.shutdown(wait=False)
+        raise ReviewInterrupted(cleanup, started_providers) from exc
+    except Exception as exc:
+        for future in futures:
+            future.cancel()
+        started_providers = registry.started_providers()
+        cleanup = cleanup_active_processes(registry)
+        executor.shutdown(wait=False)
+        raise ReviewOrchestrationError(str(exc), cleanup, started_providers) from exc
+    else:
+        executor.shutdown(wait=True)
+    return [results[provider] for provider in providers]
+
+
+def ordered_subset(providers, selected):
+    selected = set(selected)
+    ordered = [provider for provider in providers if provider in selected]
+    ordered.extend(sorted(selected.difference(providers)))
+    return ordered
+
+
+def ordered_cleanup(providers, cleanup):
+    payload = {
+        provider: cleanup[provider] for provider in providers if provider in cleanup
+    }
+    for provider in sorted(set(cleanup).difference(payload)):
+        payload[provider] = cleanup[provider]
+    return payload
+
+
+def write_incomplete(
+    review_dir,
+    status,
+    providers,
+    started_providers,
+    cleanup,
+    message=None,
+):
+    cleanup_payload = ordered_cleanup(providers, cleanup)
+    payload = {
+        "status": status,
+        "timestamp": timestamp(),
+        "review_dir": str(review_dir),
+        "providers_selected": providers,
+        "providers_started": ordered_subset(providers, started_providers),
+        "providers_running_at_cleanup": ordered_subset(providers, cleanup),
+        "cleanup": cleanup_payload,
+    }
+    if message:
+        payload["message"] = message
+    (review_dir / "incomplete.json").write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    )
 
 
 def write_synthesis(review_dir, scope, results):
@@ -987,10 +1304,11 @@ def write_synthesis(review_dir, scope, results):
         ]
     )
     path = review_dir / "synthesis.md"
-    path.write_text("\n".join(lines))
+    path.write_text("\n".join(lines) + "\n")
 
 
 def cmd_review(args):
+    progress("preparing review prompt")
     root = resolve_root(args.root)
     config = load_config(args.config)
     providers, preset_metadata, resolver_warnings = resolve_review_providers(
@@ -1007,6 +1325,7 @@ def cmd_review(args):
     if not health_results_ok(health):
         print(format_health_results(health), file=sys.stderr)
         return 1
+    max_workers = review_parallelism(config, providers)
     review_input = resolve_review_input(args, root)
 
     out_base = args.out_dir or config.get("review", {}).get(
@@ -1016,37 +1335,72 @@ def cmd_review(args):
     if not out_base.is_absolute():
         out_base = root / out_base
     review_dir = make_review_dir(out_base, args.scope)
-    prompt = render_prompt(config, root, args.scope, review_input, strict_review)
-    prompt_path = review_dir / "prompt.md"
-    prompt_path.write_text(prompt)
 
-    results = []
-    for provider in providers:
-        results.append(
-            run_provider(
-                provider,
-                provider_configs[provider],
-                prompt_path,
-                review_dir,
-                root,
-            )
+    try:
+        prompt = render_prompt(config, root, args.scope, review_input, strict_review)
+        prompt_path = review_dir / "prompt.md"
+        progress("writing prompt")
+        prompt_path.write_text(prompt)
+        results = run_providers(
+            max_workers,
+            providers,
+            provider_configs,
+            prompt_path,
+            review_dir,
+            root,
         )
-    metadata = {
-        "scope": args.scope,
-        "root": str(root),
-        "providers": providers,
-        "preset": preset_metadata,
-        "input": review_input["metadata"],
-        "results": results,
-    }
-    if strict_review is not None:
-        metadata["strict_review"] = {
-            key: value for key, value in strict_review.items() if key != "template"
+        metadata = {
+            "scope": args.scope,
+            "root": str(root),
+            "providers": providers,
+            "preset": preset_metadata,
+            "input": review_input["metadata"],
+            "results": results,
         }
-    (review_dir / "metadata.json").write_text(
-        json.dumps(metadata, indent=2, ensure_ascii=False) + "\n"
-    )
-    write_synthesis(review_dir, args.scope, results)
+        if strict_review is not None:
+            metadata["strict_review"] = {
+                key: value for key, value in strict_review.items() if key != "template"
+            }
+        progress("writing metadata")
+        (review_dir / "metadata.json").write_text(
+            json.dumps(metadata, indent=2, ensure_ascii=False) + "\n"
+        )
+        progress("writing synthesis")
+        write_synthesis(review_dir, args.scope, results)
+    except KeyboardInterrupt:
+        started_providers = providers if "results" in locals() else []
+        write_incomplete(review_dir, "interrupted", providers, started_providers, {})
+        print(review_dir)
+        return 130
+    except ReviewInterrupted as exc:
+        write_incomplete(
+            review_dir,
+            "interrupted",
+            providers,
+            exc.started_providers,
+            exc.cleanup,
+        )
+        print(review_dir)
+        return 130
+    except ReviewOrchestrationError as exc:
+        write_incomplete(
+            review_dir,
+            "failed",
+            providers,
+            exc.started_providers,
+            exc.cleanup,
+            str(exc),
+        )
+        print(review_dir)
+        return 1
+    except Exception as exc:
+        started_providers = providers if "results" in locals() else []
+        write_incomplete(
+            review_dir, "failed", providers, started_providers, {}, str(exc)
+        )
+        print(review_dir)
+        return 1
+
     print(review_dir)
     return 0 if all(item["returncode"] == 0 for item in results) else 1
 

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -794,6 +794,11 @@ def test_codex_review_strict_cor1602_cor1609_prompt_and_metadata(tmp_path):
     assert "### Decision Matrix" in prompt
     assert "**Weighted Average: X.X/10 - PASS/FIX**" in prompt
     assert "COR-1611" in prompt
+    assert "## Review-Only Mode" in prompt
+    assert prompt.index("## Strict COR Review Mode") < prompt.index(
+        "## Review-Only Mode"
+    )
+    assert prompt.index("## Review-Only Mode") < prompt.index("## Review Artifact")
     assert "after" in prompt
 
     metadata = json.loads((review_dir / "metadata.json").read_text())

--- a/tests/test_codex_compat.py
+++ b/tests/test_codex_compat.py
@@ -89,6 +89,9 @@ def test_readme_documents_claude_and_codex_load_smoke_checks():
     assert "trinity review --pr 21 --preset deep-review" in text
     assert "trinity review --sop COR-1602 --rubric COR-1609" in text
     assert "Strict COR review mode" in text
+    assert "review.max_parallel_providers" in text
+    assert "Progress is logged to stderr" in text
+    assert "incomplete.json" in text
     assert ".agents/trinity.codex.json" in text
     assert "| `fast-review` | `glm`, `deepseek` | none |" in text
     assert "explicit `--providers`, explicit `--preset`" in text
@@ -102,6 +105,9 @@ def test_codex_skill_documents_preset_resolution():
     assert "trinity review --sop COR-1602 --rubric COR-1609" in text
     assert "strict template is `COR-1602` with `COR-1609`" in text
     assert "`fast-review` expands to `glm` and `deepseek`" in text
+    assert "review.max_parallel_providers" in text
+    assert "Progress is written to stderr" in text
+    assert "incomplete.json" in text
     assert "review.default_preset" in text
     assert "skipped providers are recorded" in text
 

--- a/tests/test_codex_review_dispatch.py
+++ b/tests/test_codex_review_dispatch.py
@@ -1,0 +1,574 @@
+"""Tests for TRN-2019 Codex review provider dispatch."""
+
+import json
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+
+from scripts import codex
+from tests.test_codex_adapter import CODEX_SCRIPT, commit_all, init_repo
+
+
+def run_codex(args, cwd=None, env=None):
+    return subprocess.run(
+        [sys.executable, str(CODEX_SCRIPT)] + args,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def simple_repo(tmp_path):
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    tracked = repo / "review.txt"
+    tracked.write_text("before\n")
+    commit_all(repo, "init")
+    tracked.write_text("before\nafter\n")
+    return repo
+
+
+def write_provider(path, body):
+    path.write_text(f"#!{sys.executable}\n{body}")
+    path.chmod(0o755)
+
+
+def write_sleep_provider(path, events, sleep_seconds=1.0, exit_code=0):
+    write_provider(
+        path,
+        f"""
+import json
+import pathlib
+import sys
+import time
+
+provider = pathlib.Path(sys.argv[0]).name
+events = pathlib.Path({str(events)!r})
+with events.open("a") as handle:
+    handle.write(json.dumps({{"provider": provider, "event": "start", "time": time.monotonic()}}) + "\\n")
+time.sleep({sleep_seconds})
+print(f"provider={{provider}}")
+print(f"stderr={{provider}}", file=sys.stderr)
+with events.open("a") as handle:
+    handle.write(json.dumps({{"provider": provider, "event": "end", "time": time.monotonic()}}) + "\\n")
+raise SystemExit({exit_code})
+""",
+    )
+
+
+def write_config(config, providers, *, max_parallel=None, default_providers=None):
+    review = {
+        "prompt_template": "Scope: {scope}\n\n{diff}\n\n{files}\n",
+        "default_providers": default_providers or list(providers),
+    }
+    if max_parallel is not None:
+        review["max_parallel_providers"] = max_parallel
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    name: {"cli": str(path), "timeout": 5}
+                    for name, path in providers.items()
+                },
+                "review": review,
+            }
+        )
+    )
+
+
+def event_rows(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def review_dir_from(result):
+    return Path(result.stdout.strip().splitlines()[-1])
+
+
+def test_review_runs_providers_in_parallel_and_preserves_result_order(tmp_path):
+    repo = simple_repo(tmp_path)
+    events = tmp_path / "events.jsonl"
+    glm = tmp_path / "glm"
+    deepseek = tmp_path / "deepseek"
+    write_sleep_provider(glm, events, sleep_seconds=1.0)
+    write_sleep_provider(deepseek, events, sleep_seconds=1.0)
+    config = tmp_path / "codex.json"
+    write_config(config, {"glm": glm, "deepseek": deepseek})
+
+    started = time.monotonic()
+    result = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+    elapsed = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    assert elapsed < 1.8
+    rows = event_rows(events)
+    starts = {row["provider"]: row["time"] for row in rows if row["event"] == "start"}
+    ends = {row["provider"]: row["time"] for row in rows if row["event"] == "end"}
+    assert max(starts.values()) < min(ends.values())
+    review_dir = review_dir_from(result)
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert [item["provider"] for item in metadata["results"]] == ["glm", "deepseek"]
+    assert "trinity: starting provider glm timeout=5s" in result.stderr
+    assert "trinity: starting provider deepseek timeout=5s" in result.stderr
+    assert "trinity: writing metadata" in result.stderr
+
+
+def test_review_max_parallel_one_keeps_sequential_behavior(tmp_path):
+    repo = simple_repo(tmp_path)
+    events = tmp_path / "events.jsonl"
+    glm = tmp_path / "glm"
+    deepseek = tmp_path / "deepseek"
+    write_sleep_provider(glm, events, sleep_seconds=0.4)
+    write_sleep_provider(deepseek, events, sleep_seconds=0.4)
+    config = tmp_path / "codex.json"
+    write_config(config, {"glm": glm, "deepseek": deepseek}, max_parallel=1)
+
+    result = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert result.returncode == 0, result.stderr
+    rows = event_rows(events)
+    starts = {row["provider"]: row["time"] for row in rows if row["event"] == "start"}
+    ends = {row["provider"]: row["time"] for row in rows if row["event"] == "end"}
+    assert starts["deepseek"] >= ends["glm"]
+    raw = (review_dir_from(result) / "raw" / "glm.txt").read_text()
+    assert "provider=glm" in raw
+    assert "[stderr]" in raw
+    assert "stderr=glm" in raw
+
+
+def test_review_collects_mixed_success_and_failure_in_provider_order(tmp_path):
+    repo = simple_repo(tmp_path)
+    events = tmp_path / "events.jsonl"
+    glm = tmp_path / "glm"
+    deepseek = tmp_path / "deepseek"
+    write_sleep_provider(glm, events, sleep_seconds=0.4, exit_code=0)
+    write_sleep_provider(deepseek, events, sleep_seconds=0.1, exit_code=3)
+    config = tmp_path / "codex.json"
+    write_config(config, {"glm": glm, "deepseek": deepseek})
+
+    result = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert result.returncode == 1
+    review_dir = review_dir_from(result)
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert [(item["provider"], item["returncode"]) for item in metadata["results"]] == [
+        ("glm", 0),
+        ("deepseek", 3),
+    ]
+    synthesis = (review_dir / "synthesis.md").read_text()
+    assert "| deepseek | FAIL 3 | `raw/deepseek.txt` |" in synthesis
+    assert synthesis.endswith("\n")
+    assert not (review_dir / "incomplete.json").exists()
+
+
+def test_review_rejects_invalid_max_parallel_values_before_review_dir(tmp_path):
+    repo = simple_repo(tmp_path)
+    events = tmp_path / "events.jsonl"
+    glm = tmp_path / "glm"
+    deepseek = tmp_path / "deepseek"
+    write_sleep_provider(glm, events, sleep_seconds=0.1)
+    write_sleep_provider(deepseek, events, sleep_seconds=0.1)
+
+    for index, value in enumerate([0, -1, True, "2", 3]):
+        config = tmp_path / f"codex-{index}.json"
+        write_config(config, {"glm": glm, "deepseek": deepseek}, max_parallel=value)
+        out_dir = tmp_path / f"reviews-{index}"
+        result = run_codex(
+            [
+                "review",
+                "--root",
+                str(repo),
+                "--config",
+                str(config),
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+
+        assert result.returncode == 1
+        assert result.stdout == ""
+        assert "review.max_parallel_providers" in result.stderr
+        assert not out_dir.exists()
+
+
+def test_review_rejects_duplicate_explicit_providers_before_review_dir(tmp_path):
+    repo = simple_repo(tmp_path)
+    events = tmp_path / "events.jsonl"
+    glm = tmp_path / "glm"
+    write_sleep_provider(glm, events, sleep_seconds=0.1)
+    config = tmp_path / "codex.json"
+    write_config(config, {"glm": glm})
+    out_dir = tmp_path / "reviews"
+
+    result = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--providers",
+            "glm,glm",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "duplicate provider selected: glm" in result.stderr
+    assert not out_dir.exists()
+
+
+def test_review_rejects_duplicate_default_providers_before_review_dir(tmp_path):
+    repo = simple_repo(tmp_path)
+    events = tmp_path / "events.jsonl"
+    glm = tmp_path / "glm"
+    write_sleep_provider(glm, events, sleep_seconds=0.1)
+    config = tmp_path / "codex.json"
+    write_config(config, {"glm": glm}, default_providers=["glm", "glm"])
+    out_dir = tmp_path / "reviews"
+
+    result = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "duplicate provider selected: glm" in result.stderr
+    assert not out_dir.exists()
+
+
+def test_review_prompt_includes_review_only_instruction_before_artifact(tmp_path):
+    repo = simple_repo(tmp_path)
+    events = tmp_path / "events.jsonl"
+    glm = tmp_path / "glm"
+    write_sleep_provider(glm, events, sleep_seconds=0.1)
+    config = tmp_path / "codex.json"
+    write_config(config, {"glm": glm})
+
+    result = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert result.returncode == 0, result.stderr
+    prompt = (review_dir_from(result) / "prompt.md").read_text()
+    assert "## Review-Only Mode" in prompt
+    assert "Do not run tests, shell commands" in prompt
+    assert prompt.index("## Review-Only Mode") < prompt.index("diff --git")
+
+
+def process_is_running(pid):
+    result = subprocess.run(
+        ["ps", "-o", "stat=", "-p", str(pid)],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and "Z" not in result.stdout
+
+
+def wait_until_not_running(pid, timeout=5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not process_is_running(pid):
+            return True
+        time.sleep(0.1)
+    return not process_is_running(pid)
+
+
+def wait_until_exists(path, timeout=5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.1)
+    return path.exists()
+
+
+def test_review_timeout_kills_provider_process_group_children(tmp_path):
+    repo = simple_repo(tmp_path)
+    child_pid = tmp_path / "child.pid"
+    provider = tmp_path / "glm"
+    write_provider(
+        provider,
+        f"""
+import pathlib
+import subprocess
+import sys
+import time
+
+child_pid = pathlib.Path({str(child_pid)!r})
+subprocess.Popen([
+    sys.executable,
+    "-c",
+    "import pathlib, sys, time; pathlib.Path(sys.argv[1]).write_text(str(__import__('os').getpid())); time.sleep(30)",
+    str(child_pid),
+])
+print("spawned child", flush=True)
+time.sleep(30)
+""",
+    )
+    config = tmp_path / "codex.json"
+    config.write_text(
+        json.dumps(
+            {
+                "providers": {"glm": {"cli": str(provider), "timeout": 1}},
+                "review": {
+                    "prompt_template": "{diff}\n\n{files}\n",
+                    "default_providers": ["glm"],
+                },
+            }
+        )
+    )
+
+    result = run_codex(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert result.returncode == 1
+    assert child_pid.exists()
+    assert wait_until_not_running(int(child_pid.read_text()))
+    review_dir = review_dir_from(result)
+    metadata = json.loads((review_dir / "metadata.json").read_text())
+    assert metadata["results"][0]["returncode"] == 124
+    raw = (review_dir / "raw" / "glm.txt").read_text()
+    assert "ERROR: timeout after 1s" in raw
+    assert "spawned child" in raw
+    assert not (review_dir / "incomplete.json").exists()
+
+
+def test_review_sigint_writes_incomplete_json_and_cleans_up(tmp_path):
+    repo = simple_repo(tmp_path)
+    glm_done = tmp_path / "glm.done"
+    deepseek_started = tmp_path / "deepseek.started"
+    glm = tmp_path / "glm"
+    deepseek = tmp_path / "deepseek"
+    write_provider(
+        glm,
+        f"""
+import pathlib
+
+pathlib.Path({str(glm_done)!r}).write_text("done")
+print("glm done", flush=True)
+""",
+    )
+    write_provider(
+        deepseek,
+        f"""
+import pathlib
+import time
+
+pathlib.Path({str(deepseek_started)!r}).write_text("started")
+print("deepseek running", flush=True)
+time.sleep(30)
+""",
+    )
+    config = tmp_path / "codex.json"
+    write_config(config, {"glm": glm, "deepseek": deepseek})
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(CODEX_SCRIPT),
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert wait_until_exists(glm_done)
+    assert wait_until_exists(deepseek_started)
+    proc.send_signal(signal.SIGINT)
+    try:
+        stdout, stderr = proc.communicate(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        raise
+
+    assert proc.returncode == 130, stderr
+    review_dir = Path(stdout.strip().splitlines()[-1])
+    incomplete = json.loads((review_dir / "incomplete.json").read_text())
+    assert incomplete["status"] == "interrupted"
+    assert incomplete["review_dir"] == str(review_dir)
+    assert incomplete["providers_selected"] == ["glm", "deepseek"]
+    assert incomplete["providers_started"] == ["glm", "deepseek"]
+    assert incomplete["providers_running_at_cleanup"] == ["deepseek"]
+    assert "glm" not in incomplete["cleanup"]
+    assert "deepseek" in incomplete["cleanup"]
+    assert not (review_dir / "metadata.json").exists()
+
+
+def test_review_sigint_before_dispatch_writes_incomplete_json(
+    tmp_path, monkeypatch, capsys
+):
+    repo = simple_repo(tmp_path)
+    events = tmp_path / "events.jsonl"
+    glm = tmp_path / "glm"
+    write_sleep_provider(glm, events, sleep_seconds=0.1)
+    config = tmp_path / "codex.json"
+    write_config(config, {"glm": glm})
+    original_write_text = Path.write_text
+
+    def interrupt_prompt_write(path, *args, **kwargs):
+        if path.name == "prompt.md":
+            raise KeyboardInterrupt
+        return original_write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(codex.Path, "write_text", interrupt_prompt_write)
+    args = codex.build_parser().parse_args(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert codex.cmd_review(args) == 130
+    review_dir = Path(capsys.readouterr().out.strip().splitlines()[-1])
+    incomplete = json.loads((review_dir / "incomplete.json").read_text())
+    assert incomplete["status"] == "interrupted"
+    assert incomplete["providers_started"] == []
+    assert incomplete["providers_running_at_cleanup"] == []
+    assert incomplete["cleanup"] == {}
+    assert not (review_dir / "metadata.json").exists()
+
+
+def test_review_sigint_during_metadata_write_marks_incomplete(
+    tmp_path, monkeypatch, capsys
+):
+    repo = simple_repo(tmp_path)
+    events = tmp_path / "events.jsonl"
+    glm = tmp_path / "glm"
+    write_sleep_provider(glm, events, sleep_seconds=0.1)
+    config = tmp_path / "codex.json"
+    write_config(config, {"glm": glm})
+    original_write_text = Path.write_text
+
+    def interrupt_metadata_write(path, *args, **kwargs):
+        if path.name == "metadata.json":
+            raise KeyboardInterrupt
+        return original_write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(codex.Path, "write_text", interrupt_metadata_write)
+    args = codex.build_parser().parse_args(
+        [
+            "review",
+            "--root",
+            str(repo),
+            "--config",
+            str(config),
+            "--out-dir",
+            str(tmp_path / "reviews"),
+        ]
+    )
+
+    assert codex.cmd_review(args) == 130
+    review_dir = Path(capsys.readouterr().out.strip().splitlines()[-1])
+    incomplete = json.loads((review_dir / "incomplete.json").read_text())
+    assert incomplete["status"] == "interrupted"
+    assert incomplete["providers_started"] == ["glm"]
+    assert incomplete["providers_running_at_cleanup"] == []
+    assert incomplete["cleanup"] == {}
+    assert not (review_dir / "metadata.json").exists()
+    assert not (review_dir / "synthesis.md").exists()
+
+
+def test_run_providers_does_not_start_queued_provider_after_failure(
+    tmp_path, monkeypatch
+):
+    calls = []
+
+    def fail_first_provider(provider, *_args):
+        calls.append(provider)
+        if provider == "glm":
+            raise RuntimeError("dispatch failed")
+        return {
+            "provider": provider,
+            "returncode": 0,
+            "raw": f"raw/{provider}.txt",
+            "started_at": "2026-05-05T00:00:00",
+            "finished_at": "2026-05-05T00:00:00",
+        }
+
+    monkeypatch.setattr(codex, "run_provider", fail_first_provider)
+
+    try:
+        codex.run_providers(
+            1,
+            ["glm", "deepseek"],
+            {"glm": {}, "deepseek": {}},
+            tmp_path / "prompt.md",
+            tmp_path,
+            tmp_path,
+        )
+    except codex.ReviewOrchestrationError as exc:
+        assert str(exc) == "dispatch failed"
+    else:
+        raise AssertionError("expected ReviewOrchestrationError")
+
+    assert calls == ["glm"]


### PR DESCRIPTION
## Summary
- Add TRN-2019 CHG for issue #27 and implement parallel Codex review provider dispatch.
- Add stderr progress logs, process-group timeout/interrupt cleanup, review-only prompt guidance, and incomplete review markers.
- Document runtime behavior in README plus repo/plugin Codex Trinity skills.

## Verification
- make test
- make lint
- af validate --root .
- git diff --check
- Trinity fast-review: DeepSeek PASS; GLM timed out twice at the configured 360s and was cleaned up as provider result 124, with completed metadata/synthesis and no incomplete marker. Latest artifact: .trinity/reviews/20260505-233456-TRN-2019
