### PR TITLE
Prepare v3.1.1 README release gate fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- README install-version examples now match `VERSION=3.1.0`, and the release metadata gate covers README examples via `make bump`, `make release-prep`, and tests.
+
 ## [3.1.0] - 2026-05-06
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ bump:           ## Bump version (TRN-1003): make bump VERSION=x.y.z
 	@perl -i -pe 's/__version__ = ".*"/__version__ = "$(VERSION)"/' scripts/__init__.py
 	@perl -i -pe 's/REQUIRED_VERSION=".*"/REQUIRED_VERSION="$(VERSION)"/' SKILL.md
 	@perl -i -pe 's/^  "version": "[0-9]+\.[0-9]+\.[0-9]+",/  "version": "$(VERSION)",/' plugins/trinity/.codex-plugin/plugin.json
+	@perl -i -pe 's#Trinity [0-9]+\.[0-9]+\.[0-9]+ installed to ~/\.claude/#Trinity $(VERSION) installed to ~/.claude/#' README.md
+	@perl -i -pe 's/TRINITY_VERSION=[0-9]+\.[0-9]+\.[0-9]+/TRINITY_VERSION=$(VERSION)/' README.md
 	@echo "Bumped to $(VERSION)"
 
 release-prep:   ## Stage release-metadata commit + local tag (TRN-1004): no push, CI publishes
@@ -114,7 +116,7 @@ release-prep:   ## Stage release-metadata commit + local tag (TRN-1004): no push
 	$(MAKE) lint
 	@git diff --quiet providers/ || (echo "release-prep: providers/ has uncommitted changes — run 'make build' and commit first"; exit 1)
 	@git reset HEAD
-	@git add VERSION scripts/__init__.py CHANGELOG.md SKILL.md plugins/trinity/.codex-plugin/plugin.json
+	@git add VERSION scripts/__init__.py CHANGELOG.md SKILL.md plugins/trinity/.codex-plugin/plugin.json README.md
 	@git commit -m "Release v$(CURRENT_VERSION)"
 	@git tag "v$(CURRENT_VERSION)"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ curl -fsSL https://raw.githubusercontent.com/frankyxhl/trinity/main/install.sh |
 This downloads all skill files to `~/.claude/` and registers the five default providers (glm, codex, gemini, openrouter, deepseek) in `~/.claude/trinity.json`. Expected output ends with:
 
 ```
-Trinity 3.0.0 installed to ~/.claude/
+Trinity 3.1.0 installed to ~/.claude/
 ```
 
 If the command fails, check stderr for `trinity-install: failed downloading <file>` — that tells you exactly which file 404'd.
@@ -103,7 +103,7 @@ curl -fsSL https://raw.githubusercontent.com/frankyxhl/trinity/main/install.sh |
 This downloads all skill files directly to `~/.claude/` — no git clone required. To install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/frankyxhl/trinity/main/install.sh | TRINITY_VERSION=3.0.0 bash
+curl -fsSL https://raw.githubusercontent.com/frankyxhl/trinity/main/install.sh | TRINITY_VERSION=3.1.0 bash
 ```
 
 **Or, if you have the repo cloned:**

--- a/rules/TRN-1003-SOP-Version-Bump.md
+++ b/rules/TRN-1003-SOP-Version-Bump.md
@@ -1,8 +1,8 @@
 # SOP-1003: Version Bump — Trinity
 
 **Applies to:** trinity/ package
-**Last updated:** 2026-05-04
-**Last reviewed:** 2026-05-04
+**Last updated:** 2026-05-06
+**Last reviewed:** 2026-05-06
 **Status:** Active
 
 ---
@@ -15,7 +15,7 @@ Human preparation step before `make release-prep` (TRN-1004). Updates CHANGELOG 
 
 ## Why
 
-Version metadata lives in multiple files (`VERSION`, `scripts/__init__.py`, `SKILL.md`, and `CHANGELOG.md`). This SOP keeps them synchronized before release automation creates the release commit and tag.
+Version metadata lives in multiple files (`VERSION`, `scripts/__init__.py`, `SKILL.md`, `plugins/trinity/.codex-plugin/plugin.json`, README install examples, and `CHANGELOG.md`). This SOP keeps them synchronized before release automation creates the release commit and tag.
 
 ---
 
@@ -35,14 +35,14 @@ Version metadata lives in multiple files (`VERSION`, `scripts/__init__.py`, `SKI
 
 ## Steps
 
-0. **Prerequisite:** All feature code and tests MUST be committed first. Run `git status` — only release files (CHANGELOG, VERSION, __init__.py, SKILL.md) should change after this point. If there are unstaged `.py` or test files, commit them before proceeding.
+0. **Prerequisite:** All feature code and tests MUST be committed first. Run `git status` — only release metadata files (`CHANGELOG.md`, `VERSION`, `scripts/__init__.py`, `SKILL.md`, `plugins/trinity/.codex-plugin/plugin.json`, `README.md`) should change after this point. If there are unstaged `.py` or test files, commit them before proceeding.
 1. Decide new version (semver: MAJOR for breaking, MINOR for new feature, PATCH for fix)
 2. Update `CHANGELOG.md`: rename `[Unreleased]` to `[x.y.z] - YYYY-MM-DD`, add new empty `[Unreleased]` section above it
-3. Run `make bump VERSION=x.y.z` — updates `VERSION`, `scripts/__init__.py`, and `SKILL.md`. Also runs `make build` (TRN-2004) to regenerate `providers/*.md` from `*.delta.md` + `_base/` partials. If providers/ has uncommitted regenerated content, commit it before continuing — the release commit only stages release-metadata files.
-4. Do not commit the metadata files — `make release-prep` (TRN-1004) stages and commits all 4 files together as `Release vX.Y.Z` and creates the local tag
-5. Worktree will be dirty (CHANGELOG.md + VERSION + __init__.py + SKILL.md modified, all unstaged) — expected. Proceed to TRN-1004.
+3. Run `make bump VERSION=x.y.z` — updates `VERSION`, `scripts/__init__.py`, `SKILL.md`, the Codex plugin manifest, and README install-version examples. Also runs `make build` (TRN-2004) to regenerate `providers/*.md` from `*.delta.md` + `_base/` partials. If providers/ has uncommitted regenerated content, commit it before continuing — the release commit only stages release-metadata files.
+4. Do not commit the metadata files — `make release-prep` (TRN-1004) stages and commits the release metadata files together as `Release vX.Y.Z` and creates the local tag
+5. Worktree will be dirty (`CHANGELOG.md`, `VERSION`, `scripts/__init__.py`, `SKILL.md`, `plugins/trinity/.codex-plugin/plugin.json`, `README.md` modified, all unstaged) — expected. Proceed to TRN-1004.
 
-**Portable in-place rewrite:** `make bump` uses `perl -i -pe` (cross-platform: macOS BSD + Linux GNU) to rewrite `__version__` in `scripts/__init__.py` and `REQUIRED_VERSION` in `SKILL.md`. The prior BSD-only `sed -i ''` form would fail on Linux because GNU sed treats `''` as the input file path. Regression test: `tests/test_make_bump.sh` (T1 = portable rewrite semantics; T2 = static guard against re-introducing the BSD-only form). Wired into `make test`.
+**Portable in-place rewrite:** `make bump` uses `perl -i -pe` (cross-platform: macOS BSD + Linux GNU) to rewrite `__version__` in `scripts/__init__.py`, `REQUIRED_VERSION` in `SKILL.md`, the Codex plugin manifest version, and README install-version examples. The prior BSD-only `sed -i ''` form would fail on Linux because GNU sed treats `''` as the input file path. Regression test: `tests/test_make_bump.sh` (T1 = portable rewrite semantics; T2 = static guard against re-introducing the BSD-only form). Wired into `make test`.
 
 The release workflow (TRN-2006) still does not call `make bump` — release-time version edits are made before pushing the tag, not from inside CI — but the portability fix removes a contributor-side trap on Linux dev machines.
 
@@ -53,7 +53,7 @@ The release workflow (TRN-2006) still does not call `make bump` — release-time
 ```bash
 git status --short
 make bump VERSION=3.1.0
-git diff -- CHANGELOG.md VERSION scripts/__init__.py SKILL.md
+git diff -- CHANGELOG.md VERSION scripts/__init__.py SKILL.md plugins/trinity/.codex-plugin/plugin.json README.md
 ```
 
 ---
@@ -68,3 +68,4 @@ git diff -- CHANGELOG.md VERSION scripts/__init__.py SKILL.md
 | 2026-04-25 | Note `make build` runs as part of `make bump` (TRN-2004) | Claude Opus 4.7 |
 | 2026-04-26 | TRN-1801 evolve cycle 1: replace stale `sed -i ''` note with `perl -i -pe` (matches C1 Makefile fix) + reference `tests/test_make_bump.sh`. Add `Last reviewed`. | Claude Opus 4.7 |
 | 2026-04-26 | Step 4: `make release` → `make release-prep` (TRN-2006); add BSD-sed warning | Claude Opus 4.7 |
+| 2026-05-06 | Include Codex plugin manifest and README install examples in the release metadata gate. | Codex |

--- a/rules/TRN-1004-SOP-Release.md
+++ b/rules/TRN-1004-SOP-Release.md
@@ -1,8 +1,8 @@
 # SOP-1004: Release — Trinity
 
 **Applies to:** trinity/ package
-**Last updated:** 2026-05-04
-**Last reviewed:** 2026-05-04
+**Last updated:** 2026-05-06
+**Last reviewed:** 2026-05-06
 **Status:** Active
 
 ---
@@ -36,7 +36,7 @@ Trinity releases are tag-driven and publish through GitHub Actions. This SOP kee
 ## Prerequisites
 
 - All feature code and tests committed (`git status` clean)
-- TRN-1003 completed on `main`: `CHANGELOG.md` has a non-empty `## [X.Y.Z]` section, `VERSION` / `scripts/__init__.py` / `SKILL.md` reflect `X.Y.Z`. (Easiest path: a "Release vX.Y.Z" PR with these 4 files, merged to main.)
+- TRN-1003 completed on `main`: `CHANGELOG.md` has a non-empty `## [X.Y.Z]` section, `VERSION` / `scripts/__init__.py` / `SKILL.md` / `plugins/trinity/.codex-plugin/plugin.json` / README install-version examples reflect `X.Y.Z`. (Easiest path: a "Release vX.Y.Z" PR with these metadata files, merged to main.)
 - `providers/*.md` is up-to-date with `*.delta.md` + `_base/` partials (TRN-2004) — `make verify-built` exits 0
 - One-time setup: tag-protection ruleset (see TRN-2007 §D11). Pattern `v[0-9]*.[0-9]*.[0-9]*` (fnmatch — GitHub Rulesets do NOT support regex `+`). Bypass list MUST include **Repository admin** with `Always` mode (covers Path B and the PAT-driven Path A push).
 - One-time setup: `RELEASE_TAG_PAT` repo secret (fine-grained PAT, repo-scoped, `Contents: Read and write`). Required for Path A on personal repos because the GitHub Actions integration cannot be added to a personal-repo ruleset bypass list. See TRN-2007 §D11 for the creation + rotation runbook. Path B and Path C work without this secret.
@@ -105,7 +105,7 @@ Same pre-flight runs. Workflow fails cleanly with "Release vX.Y.Z already exists
 
 - `make release` no longer exists (TRN-2006). Calling it prints `make: *** No rule to make target 'release'` — intended footgun-prevention.
 - All paths converge at the same publish step. The pre-flight checks (semver regex, tag↔VERSION, tag-on-main, CHANGELOG section non-empty) run identically regardless of entry point.
-- Workflow uses the auto-issued `GITHUB_TOKEN` only — no PAT, no OIDC, no secrets. Tag pushes still go through repository tag-protection rulesets.
+- Workflow uses `GITHUB_TOKEN` for release creation. Path A also requires the repo secret `RELEASE_TAG_PAT` for the one-click tag push because personal-repo tag rulesets cannot add GitHub Actions to the bypass list.
 
 ---
 
@@ -129,3 +129,4 @@ git push origin v3.1.0
 | 2026-04-25 | Add `make verify-built` prerequisite + step (TRN-2004) | Claude Opus 4.7 |
 | 2026-04-26 | Full rewrite: `make release` → `make release-prep` + CI publish (TRN-2006) | Claude Opus 4.7 |
 | 2026-04-26 | Add Path A (one-click), restructure into A/B/C paths (TRN-2007) | Claude Opus 4.7 |
+| 2026-05-06 | Add README install-version examples and Codex plugin manifest to the release metadata prerequisite; correct Path A token note. | Codex |

--- a/tests/test_codex_compat.py
+++ b/tests/test_codex_compat.py
@@ -1,6 +1,7 @@
 """Tests for Codex skill/plugin compatibility packaging."""
 
 import json
+import re
 from pathlib import Path
 
 
@@ -95,6 +96,22 @@ def test_readme_documents_claude_and_codex_load_smoke_checks():
     assert ".agents/trinity.codex.json" in text
     assert "| `fast-review` | `glm`, `deepseek` | none |" in text
     assert "explicit `--providers`, explicit `--preset`" in text
+
+
+def test_readme_version_examples_match_version():
+    text = README.read_text()
+
+    install_output_versions = re.findall(
+        r"Trinity ([0-9]+\.[0-9]+\.[0-9]+) installed to ~/.claude/",
+        text,
+    )
+    pinned_install_versions = re.findall(
+        r"TRINITY_VERSION=([0-9]+\.[0-9]+\.[0-9]+)",
+        text,
+    )
+
+    assert install_output_versions == [VERSION]
+    assert pinned_install_versions == [VERSION]
 
 
 def test_codex_skill_documents_preset_resolution():

--- a/tests/test_make_bump.sh
+++ b/tests/test_make_bump.sh
@@ -2,10 +2,10 @@
 # tests/test_make_bump.sh — Regression test for cross-platform `make bump` (TRN-1801 cycle 1, evolve C1)
 #
 # The `bump` target rewrites __version__ in scripts/__init__.py, REQUIRED_VERSION
-# in SKILL.md, and the Codex plugin manifest version. Prior to this test, the target
-# used `sed -i ''` which is BSD-only — on Linux, `''` is interpreted as the input file
-# and the command fails. The fix is `perl -i -pe`, which is portable across macOS
-# (BSD) and Linux (GNU).
+# in SKILL.md, the Codex plugin manifest version, and README install-version
+# examples. Prior to this test, the target used `sed -i ''` which is BSD-only —
+# on Linux, `''` is interpreted as the input file and the command fails. The fix
+# is `perl -i -pe`, which is portable across macOS (BSD) and Linux (GNU).
 #
 # This test guards against silent regression to the BSD-only form, and verifies the
 # substitution semantics on a fixture file.
@@ -22,9 +22,9 @@ FAIL=0
 _pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
 _fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
 
-# T1: portable in-place rewrite of __version__, REQUIRED_VERSION, and plugin
-# manifest version succeeds and preserves unrelated lines, on whichever OS the
-# test runs.
+# T1: portable in-place rewrite of __version__, REQUIRED_VERSION, plugin manifest
+# version, and README install-version examples succeeds and preserves unrelated
+# lines, on whichever OS the test runs.
 t1_portable_in_place_rewrite() {
     TMP=$(mktemp -d)
     cat > "${TMP}/init.py" <<'EOF'
@@ -43,10 +43,17 @@ EOF
   "description": "keep me"
 }
 EOF
+    cat > "${TMP}/README.md" <<'EOF'
+Trinity 0.0.0 installed to ~/.claude/
+curl -fsSL https://raw.githubusercontent.com/frankyxhl/trinity/main/install.sh | TRINITY_VERSION=0.0.0 bash
+keep me
+EOF
 
     perl -i -pe 's/__version__ = ".*"/__version__ = "9.9.9"/' "${TMP}/init.py"
     perl -i -pe 's/REQUIRED_VERSION=".*"/REQUIRED_VERSION="9.9.9"/' "${TMP}/skill.md"
     perl -i -pe 's/^  "version": "[0-9]+\.[0-9]+\.[0-9]+",/  "version": "9.9.9",/' "${TMP}/plugin.json"
+    perl -i -pe 's#Trinity [0-9]+\.[0-9]+\.[0-9]+ installed to ~/\.claude/#Trinity 9.9.9 installed to ~/.claude/#' "${TMP}/README.md"
+    perl -i -pe 's/TRINITY_VERSION=[0-9]+\.[0-9]+\.[0-9]+/TRINITY_VERSION=9.9.9/' "${TMP}/README.md"
 
     grep -qx '__version__ = "9.9.9"' "${TMP}/init.py" \
         || { _fail "T1: __version__ not rewritten"; rm -rf "${TMP}"; return; }
@@ -60,6 +67,12 @@ EOF
         || { _fail "T1: plugin manifest version not rewritten"; rm -rf "${TMP}"; return; }
     grep -qx '  "description": "keep me"' "${TMP}/plugin.json" \
         || { _fail "T1: unrelated line in plugin.json lost"; rm -rf "${TMP}"; return; }
+    grep -qx 'Trinity 9.9.9 installed to ~/.claude/' "${TMP}/README.md" \
+        || { _fail "T1: README install output version not rewritten"; rm -rf "${TMP}"; return; }
+    grep -qx 'curl -fsSL https://raw.githubusercontent.com/frankyxhl/trinity/main/install.sh | TRINITY_VERSION=9.9.9 bash' "${TMP}/README.md" \
+        || { _fail "T1: README TRINITY_VERSION example not rewritten"; rm -rf "${TMP}"; return; }
+    grep -qx 'keep me' "${TMP}/README.md" \
+        || { _fail "T1: unrelated line in README.md lost"; rm -rf "${TMP}"; return; }
 
     _pass "T1: perl -i -pe rewrites all version pins and preserves unrelated lines"
     rm -rf "${TMP}"

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -213,8 +213,10 @@ echo "-- T9: Makefile invariants"
 check_neg "Makefile: release target removed"  grep -qE '^release:' Makefile
 check "Makefile: release-prep present"    grep -qE '^release-prep:' Makefile
 check "Makefile: setup uses uv→pip"       grep -q 'command -v uv' Makefile
-check "Makefile: release-prep stages plugin manifest" grep -qF 'plugins/trinity/.codex-plugin/plugin.json' Makefile
-check "Makefile: release-prep stages README" grep -qF 'README.md' Makefile
+check "Makefile: release-prep stages plugin manifest" bash -c \
+  "awk '/^release-prep:/{in_target=1; next} /^[[:alnum:]_-]+:/{in_target=0} in_target && /git add/ {print}' Makefile | grep -qF 'plugins/trinity/.codex-plugin/plugin.json'"
+check "Makefile: release-prep stages README" bash -c \
+  "awk '/^release-prep:/{in_target=1; next} /^[[:alnum:]_-]+:/{in_target=0} in_target && /git add/ {print}' Makefile | grep -qF 'README.md'"
 
 echo "-- T11: multi-model review fixes (concurrency, 2-job split, env-mapping)"
 # Concurrency key prevents two release runs at once.

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -214,6 +214,7 @@ check_neg "Makefile: release target removed"  grep -qE '^release:' Makefile
 check "Makefile: release-prep present"    grep -qE '^release-prep:' Makefile
 check "Makefile: setup uses uv→pip"       grep -q 'command -v uv' Makefile
 check "Makefile: release-prep stages plugin manifest" grep -qF 'plugins/trinity/.codex-plugin/plugin.json' Makefile
+check "Makefile: release-prep stages README" grep -qF 'README.md' Makefile
 
 echo "-- T11: multi-model review fixes (concurrency, 2-job split, env-mapping)"
 # Concurrency key prevents two release runs at once.


### PR DESCRIPTION
## Summary

This PR fixes the README version drift found after the v3.1.0 release and adds a release gate so the same class of drift is caught automatically next time.

Changes:
- Update README install examples from `3.0.0` to the current release version.
- Teach `make bump VERSION=x.y.z` to update README install-version examples.
- Teach `make release-prep` to stage `README.md` with the other release metadata files.
- Add a test that fails when README install-version examples drift from `VERSION`.
- Update TRN-1003 and TRN-1004 so the SOP names README and the Codex plugin manifest as release metadata.

## Why

The v3.1.0 source archive was published before this README fix landed, so its README still showed stale `3.0.0` examples. Retagging v3.1.0 would be unsafe. The clean path is to fix the gate on `main`, then cut a patch release `v3.1.1`.

## Verification

- `make bump VERSION=3.1.0`
- `make test`
- `make lint`
- `af validate --root .`
- `git diff --check`

## Release Plan

After this PR merges, prepare and publish `v3.1.1` using the normal TRN-1003/TRN-1004 flow.