### PR TITLE
Add claude-code provider and pin GLM high reasoning

### DIFF
--- a/.agents/trinity.codex.json
+++ b/.agents/trinity.codex.json
@@ -1,7 +1,7 @@
 {
   "providers": {
     "glm": {
-      "cli": "droid exec --model glm-5",
+      "cli": "droid exec --model glm-5.1 --reasoning-effort high",
       "supports_resume": true,
       "resume_arg": "-s",
       "timeout": 360

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+- `claude-code` is now a first-class Claude Code provider. `make install` and
+  `install.sh` install `trinity-claude-code.md`, register
+  `~/.claude/skills/trinity/bin/claude-code -p`, and ship an isolated nested
+  Claude Code wrapper that disables Trinity recursion, uses separate
+  `CLAUDE_CONFIG_DIR`, disables slash commands, and defaults to
+  `--model sonnet --effort high`.
+
+### Changed
+- GLM now uses Droid Core `glm-5.1` with explicit highest supported reasoning
+  effort: `--reasoning-effort high`. Claude Code installs keep
+  `--auto medium` for normal development tasks, while Codex-native review
+  config stays read-only and only changes the model/effort flags.
+
 ## [3.1.1] - 2026-05-06
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,13 @@ install:        ## Install Trinity to ~/.claude/ (TRN-1005)
 	cp providers/gemini.md ~/.claude/agents/trinity-gemini.md
 	cp providers/openrouter.md ~/.claude/agents/trinity-openrouter.md
 	cp providers/deepseek.md ~/.claude/agents/trinity-deepseek.md
+	cp providers/claude-code.md ~/.claude/agents/trinity-claude-code.md
 	cp providers/bin/deepseek ~/.claude/skills/trinity/bin/deepseek
 	cp providers/bin/openrouter ~/.claude/skills/trinity/bin/openrouter
-	chmod +x ~/.claude/skills/trinity/bin/deepseek ~/.claude/skills/trinity/bin/openrouter
+	cp providers/bin/claude-code ~/.claude/skills/trinity/bin/claude-code
+	chmod +x ~/.claude/skills/trinity/bin/deepseek ~/.claude/skills/trinity/bin/openrouter ~/.claude/skills/trinity/bin/claude-code
 	python3 ~/.claude/skills/trinity/scripts/install.py register glm \
-		--cli "droid exec --model glm-5" \
+		--cli "droid exec --auto medium --model glm-5.1 --reasoning-effort high" \
 		--global-config ~/.claude/trinity.json
 	python3 ~/.claude/skills/trinity/scripts/install.py register codex \
 		--cli "codex exec --skip-git-repo-check -m gpt-5.5" \
@@ -60,6 +62,9 @@ install:        ## Install Trinity to ~/.claude/ (TRN-1005)
 		--global-config ~/.claude/trinity.json
 	python3 ~/.claude/skills/trinity/scripts/install.py register deepseek \
 		--cli "$(HOME)/.claude/skills/trinity/bin/deepseek -p" \
+		--global-config ~/.claude/trinity.json
+	python3 ~/.claude/skills/trinity/scripts/install.py register claude-code \
+		--cli "$(HOME)/.claude/skills/trinity/bin/claude-code -p" \
 		--global-config ~/.claude/trinity.json
 	@echo "Installed Trinity $(CURRENT_VERSION)"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trinity — Multi-Model Orchestration for Claude Code
 
-Dispatch tasks to any LLM (GLM, Codex, Gemini, or your own) from within Claude Code. Providers run in the background via Claude's Agent tool. Sessions persist across turns. Health monitoring tells you if they're alive.
+Dispatch tasks to any LLM (GLM, Codex, Gemini, Claude Code, or your own) from within Claude Code. Providers run in the background via Claude's Agent tool. Sessions persist across turns. Health monitoring tells you if they're alive.
 
 The name comes from 三位一体 — not a fixed count, but a philosophy: all AIs united, working together. Whoever runs Trinity is the Leader. Any external LLM with a CLI is a Member.
 
@@ -42,7 +42,7 @@ The name comes from 三位一体 — not a fixed count, but a philosophy: all AI
 curl -fsSL https://raw.githubusercontent.com/frankyxhl/trinity/main/install.sh | bash
 ```
 
-This downloads all skill files to `~/.claude/` and registers the five default providers (glm, codex, gemini, openrouter, deepseek) in `~/.claude/trinity.json`. Expected output ends with:
+This downloads all skill files to `~/.claude/` and registers the six default providers (glm, codex, gemini, openrouter, deepseek, claude-code) in `~/.claude/trinity.json`. Expected output ends with:
 
 ```
 Trinity 3.1.1 installed to ~/.claude/
@@ -62,7 +62,7 @@ Trinity's skill (`SKILL.md`) is loaded by Claude Code at startup. The install ta
 /trinity status
 ```
 
-Expected output: glm, codex, gemini, openrouter, and deepseek all show ✅ usable. If any show ⚠️, run `/trinity install <provider>` to repair.
+Expected output: glm, codex, gemini, openrouter, deepseek, and claude-code all show ✅ usable. If any show ⚠️, run `/trinity install <provider>` to repair.
 
 ### What was installed
 
@@ -75,8 +75,10 @@ Expected output: glm, codex, gemini, openrouter, and deepseek all show ✅ usabl
 | `~/.claude/agents/trinity-gemini.md` | Gemini worker agent |
 | `~/.claude/agents/trinity-openrouter.md` | OpenRouter worker agent |
 | `~/.claude/agents/trinity-deepseek.md` | DeepSeek V4 worker agent |
+| `~/.claude/agents/trinity-claude-code.md` | Claude Code worker agent |
 | `~/.claude/skills/trinity/bin/deepseek` | DeepSeek `claude --dangerously-skip-permissions` wrapper (env injection + key-file loader) |
 | `~/.claude/skills/trinity/bin/openrouter` | OpenRouter wrapper (same shape) |
+| `~/.claude/skills/trinity/bin/claude-code` | Isolated nested Claude Code wrapper (`--model sonnet --effort high`) |
 | `~/.claude/trinity.json` | Global provider registry |
 
 ---
@@ -128,9 +130,9 @@ Each install command:
 5. Runs a smoke test to verify everything works
 6. Rolls back atomically if any step fails
 
-**Wrapper-based providers** (`openrouter`, `deepseek`) don't have a package install path — they use the `claude` binary pointed at an Anthropic-compatible endpoint via small POSIX shell wrappers shipped in `providers/bin/` and installed to `~/.claude/skills/trinity/bin/`. `install.sh` and `make install` set them up automatically; no `~/.zshrc` edits required.
+**Wrapper-based providers** (`openrouter`, `deepseek`, `claude-code`) don't have a package install path — they use small POSIX shell wrappers shipped in `providers/bin/` and installed to `~/.claude/skills/trinity/bin/`. `openrouter` and `deepseek` point the `claude` binary at Anthropic-compatible endpoints. `claude-code` starts an isolated nested Claude Code process with Trinity dispatch disabled, defaulting to `--model sonnet --effort high`. `install.sh` and `make install` set them up automatically; no `~/.zshrc` edits required.
 
-Each wrapper expects an API key, in this order of precedence:
+The Anthropic-compatible wrappers expect an API key, in this order of precedence:
 1. **Environment variable** — `DEEPSEEK_API_KEY` / `OPENROUTER_API_KEY`
 2. **Key file** — `~/.secrets/<provider>_api_key` with mode `600` (or `400`); the wrapper refuses anything more permissive
 
@@ -162,11 +164,15 @@ cp trinity/providers/openrouter.md ~/.claude/agents/trinity-openrouter.md
 # DeepSeek V4
 cp trinity/providers/deepseek.md ~/.claude/agents/trinity-deepseek.md
 
-# Wrapper bin scripts (deepseek + openrouter)
+# Claude Code
+cp trinity/providers/claude-code.md ~/.claude/agents/trinity-claude-code.md
+
+# Wrapper bin scripts (deepseek + openrouter + claude-code)
 mkdir -p ~/.claude/skills/trinity/bin
 cp trinity/providers/bin/deepseek   ~/.claude/skills/trinity/bin/deepseek
 cp trinity/providers/bin/openrouter ~/.claude/skills/trinity/bin/openrouter
-chmod +x ~/.claude/skills/trinity/bin/deepseek ~/.claude/skills/trinity/bin/openrouter
+cp trinity/providers/bin/claude-code ~/.claude/skills/trinity/bin/claude-code
+chmod +x ~/.claude/skills/trinity/bin/deepseek ~/.claude/skills/trinity/bin/openrouter ~/.claude/skills/trinity/bin/claude-code
 ```
 
 Then create `~/.claude/trinity.json`:
@@ -175,9 +181,10 @@ Then create `~/.claude/trinity.json`:
   "providers": {
     "codex":      { "cli": "codex exec --skip-git-repo-check -m gpt-5.5", "installed": true },
     "gemini":     { "cli": "gemini -p",                        "installed": true },
-    "glm":        { "cli": "droid exec --model glm-5",         "installed": true },
-    "openrouter": { "cli": "/Users/<you>/.claude/skills/trinity/bin/openrouter -p", "installed": true },
-    "deepseek":   { "cli": "/Users/<you>/.claude/skills/trinity/bin/deepseek -p",   "installed": true }
+    "glm":        { "cli": "droid exec --auto medium --model glm-5.1 --reasoning-effort high", "installed": true },
+    "openrouter":  { "cli": "/Users/<you>/.claude/skills/trinity/bin/openrouter -p",  "installed": true },
+    "deepseek":    { "cli": "/Users/<you>/.claude/skills/trinity/bin/deepseek -p",    "installed": true },
+    "claude-code": { "cli": "/Users/<you>/.claude/skills/trinity/bin/claude-code -p", "installed": true }
   },
   "defaults": {
     "heartbeat_interval": 120,
@@ -234,6 +241,9 @@ Default preset config:
 The Codex DeepSeek entry uses the installed
 `~/.codex/skills/trinity/bin/deepseek -p` wrapper so it does not depend on a
 locally accepted `droid` model alias.
+The optional `claude-code` preset entry is a Claude Code worker-agent provider;
+it is skipped by Codex-native reviews unless the user explicitly adds a
+compatible CLI entry to `~/.codex/trinity.json`.
 
 **Check provider health**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,6 +12,12 @@ Dispatch tasks to external LLM providers via background sub-agents. Providers ar
 ## Startup Check (run once per session before first dispatch)
 
 ```bash
+# 0. Refuse nested dispatch when Trinity is running as a claude-code provider
+if [ "${TRINITY_DISABLE_DISPATCH:-}" = "1" ]; then
+  echo "trinity: Nested Trinity dispatch is disabled in this Claude Code process (set by the claude-code provider wrapper)."
+  exit 1
+fi
+
 # 1. Verify python3 is available
 command -v python3 >/dev/null 2>&1 || {
   echo "trinity: python3 not found. Install: brew install python3"
@@ -73,7 +79,7 @@ A provider is **usable** only when it has both a config entry AND an agent file.
 ```json
 {
   "providers": {
-    "glm":    { "cli": "droid exec --model glm-5",         "installed": true },
+    "glm":    { "cli": "droid exec --auto medium --model glm-5.1 --reasoning-effort high", "installed": true },
     "codex":  { "cli": "codex exec --skip-git-repo-check", "installed": true },
     "gemini": { "cli": "gemini -p",                        "installed": true }
   },
@@ -274,7 +280,7 @@ Run provider discovery. Display two sections:
 ```
 | Provider | Status    | CLI                              |
 |----------|-----------|----------------------------------|
-| glm      | ✅ usable  | droid exec --model glm-5         |
+| glm      | ✅ usable  | droid exec --auto medium --model glm-5.1 --reasoning-effort high |
 | codex    | ✅ usable  | codex exec --skip-git-repo-check |
 | gemini   | ⚠️ missing | (agent file not found)           |
 ```

--- a/install.sh
+++ b/install.sh
@@ -47,16 +47,19 @@ _download "providers/codex.md"        "${HOME}/.claude/agents/trinity-codex.md"
 _download "providers/gemini.md"       "${HOME}/.claude/agents/trinity-gemini.md"
 _download "providers/openrouter.md"   "${HOME}/.claude/agents/trinity-openrouter.md"
 _download "providers/deepseek.md"     "${HOME}/.claude/agents/trinity-deepseek.md"
+_download "providers/claude-code.md"  "${HOME}/.claude/agents/trinity-claude-code.md"
 _download "providers/bin/deepseek"    "${HOME}/.claude/skills/trinity/bin/deepseek"
 _download "providers/bin/openrouter"  "${HOME}/.claude/skills/trinity/bin/openrouter"
+_download "providers/bin/claude-code" "${HOME}/.claude/skills/trinity/bin/claude-code"
 chmod +x "${HOME}/.claude/skills/trinity/bin/deepseek" \
-         "${HOME}/.claude/skills/trinity/bin/openrouter"
+         "${HOME}/.claude/skills/trinity/bin/openrouter" \
+         "${HOME}/.claude/skills/trinity/bin/claude-code"
 
 CURRENT_FILE=""
 
 # Register default providers in ~/.claude/trinity.json
 python3 "${HOME}/.claude/skills/trinity/scripts/install.py" register glm \
-    --cli "droid exec --model glm-5" \
+    --cli "droid exec --auto medium --model glm-5.1 --reasoning-effort high" \
     --global-config "${HOME}/.claude/trinity.json"
 python3 "${HOME}/.claude/skills/trinity/scripts/install.py" register codex \
     --cli "codex exec --skip-git-repo-check -m gpt-5.5" \
@@ -69,6 +72,9 @@ python3 "${HOME}/.claude/skills/trinity/scripts/install.py" register openrouter 
     --global-config "${HOME}/.claude/trinity.json"
 python3 "${HOME}/.claude/skills/trinity/scripts/install.py" register deepseek \
     --cli "${HOME}/.claude/skills/trinity/bin/deepseek -p" \
+    --global-config "${HOME}/.claude/trinity.json"
+python3 "${HOME}/.claude/skills/trinity/scripts/install.py" register claude-code \
+    --cli "${HOME}/.claude/skills/trinity/bin/claude-code -p" \
     --global-config "${HOME}/.claude/trinity.json"
 
 # Print success with version

--- a/providers/bin/claude-code
+++ b/providers/bin/claude-code
@@ -1,0 +1,23 @@
+#!/bin/sh
+# providers/bin/claude-code — isolated nested Claude Code wrapper for Trinity.
+#
+# This wrapper prevents recursive Trinity dispatch and keeps nested Claude Code
+# state separate from the orchestrator's normal ~/.claude state.
+set -eu
+
+MODEL="${TRINITY_CLAUDE_CODE_MODEL:-sonnet}"
+EFFORT="${TRINITY_CLAUDE_CODE_EFFORT:-high}"
+
+case "$EFFORT" in
+    low|medium|high|xhigh|max) ;;
+    *)
+        echo "trinity-claude-code: invalid effort '$EFFORT' (expected low|medium|high|xhigh|max)." >&2
+        exit 1
+        ;;
+esac
+
+TRINITY_DISABLE_DISPATCH="1" \
+CLAUDE_CONFIG_DIR="${HOME}/.claude-trinity-claude-code" \
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1" \
+exec claude --permission-mode bypassPermissions --disable-slash-commands \
+    --model "$MODEL" --effort "$EFFORT" "$@"

--- a/providers/claude-code.delta.md
+++ b/providers/claude-code.delta.md
@@ -1,0 +1,93 @@
+---
+name: trinity-claude-code
+description: |
+  Worker agent for Claude Code via an isolated nested `claude` CLI process.
+  Uses the wrapper installed by Trinity at providers/bin/claude-code to set
+  TRINITY_DISABLE_DISPATCH=1, isolate CLAUDE_CONFIG_DIR, disable slash
+  commands, and default to Claude Code's Sonnet model alias with high effort.
+  Supports session resume via --resume.
+
+  Invoked via Agent tool with subagent_type="general-purpose".
+  Claude passes: provider instance name, project dir, and task description.
+tools: Bash, Read, Write, Edit, Grep, Glob
+---
+
+You are a worker agent that executes tasks using Claude Code via a nested, isolated `claude` CLI process.
+
+## Your Job
+
+1. Receive a task from Claude (the orchestrator)
+2. Manage the session (new or resume)
+3. Call the provider via CLI
+4. Return a structured summary
+
+## Recursion Guard
+
+Never invoke `/trinity`, `$trinity`, or Trinity provider dispatch from this worker.
+The wrapper sets `TRINITY_DISABLE_DISPATCH=1` and starts Claude Code with
+`--disable-slash-commands`; treat that as a hard boundary. This provider may
+inspect files, run commands, and produce review or implementation guidance, but
+must not delegate back into Trinity.
+
+@include _base/common-session.md
+
+### Setup (run once before new or resume)
+
+Define the CLI entry function and session directory. `run_claude_code` calls the
+wrapper script installed by `install.sh` / `make install` (repo source:
+`providers/bin/claude-code`). The wrapper sets the nested session guard,
+isolates Claude Code state under `~/.claude-trinity-claude-code`, disables
+nonessential traffic, disables slash commands, and passes the default
+`--model sonnet --effort high`.
+
+If the task prompt contains `EFFORT=<level>`, where `<level>` is one of
+`low`, `medium`, `high`, `xhigh`, or `max`, pass it through
+`TRINITY_CLAUDE_CODE_EFFORT`. The wrapper also honors
+`TRINITY_CLAUDE_CODE_MODEL` when the orchestrator explicitly sets it.
+
+```bash
+run_claude_code() {
+  "$HOME/.claude/skills/trinity/bin/claude-code" "$@"
+}
+
+EFFORT=$(printf '%s\n' "$PROMPT" | grep -oE 'EFFORT=(low|medium|high|xhigh|max)' | head -1 | cut -d= -f2)
+
+# Session directory (scoped to project)
+PROJECT_SLUG=$(echo "$PROJECT_DIR" | sed 's|/|-|g; s|^-||')
+SESSION_DIR="$HOME/.claude-trinity-claude-code/projects/${PROJECT_SLUG}"
+```
+
+### New session (SESSION_ID == "NEW")
+Generate a trace marker and prepend it to the prompt (see family-wrapper section for the full pattern), then call:
+```bash
+if [ -n "$EFFORT" ]; then
+  TRINITY_CLAUDE_CODE_EFFORT="$EFFORT" run_claude_code -p "$MARKED_PROMPT"
+else
+  run_claude_code -p "$MARKED_PROMPT"
+fi
+```
+After the call, the marker grep in the family-wrapper section identifies the new JSONL.
+
+### Resume session (SESSION_ID != "NEW")
+```bash
+if [ -n "$EFFORT" ]; then
+  TRINITY_CLAUDE_CODE_EFFORT="$EFFORT" run_claude_code --resume "$SESSION_ID" -p "<prompt>"
+else
+  run_claude_code --resume "$SESSION_ID" -p "<prompt>"
+fi
+```
+If resume fails (session expired or not found), discard and create new.
+
+@include _base/family-wrapper.md
+
+## Instance Key
+
+Passed by Claude in the prompt. Format:
+- Default: `claude-code`
+- Named: `claude-code:review`, `claude-code:code`, etc.
+
+@include _base/common-tail.md
+- Always use `run_claude_code -p` for non-interactive mode
+- For resume: `run_claude_code --resume <session_id> -p "<prompt>"`
+- Always read responses from the session JSONL file, never from stdout
+- Do not run nested Trinity dispatch; the provider wrapper enforces this

--- a/providers/claude-code.md
+++ b/providers/claude-code.md
@@ -1,0 +1,212 @@
+---
+name: trinity-claude-code
+description: |
+  Worker agent for Claude Code via an isolated nested `claude` CLI process.
+  Uses the wrapper installed by Trinity at providers/bin/claude-code to set
+  TRINITY_DISABLE_DISPATCH=1, isolate CLAUDE_CONFIG_DIR, disable slash
+  commands, and default to Claude Code's Sonnet model alias with high effort.
+  Supports session resume via --resume.
+
+  Invoked via Agent tool with subagent_type="general-purpose".
+  Claude passes: provider instance name, project dir, and task description.
+tools: Bash, Read, Write, Edit, Grep, Glob
+---
+
+You are a worker agent that executes tasks using Claude Code via a nested, isolated `claude` CLI process.
+
+## Your Job
+
+1. Receive a task from Claude (the orchestrator)
+2. Manage the session (new or resume)
+3. Call the provider via CLI
+4. Return a structured summary
+
+## Recursion Guard
+
+Never invoke `/trinity`, `$trinity`, or Trinity provider dispatch from this worker.
+The wrapper sets `TRINITY_DISABLE_DISPATCH=1` and starts Claude Code with
+`--disable-slash-commands`; treat that as a hard boundary. This provider may
+inspect files, run commands, and produce review or implementation guidance, but
+must not delegate back into Trinity.
+
+## Session Management
+
+Session store location: `<project_dir>/.claude/trinity.json` (under the `sessions` key)
+
+### Reading sessions
+```bash
+SESSION_ID=$(python3 ~/.claude/skills/trinity/scripts/session.py read "$PROJECT_DIR" "$INSTANCE_KEY")
+```
+- Returns "NEW" if no existing session.
+
+### Writing sessions
+After a successful call, update the session store:
+```bash
+python3 ~/.claude/skills/trinity/scripts/session.py write "$PROJECT_DIR" "$INSTANCE_KEY" "$SESSION_ID" "$TASK_SUMMARY"
+```
+
+### Setup (run once before new or resume)
+
+Define the CLI entry function and session directory. `run_claude_code` calls the
+wrapper script installed by `install.sh` / `make install` (repo source:
+`providers/bin/claude-code`). The wrapper sets the nested session guard,
+isolates Claude Code state under `~/.claude-trinity-claude-code`, disables
+nonessential traffic, disables slash commands, and passes the default
+`--model sonnet --effort high`.
+
+If the task prompt contains `EFFORT=<level>`, where `<level>` is one of
+`low`, `medium`, `high`, `xhigh`, or `max`, pass it through
+`TRINITY_CLAUDE_CODE_EFFORT`. The wrapper also honors
+`TRINITY_CLAUDE_CODE_MODEL` when the orchestrator explicitly sets it.
+
+```bash
+run_claude_code() {
+  "$HOME/.claude/skills/trinity/bin/claude-code" "$@"
+}
+
+EFFORT=$(printf '%s\n' "$PROMPT" | grep -oE 'EFFORT=(low|medium|high|xhigh|max)' | head -1 | cut -d= -f2)
+
+# Session directory (scoped to project)
+PROJECT_SLUG=$(echo "$PROJECT_DIR" | sed 's|/|-|g; s|^-||')
+SESSION_DIR="$HOME/.claude-trinity-claude-code/projects/${PROJECT_SLUG}"
+```
+
+### New session (SESSION_ID == "NEW")
+Generate a trace marker and prepend it to the prompt (see family-wrapper section for the full pattern), then call:
+```bash
+if [ -n "$EFFORT" ]; then
+  TRINITY_CLAUDE_CODE_EFFORT="$EFFORT" run_claude_code -p "$MARKED_PROMPT"
+else
+  run_claude_code -p "$MARKED_PROMPT"
+fi
+```
+After the call, the marker grep in the family-wrapper section identifies the new JSONL.
+
+### Resume session (SESSION_ID != "NEW")
+```bash
+if [ -n "$EFFORT" ]; then
+  TRINITY_CLAUDE_CODE_EFFORT="$EFFORT" run_claude_code --resume "$SESSION_ID" -p "<prompt>"
+else
+  run_claude_code --resume "$SESSION_ID" -p "<prompt>"
+fi
+```
+If resume fails (session expired or not found), discard and create new.
+
+### Race-safe session file selection
+
+`claude -p` (used by anthropic_cli wrappers) does NOT emit response text to stdout. The response must be read from the session JSONL file under `${SESSION_DIR}/<session_id>.jsonl`.
+
+Picking the right file under concurrent same-project dispatches is the tricky part. Mtime alone is unsafe (TRINITY-2004 bundled fix #2): two simultaneous calls in the same wall-clock second produce JSONL files with identical mtimes, defeating any "newest file" heuristic. Macos APFS and Linux ext4 commonly only expose 1-second mtime resolution.
+
+**Solution: inject a unique trace marker into the prompt and grep the JSONL for it.** This works with bash 3.2+ (no associative arrays), is robust under any concurrency, and survives sub-second collisions.
+
+```bash
+# 1) Generate a unique trace ID for this call.
+TRINITY_TRACE="trinity-trace-$$-${RANDOM}-$(date +%s)"
+
+# 2) Embed the marker as an HTML comment at the top of the prompt.
+#    Anthropic CLI passes the prompt verbatim; the comment lands in the
+#    JSONL as part of the user message and is invisible to the model's output.
+MARKED_PROMPT=$(printf '<!-- %s -->\n%s' "$TRINITY_TRACE" "$PROMPT")
+
+# 3) Run the CLI call with $MARKED_PROMPT (provider-specific).
+
+# 4) After the call: find the JSONL file that contains the trace marker.
+JSONL=""
+for f in "${SESSION_DIR}"/*.jsonl; do
+  [ -e "$f" ] || continue
+  if grep -q "$TRINITY_TRACE" "$f" 2>/dev/null; then
+    JSONL="$f"
+    break
+  fi
+done
+if [ -z "$JSONL" ]; then
+  echo "ERROR: no session file containing trace marker $TRINITY_TRACE found" >&2
+  exit 1
+fi
+SESSION_ID=$(basename "$JSONL" .jsonl)
+```
+
+For resumed sessions the JSONL path is already known — read the same file directly:
+```bash
+JSONL="${SESSION_DIR}/${SESSION_ID}.jsonl"
+```
+
+### Extracting the response
+
+Skips malformed lines, thinking blocks, and non-text content; returns the most recent assistant text turn:
+```bash
+RESPONSE=$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    for line in reversed(f.readlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if d.get('type') != 'assistant':
+            continue
+        msg = d.get('message')
+        if not isinstance(msg, dict):
+            continue
+        texts = []
+        for c in (msg.get('content') or []):
+            if isinstance(c, dict) and c.get('type') == 'text':
+                texts.append(c.get('text', ''))
+        if texts:
+            print('\n'.join(texts))
+            break
+" "$JSONL")
+```
+
+## Instance Key
+
+Passed by Claude in the prompt. Format:
+- Default: `claude-code`
+- Named: `claude-code:review`, `claude-code:code`, etc.
+
+## Timeout
+
+- Set Bash timeout to 120000ms (2 min) for simple tasks
+- Set Bash timeout to 600000ms (10 min) for complex tasks
+
+## Iteration
+
+You may call the provider multiple times using resume:
+- If the first response is incomplete, ask the provider to continue
+- If the response needs refinement, send follow-up instructions
+- Maximum 3 rounds unless the task clearly requires more
+
+## Response Format
+
+Return to Claude:
+
+```
+## Task
+<what the provider was asked to do>
+
+## Instance
+<instance_key>
+
+## Result
+<key findings, code, suggestions, or outputs>
+
+## Session
+- ID: <session_id>
+- Status: new | resumed
+- Rounds: <number of CLI calls made>
+```
+
+## Rules
+
+- Always manage sessions (read before, write after)
+- If the provider needs file contents, read the file yourself and include it in the prompt
+- If the provider produces code, verify it looks reasonable before returning
+- Keep your summary focused — Claude doesn't need the full conversation log
+- Always use `run_claude_code -p` for non-interactive mode
+- For resume: `run_claude_code --resume <session_id> -p "<prompt>"`
+- Always read responses from the session JSONL file, never from stdout
+- Do not run nested Trinity dispatch; the provider wrapper enforces this

--- a/providers/glm.delta.md
+++ b/providers/glm.delta.md
@@ -1,28 +1,29 @@
 ---
 name: trinity-glm
 description: |
-  Worker agent for GLM-5 (via droid exec --model glm-5). Handles session management automatically.
-  Spawned by Claude to delegate coding, analysis, or brainstorming tasks to GLM-5.
+  Worker agent for GLM-5.1 (via droid exec --auto medium --model glm-5.1 --reasoning-effort high).
+  Handles session management automatically.
+  Spawned by Claude to delegate coding, analysis, or brainstorming tasks to GLM-5.1.
 
   Invoked via Agent tool with subagent_type="general-purpose".
   Claude passes: provider instance name, project dir, and task description.
 tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 
-You are a worker agent that executes tasks using GLM-5 via the `droid` CLI.
+You are a worker agent that executes tasks using GLM-5.1 via the `droid` CLI.
 
 ## Your Job
 
 1. Receive a task from Claude (the orchestrator)
 2. Manage the session (new or resume)
-3. Call GLM-5 via droid exec
+3. Call GLM-5.1 via droid exec
 4. Return a structured summary
 
 @include _base/common-session.md
 
 ### New session (no existing session)
 ```bash
-RESPONSE=$(droid exec --model glm-5 "<prompt>" 2>&1)
+RESPONSE=$(droid exec --auto medium --model glm-5.1 --reasoning-effort high "<prompt>" 2>&1)
 ```
 Then extract session ID from droid's session list:
 ```bash
@@ -36,7 +37,7 @@ print(sessions[0]['sessionId'] if sessions else 'UNKNOWN')
 
 ### Resume session (existing session found)
 ```bash
-RESPONSE=$(droid exec --model glm-5 -s "$SESSION_ID" "<prompt>" 2>&1)
+RESPONSE=$(droid exec --auto medium --model glm-5.1 --reasoning-effort high -s "$SESSION_ID" "<prompt>" 2>&1)
 ```
 
 If resume fails (non-zero exit or error), discard the old session and create a new one.
@@ -48,5 +49,5 @@ The instance key is passed by Claude in the prompt. Format:
 - Named: `glm:auth`, `glm:order`, etc.
 
 @include _base/common-tail.md
-- Always use `droid exec --model glm-5` (non-interactive mode)
+- Always use `droid exec --auto medium --model glm-5.1 --reasoning-effort high` (non-interactive mode)
 - If the task description mentions "complex", "large", or "multi-file", use the longer 600000ms timeout

--- a/providers/glm.md
+++ b/providers/glm.md
@@ -1,21 +1,22 @@
 ---
 name: trinity-glm
 description: |
-  Worker agent for GLM-5 (via droid exec --model glm-5). Handles session management automatically.
-  Spawned by Claude to delegate coding, analysis, or brainstorming tasks to GLM-5.
+  Worker agent for GLM-5.1 (via droid exec --auto medium --model glm-5.1 --reasoning-effort high).
+  Handles session management automatically.
+  Spawned by Claude to delegate coding, analysis, or brainstorming tasks to GLM-5.1.
 
   Invoked via Agent tool with subagent_type="general-purpose".
   Claude passes: provider instance name, project dir, and task description.
 tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 
-You are a worker agent that executes tasks using GLM-5 via the `droid` CLI.
+You are a worker agent that executes tasks using GLM-5.1 via the `droid` CLI.
 
 ## Your Job
 
 1. Receive a task from Claude (the orchestrator)
 2. Manage the session (new or resume)
-3. Call GLM-5 via droid exec
+3. Call GLM-5.1 via droid exec
 4. Return a structured summary
 
 ## Session Management
@@ -36,7 +37,7 @@ python3 ~/.claude/skills/trinity/scripts/session.py write "$PROJECT_DIR" "$INSTA
 
 ### New session (no existing session)
 ```bash
-RESPONSE=$(droid exec --model glm-5 "<prompt>" 2>&1)
+RESPONSE=$(droid exec --auto medium --model glm-5.1 --reasoning-effort high "<prompt>" 2>&1)
 ```
 Then extract session ID from droid's session list:
 ```bash
@@ -50,7 +51,7 @@ print(sessions[0]['sessionId'] if sessions else 'UNKNOWN')
 
 ### Resume session (existing session found)
 ```bash
-RESPONSE=$(droid exec --model glm-5 -s "$SESSION_ID" "<prompt>" 2>&1)
+RESPONSE=$(droid exec --auto medium --model glm-5.1 --reasoning-effort high -s "$SESSION_ID" "<prompt>" 2>&1)
 ```
 
 If resume fails (non-zero exit or error), discard the old session and create a new one.
@@ -99,5 +100,5 @@ Return to Claude:
 - If the provider needs file contents, read the file yourself and include it in the prompt
 - If the provider produces code, verify it looks reasonable before returning
 - Keep your summary focused — Claude doesn't need the full conversation log
-- Always use `droid exec --model glm-5` (non-interactive mode)
+- Always use `droid exec --auto medium --model glm-5.1 --reasoning-effort high` (non-interactive mode)
 - If the task description mentions "complex", "large", or "multi-file", use the longer 600000ms timeout

--- a/rules/TRN-1006-SOP-Provider-Model-IDs.md
+++ b/rules/TRN-1006-SOP-Provider-Model-IDs.md
@@ -1,8 +1,8 @@
 # SOP-1006: Provider Model IDs — Pinning and the `[1m]` Convention
 
 **Applies to:** Trinity project (`frankyxhl/trinity`)
-**Last updated:** 2026-04-26
-**Last reviewed:** 2026-04-26
+**Last updated:** 2026-05-06
+**Last reviewed:** 2026-05-06
 **Status:** Active
 **Related:** TRN-2005 (CHG: Pin trinity-codex to gpt-5.5), TRN-2009 (CHG: Remove zsh dependency)
 
@@ -81,11 +81,11 @@ Trinity's wrappers always double-quote the assignment (see `providers/bin/deepse
 
 Single source of truth per provider:
 
-| Provider | Model pin location | Pinned value (as of 2026-04-26) |
+| Provider | Model pin location | Pinned value (as of 2026-05-06) |
 |----------|--------------------|----------------------------------|
 | `codex` | `Makefile` `install` target + `install.sh` `register codex --cli` | `codex exec --skip-git-repo-check -m gpt-5.5` (TRN-2005) |
 | `gemini` | `providers/gemini.delta.md` `### New session` invocation | `gemini-3.1-pro-preview` |
-| `glm` | `Makefile` / `install.sh` `register glm --cli` | `droid exec --model glm-5` |
+| `glm` | `Makefile` / `install.sh` `register glm --cli`, `.agents/trinity.codex.json`, and `providers/glm.delta.md` | Claude Code install: `droid exec --auto medium --model glm-5.1 --reasoning-effort high`; Codex review: `droid exec --model glm-5.1 --reasoning-effort high` |
 | `deepseek` | `providers/bin/deepseek` env block | `ANTHROPIC_MODEL="deepseek-v4-pro[1m]"`, `ANTHROPIC_SMALL_FAST_MODEL="deepseek-v4-flash"` |
 | `openrouter` | `providers/bin/openrouter` env block | `ANTHROPIC_MODEL="qwen/qwen3.6-plus:free"`, `ANTHROPIC_SMALL_FAST_MODEL="qwen/qwen3.6-plus:free"` |
 
@@ -166,4 +166,5 @@ Tracked in `Makefile` install target and `install.sh` register call.
 
 | Date | Change | By |
 |------|--------|----|
+| 2026-05-06 | Update GLM pin location/value for GLM-5.1 plus explicit highest supported reasoning effort | Codex |
 | 2026-04-26 | Initial version — bracket-suffix convention, pin locations, update steps | Claude Opus 4.7 |

--- a/rules/TRN-2012-CHG-Claude-Code-Provider.md
+++ b/rules/TRN-2012-CHG-Claude-Code-Provider.md
@@ -2,8 +2,8 @@
 
 **Applies to:** Trinity project (`frankyxhl/trinity`)
 **Date:** 2026-05-04
-**Last updated:** 2026-05-04
-**Last reviewed:** 2026-05-04
+**Last updated:** 2026-05-06
+**Last reviewed:** 2026-05-06
 **Status:** Proposed
 **Requested by:** Frank
 **Implementer:** Codex
@@ -32,18 +32,19 @@ mechanical recursion guard before invoking `claude`.
 
 Default model and effort must be explicit:
 
-- **Default model:** `claude-opus-4-7`
-- **Default effort:** `xhigh`
+- **Default model:** `sonnet`
+- **Default effort:** `high`
 - **Allowed effort values:** `low`, `medium`, `high`, `xhigh`, `max`
 - **Override mechanism:** support `TRINITY_CLAUDE_CODE_MODEL` and
   `TRINITY_CLAUDE_CODE_EFFORT` environment variables in the wrapper. Provider
   instructions may also parse `EFFORT=<level>` from the task prompt and export
   `TRINITY_CLAUDE_CODE_EFFORT` before calling the wrapper.
 
-Rationale: official Claude Code CLI docs list `low`, `medium`, `high`, `xhigh`,
-and `max` as effort options. Official Anthropic effort guidance recommends
-starting Claude Opus 4.7 coding and agentic work at `xhigh`, and reserving
-`max` for genuinely frontier problems where evals show headroom.
+Rationale: Claude Code accepts model aliases such as `sonnet`, and the Sonnet
+alias tracks the current recommended Sonnet model for coding work. Official
+Claude Code effort guidance lists `low`, `medium`, `high`, `xhigh`, and `max`
+as CLI-level effort options, but Sonnet's supported default is `high`; reserve
+`max` for explicit one-off overrides.
 
 ---
 
@@ -107,7 +108,7 @@ just another external CLI.
 6. Add a mocked wrapper/CLI test that stubs `claude` and verifies the wrapper:
    sets `TRINITY_DISABLE_DISPATCH=1`, sets isolated `CLAUDE_CONFIG_DIR`, sets
    `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`, passes
-   `--disable-slash-commands`, passes `--model claude-opus-4-7 --effort xhigh`
+   `--disable-slash-commands`, passes `--model sonnet --effort high`
    by default, accepts `TRINITY_CLAUDE_CODE_MODEL` and
    `TRINITY_CLAUDE_CODE_EFFORT=max` overrides, rejects invalid effort values,
    preserves `-p`/`--resume` argv, and does not require a real Claude Code
@@ -117,8 +118,8 @@ just another external CLI.
    `TRINITY_DISABLE_DISPATCH=1`.
 8. GREEN: create `providers/bin/claude-code` as a POSIX wrapper. It should call:
    ```sh
-   MODEL="${TRINITY_CLAUDE_CODE_MODEL:-claude-opus-4-7}"
-   EFFORT="${TRINITY_CLAUDE_CODE_EFFORT:-xhigh}"
+   MODEL="${TRINITY_CLAUDE_CODE_MODEL:-sonnet}"
+   EFFORT="${TRINITY_CLAUDE_CODE_EFFORT:-high}"
    exec claude --permission-mode bypassPermissions --disable-slash-commands --model "$MODEL" --effort "$EFFORT" "$@"
    ```
    with the required environment variables from Impact Analysis.
@@ -147,7 +148,7 @@ Expected evidence before marking complete:
 - `.venv/bin/pytest tests/test_config.py -q`
 - focused wrapper test for `providers/bin/claude-code` with a fake `claude`
   executable
-- model/effort regression evidence showing default `claude-opus-4-7` + `xhigh`,
+- model/effort regression evidence showing default `sonnet` + `high`,
   accepted `max` override, and rejected invalid effort override
 - regression evidence that root `SKILL.md` refuses `/trinity` dispatch when
   `TRINITY_DISABLE_DISPATCH=1`
@@ -172,10 +173,10 @@ tests pass, because it may consume Claude Code quota.
 
 ## Approval
 
-- [ ] Approved for implementation
-- [ ] Implemented
-- [ ] Verified locally
-- [ ] PR opened
+- [x] Approved for implementation
+- [x] Implemented
+- [x] Verified locally
+- [x] PR opened
 
 ---
 
@@ -185,7 +186,14 @@ tests pass, because it may consume Claude Code quota.
 |------|--------|--------|
 | 2026-05-04 | Created CHG draft with canonical provider name and TDD plan | Proposed |
 | 2026-05-04 | Reviewed with Trinity GLM, Gemini, and DeepSeek | REQUEST_CHANGES: require mechanical recursion guard, Claude config isolation, explicit CLI signature, hardcoded provider inventory, and version-bump guidance |
-| 2026-05-04 | Checked official Claude Code CLI and Anthropic effort docs | Default to `claude-opus-4-7` + `xhigh`; allow `max` as explicit override |
+| 2026-05-04 | Checked official Claude Code CLI and Anthropic effort docs | Initially proposed `claude-opus-4-7` + `xhigh`; allow `max` as explicit override |
+| 2026-05-06 | Rechecked Claude Code model/effort docs and user preference | Revised default to `sonnet` + `high`; keep explicit `max` override |
+| 2026-05-06 | Implemented provider files, wrapper, install registration, recursion guard, docs, and TDD coverage | Focused tests, `make test`, `make lint`, `make verify-built`, fake-home `make install`, and `af validate --root .` pass |
+| 2026-05-06 | Ran real Claude Code wrapper smoke on local CLI | Blocked by local auth: `Not logged in · Please run /login` |
+| 2026-05-06 | Reviewed implementation with Trinity fast-review (GLM + DeepSeek) | PASS from both; addressed DeepSeek advisory by making the nested dispatch guard exit non-zero |
+| 2026-05-06 | Re-reviewed final head with Trinity fast-review (GLM + DeepSeek) | PASS from both; addressed advisory docs clarifications before PR |
+| 2026-05-06 | Updated GLM to `glm-5.1 --reasoning-effort high` and re-reviewed with Trinity fast-review | PASS from GLM-5.1/high and DeepSeek |
+| 2026-05-06 | Opened PR #34 | Ready for GitHub review |
 
 ---
 
@@ -196,3 +204,4 @@ tests pass, because it may consume Claude Code quota.
 | 2026-05-04 | Initial CHG for Claude Code provider | Codex |
 | 2026-05-04 | Revised after Trinity provider review | Codex |
 | 2026-05-04 | Added explicit model and effort policy | Codex |
+| 2026-05-06 | Revised default model/effort to Claude Code `sonnet` + `high` | Codex |

--- a/scripts/build_providers.sh
+++ b/scripts/build_providers.sh
@@ -24,7 +24,7 @@ if [ "${1:-}" = "--check" ]; then
 fi
 
 PROVIDERS_DIR="providers"
-DELTAS=(codex gemini glm openrouter deepseek)
+DELTAS=(codex gemini glm openrouter deepseek claude-code)
 
 # Python under bash wrapper does the @include substitution and invariant checks.
 python3 - "$PROVIDERS_DIR" "$CHECK_MODE" "${DELTAS[@]}" <<'PY'

--- a/tests/test_anthropic_compat_wrappers.py
+++ b/tests/test_anthropic_compat_wrappers.py
@@ -1,10 +1,14 @@
 """
-Tests for providers/bin/deepseek and providers/bin/openrouter (TRN-2008/TRN-2009).
+Tests for providers/bin/deepseek, providers/bin/openrouter, and
+providers/bin/claude-code (TRN-2008/TRN-2009/TRN-2012).
 
-The wrapper scripts run `exec claude --dangerously-skip-permissions "$@"` after
-loading an API key (env DEEPSEEK_API_KEY / OPENROUTER_API_KEY wins; falls back
-to ~/.secrets/<provider>_api_key with mode 600 or 400) and injecting
-ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_MODEL etc.
+The Anthropic-compatible wrappers run
+`exec claude --dangerously-skip-permissions "$@"` after loading an API key (env
+DEEPSEEK_API_KEY / OPENROUTER_API_KEY wins; falls back to
+~/.secrets/<provider>_api_key with mode 600 or 400) and injecting
+ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_MODEL etc. The
+claude-code wrapper instead runs native Claude Code with
+`--permission-mode bypassPermissions`.
 
 Strategy: prepend a Python `claude` stub onto PATH that records argv + selected
 env vars to a JSON file before exit(0). Because the wrapper does `exec`, the
@@ -25,6 +29,7 @@ import pytest
 REPO_ROOT = Path(__file__).parent.parent
 DEEPSEEK_BIN = REPO_ROOT / "providers" / "bin" / "deepseek"
 OPENROUTER_BIN = REPO_ROOT / "providers" / "bin" / "openrouter"
+CLAUDE_CODE_BIN = REPO_ROOT / "providers" / "bin" / "claude-code"
 
 CAPTURED_ENV_KEYS = (
     "ANTHROPIC_BASE_URL",
@@ -35,6 +40,7 @@ CAPTURED_ENV_KEYS = (
     "API_TIMEOUT_MS",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
     "CLAUDE_CONFIG_DIR",
+    "TRINITY_DISABLE_DISPATCH",
 )
 
 
@@ -273,18 +279,75 @@ def test_t13_deepseek_unknown_perm_when_stat_fails(stub_env, tmp_path):
     assert not rec.exists()
 
 
+def test_t14_claude_code_default_model_effort_and_recursion_guard(stub_env):
+    env, rec = stub_env()
+    res = _run(CLAUDE_CODE_BIN, ["-p", "hello"], env)
+    assert res.returncode == 0, res.stderr
+    rec_data = json.loads(rec.read_text())
+    assert rec_data["argv"] == [
+        "--permission-mode",
+        "bypassPermissions",
+        "--disable-slash-commands",
+        "--model",
+        "sonnet",
+        "--effort",
+        "high",
+        "-p",
+        "hello",
+    ]
+    e = rec_data["env"]
+    assert e["TRINITY_DISABLE_DISPATCH"] == "1"
+    assert e["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+    assert e["CLAUDE_CONFIG_DIR"].endswith(".claude-trinity-claude-code")
+
+
+def test_t14_claude_code_accepts_model_and_max_effort_overrides(stub_env):
+    env, rec = stub_env(
+        {
+            "TRINITY_CLAUDE_CODE_MODEL": "claude-sonnet-4-6",
+            "TRINITY_CLAUDE_CODE_EFFORT": "max",
+        }
+    )
+    res = _run(CLAUDE_CODE_BIN, ["--resume", "cc-sess", "-p", "continue"], env)
+    assert res.returncode == 0, res.stderr
+    assert json.loads(rec.read_text())["argv"] == [
+        "--permission-mode",
+        "bypassPermissions",
+        "--disable-slash-commands",
+        "--model",
+        "claude-sonnet-4-6",
+        "--effort",
+        "max",
+        "--resume",
+        "cc-sess",
+        "-p",
+        "continue",
+    ]
+
+
+def test_t14_claude_code_rejects_invalid_effort_before_invoking_claude(stub_env):
+    env, rec = stub_env({"TRINITY_CLAUDE_CODE_EFFORT": "ultra"})
+    res = _run(CLAUDE_CODE_BIN, ["-p", "hello"], env)
+    assert res.returncode == 1
+    assert "invalid effort" in res.stderr
+    assert "low|medium|high|xhigh|max" in res.stderr
+    assert not rec.exists()
+
+
 # --- Sanity check on installed bits (these are the obvious RED indicators) ---
 
 
 def test_wrapper_scripts_exist_and_executable():
     assert DEEPSEEK_BIN.is_file(), f"{DEEPSEEK_BIN} missing"
     assert OPENROUTER_BIN.is_file(), f"{OPENROUTER_BIN} missing"
+    assert CLAUDE_CODE_BIN.is_file(), f"{CLAUDE_CODE_BIN} missing"
     assert os.access(DEEPSEEK_BIN, os.X_OK), f"{DEEPSEEK_BIN} not executable"
     assert os.access(OPENROUTER_BIN, os.X_OK), f"{OPENROUTER_BIN} not executable"
+    assert os.access(CLAUDE_CODE_BIN, os.X_OK), f"{CLAUDE_CODE_BIN} not executable"
 
 
 def test_wrappers_use_posix_sh_shebang():
-    for p in (DEEPSEEK_BIN, OPENROUTER_BIN):
+    for p in (DEEPSEEK_BIN, OPENROUTER_BIN, CLAUDE_CODE_BIN):
         first_line = p.read_text().splitlines()[0]
         assert first_line == "#!/bin/sh", (
             f"{p}: expected POSIX sh shebang, got {first_line!r}"

--- a/tests/test_build_providers.sh
+++ b/tests/test_build_providers.sh
@@ -16,9 +16,9 @@ set -e
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-PROVIDERS=(codex gemini glm openrouter deepseek)
+PROVIDERS=(codex gemini glm openrouter deepseek claude-code)
 NATIVE=(codex gemini glm)
-WRAPPER=(openrouter deepseek)
+WRAPPER=(openrouter deepseek claude-code)
 PARTIALS=(_base/common-session.md _base/common-tail.md _base/family-wrapper.md)
 
 PASS=0
@@ -154,9 +154,10 @@ done
 # Provider-specific CLI signatures (delta content survived).
 check "codex CLI signature"      grep -q 'codex exec' providers/codex.md
 check "gemini CLI signature"     grep -q 'gemini --model' providers/gemini.md
-check "glm CLI signature"        grep -q 'droid exec --model glm-5' providers/glm.md
+check "glm CLI signature"        grep -q 'droid exec --auto medium --model glm-5.1 --reasoning-effort high' providers/glm.md
 check "openrouter run function"  grep -q 'run_openrouter()' providers/openrouter.md
 check "deepseek run function"    grep -q 'run_deepseek()' providers/deepseek.md
+check "claude-code run function" grep -q 'run_claude_code()' providers/claude-code.md
 
 echo "-- T7: drift sentinels (3 bundled fixes stay applied)"
 # Fix #1 — codex reasoning effort: model_reasoning_effort, default xhigh, override parsing

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -128,7 +128,7 @@ def test_codex_default_config_has_direct_review_providers():
     data = json.loads(CODEX_CONFIG.read_text())
 
     assert data["providers"]["glm"] == {
-        "cli": "droid exec --model glm-5",
+        "cli": "droid exec --model glm-5.1 --reasoning-effort high",
         "supports_resume": True,
         "resume_arg": "-s",
         "timeout": 360,
@@ -1549,7 +1549,10 @@ def test_install_codex_installs_skill_config_and_wrapper_without_claude(tmp_path
     )
     deepseek_wrapper = home / ".codex" / "skills" / "trinity" / "bin" / "deepseek"
     installed_config = json.loads((home / ".codex" / "trinity.json").read_text())
-    assert installed_config["providers"]["glm"]["cli"] == "droid exec --model glm-5"
+    assert (
+        installed_config["providers"]["glm"]["cli"]
+        == "droid exec --model glm-5.1 --reasoning-effort high"
+    )
     assert installed_config["providers"]["deepseek"]["cli"] == (
         "~/.codex/skills/trinity/bin/deepseek -p"
     )

--- a/tests/test_codex_compat.py
+++ b/tests/test_codex_compat.py
@@ -136,3 +136,12 @@ def test_claude_skill_documents_review_presets():
     assert "| `fast-review` | `glm`, `deepseek` | none |" in text
     assert "Configured presets" in text
     assert "Preset/provider collisions are invalid" in text
+
+
+def test_claude_skill_documents_nested_dispatch_guard():
+    text = ROOT_SKILL.read_text()
+
+    assert "TRINITY_DISABLE_DISPATCH" in text
+    assert "Nested Trinity dispatch is disabled" in text
+    assert "claude-code provider wrapper" in text
+    assert "exit 1" in text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -130,6 +130,39 @@ def test_providers_project_key_wins_on_conflict(tmp_path):
     assert result["providers"]["codex"]["cli"] == "codex-global"
 
 
+def test_hyphenated_provider_keys_are_preserved_in_merge(tmp_path):
+    global_config = tmp_path / "global" / "trinity.json"
+    write_config(
+        global_config,
+        {
+            "providers": {
+                "claude-code": {
+                    "cli": "$HOME/.claude/skills/trinity/bin/claude-code -p",
+                    "installed": True,
+                }
+            }
+        },
+    )
+    project_dir = tmp_path / "project"
+    project_trinity = project_dir / ".claude" / "trinity.json"
+    write_config(
+        project_trinity,
+        {"providers": {"claude-code": {"cli": "project-claude-code -p"}}},
+    )
+    rc, out, err = run(
+        [
+            "merge",
+            "--global-config",
+            str(global_config),
+            "--project-dir",
+            str(project_dir),
+        ]
+    )
+    assert rc == 0
+    result = json.loads(out)
+    assert result["providers"]["claude-code"]["cli"] == "project-claude-code -p"
+
+
 def test_defaults_project_wins_per_key(tmp_path):
     global_config = tmp_path / "global" / "trinity.json"
     write_config(global_config, {"defaults": {"timeout": 60, "model": "global-model"}})

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -96,6 +96,41 @@ def test_config_entry_with_agent_file_is_usable(tmp_path):
     assert entry["agent"] is not None
 
 
+def test_hyphenated_provider_name_is_discovered_from_config_and_agent(tmp_path):
+    global_config = tmp_path / "global" / "trinity.json"
+    project_dir = tmp_path / "project"
+    write_config(
+        project_dir / ".claude" / "trinity.json",
+        {
+            "providers": {
+                "claude-code": {
+                    "cli": "$HOME/.claude/skills/trinity/bin/claude-code -p"
+                }
+            }
+        },
+    )
+    write_agent(project_dir, "claude-code")
+    rc, out, err = run(
+        [
+            "list",
+            "--global-config",
+            str(global_config),
+            "--project-dir",
+            str(project_dir),
+        ]
+    )
+    assert rc == 0
+    result = json.loads(out)
+    assert result == [
+        {
+            "name": "claude-code",
+            "status": "usable",
+            "cli": "$HOME/.claude/skills/trinity/bin/claude-code -p",
+            "agent": str(project_dir / ".claude" / "agents" / "trinity-claude-code.md"),
+        }
+    ]
+
+
 def test_config_entry_no_agent_file_is_missing_agent(tmp_path):
     global_config = tmp_path / "global" / "trinity.json"
     project_dir = tmp_path / "project"

--- a/tests/test_install_sh.sh
+++ b/tests/test_install_sh.sh
@@ -46,12 +46,12 @@ t1_happy_path() {
 
     if [ $RC -ne 0 ]; then _fail "T1: non-zero exit"; return; fi
 
-    # Verify trinity.json was created with all 5 providers
+    # Verify trinity.json was created with all 6 providers
     TRINITY_JSON="${FAKE_HOME}/.claude/trinity.json"
     if [ ! -f "${TRINITY_JSON}" ]; then
         _fail "T1: ~/.claude/trinity.json not created"; rm -rf "${FAKE_HOME}"; return
     fi
-    for provider in glm codex gemini openrouter deepseek; do
+    for provider in glm codex gemini openrouter deepseek claude-code; do
         if ! python3 -c "import json,sys; d=json.load(open('${TRINITY_JSON}')); sys.exit(0 if '${provider}' in d.get('providers',{}) else 1)"; then
             _fail "T1: provider ${provider} missing from trinity.json"; rm -rf "${FAKE_HOME}"; return
         fi
@@ -69,13 +69,14 @@ t1_happy_path() {
         ".claude/agents/trinity-gemini.md"
         ".claude/agents/trinity-openrouter.md"
         ".claude/agents/trinity-deepseek.md"
+        ".claude/agents/trinity-claude-code.md"
     )
     for f in "${EXPECTED_FILES[@]}"; do
         if [ ! -f "${FAKE_HOME}/${f}" ]; then
             _fail "T1: missing ${f}"; rm -rf "${FAKE_HOME}"; return
         fi
     done
-    _pass "T1: happy path — all 11 files installed"
+    _pass "T1: happy path — all provider files installed"
     rm -rf "${FAKE_HOME}"
 }
 
@@ -200,8 +201,9 @@ t7_success_output_version() {
     rm -rf "${FAKE_HOME}"
 }
 
-# T9 (TRN-2008/2009): bin scripts present + executable; deepseek/openrouter
-# registered with absolute-path cli (no _cy reference).
+# T9 (TRN-2008/2009/TRN-2012): bin scripts present + executable;
+# deepseek/openrouter/claude-code registered with absolute-path cli (no _cy
+# reference).
 t9_bin_scripts_and_absolute_cli() {
     FAKE_HOME=$(mktemp -d)
     _start_server "${REPO_DIR}"
@@ -210,7 +212,7 @@ t9_bin_scripts_and_absolute_cli() {
     _stop_server
 
     BIN_DIR="${FAKE_HOME}/.claude/skills/trinity/bin"
-    for w in deepseek openrouter; do
+    for w in deepseek openrouter claude-code; do
         if [ ! -x "${BIN_DIR}/${w}" ]; then
             _fail "T9: ${BIN_DIR}/${w} missing or not executable"
             rm -rf "${FAKE_HOME}"; return
@@ -220,8 +222,10 @@ t9_bin_scripts_and_absolute_cli() {
     TRINITY_JSON="${FAKE_HOME}/.claude/trinity.json"
     EXPECTED_DS="${BIN_DIR}/deepseek -p"
     EXPECTED_OR="${BIN_DIR}/openrouter -p"
+    EXPECTED_CC="${BIN_DIR}/claude-code -p"
     ACTUAL_DS=$(python3 -c "import json; print(json.load(open('${TRINITY_JSON}'))['providers']['deepseek']['cli'])")
     ACTUAL_OR=$(python3 -c "import json; print(json.load(open('${TRINITY_JSON}'))['providers']['openrouter']['cli'])")
+    ACTUAL_CC=$(python3 -c "import json; print(json.load(open('${TRINITY_JSON}'))['providers']['claude-code']['cli'])")
 
     if [ "${ACTUAL_DS}" != "${EXPECTED_DS}" ]; then
         _fail "T9: deepseek cli mismatch: got '${ACTUAL_DS}' expected '${EXPECTED_DS}'"
@@ -231,6 +235,10 @@ t9_bin_scripts_and_absolute_cli() {
         _fail "T9: openrouter cli mismatch: got '${ACTUAL_OR}' expected '${EXPECTED_OR}'"
         rm -rf "${FAKE_HOME}"; return
     fi
+    if [ "${ACTUAL_CC}" != "${EXPECTED_CC}" ]; then
+        _fail "T9: claude-code cli mismatch: got '${ACTUAL_CC}' expected '${EXPECTED_CC}'"
+        rm -rf "${FAKE_HOME}"; return
+    fi
 
     # Sanity: no legacy _cy reference anywhere in trinity.json.
     if grep -q "_cy" "${TRINITY_JSON}"; then
@@ -238,7 +246,7 @@ t9_bin_scripts_and_absolute_cli() {
         rm -rf "${FAKE_HOME}"; return
     fi
 
-    _pass "T9: bin scripts installed + executable; deepseek/openrouter cli use absolute paths"
+    _pass "T9: bin scripts installed + executable; wrapper provider cli use absolute paths"
     rm -rf "${FAKE_HOME}"
 }
 
@@ -279,14 +287,14 @@ EOF
         rm -rf "${FAKE_HOME}"; return
     fi
 
-    # Other providers untouched (glm was pre-existing).
+    # GLM is migrated to the current highest-reasoning default.
     ACTUAL_GLM=$(python3 -c "import json; print(json.load(open('${TRINITY_JSON}'))['providers']['glm']['cli'])")
-    if [ "${ACTUAL_GLM}" != "droid exec --model glm-5" ]; then
-        _fail "T11: glm registration mutated unexpectedly: '${ACTUAL_GLM}'"
+    if [ "${ACTUAL_GLM}" != "droid exec --auto medium --model glm-5.1 --reasoning-effort high" ]; then
+        _fail "T11: glm registration not migrated: '${ACTUAL_GLM}'"
         rm -rf "${FAKE_HOME}"; return
     fi
 
-    _pass "T11: legacy deepseek_cy/openrouter_cy cli overwritten with absolute paths; other providers untouched"
+    _pass "T11: legacy wrapper cli overwritten; glm migrated to current default"
     rm -rf "${FAKE_HOME}"
 }
 


### PR DESCRIPTION
## Summary

- Add `claude-code` as a first-class Trinity provider with an isolated nested Claude Code wrapper.
- Install and register `trinity-claude-code.md` plus `providers/bin/claude-code` through both `make install` and `install.sh`.
- Add recursion safeguards: `TRINITY_DISABLE_DISPATCH=1`, isolated `CLAUDE_CONFIG_DIR`, `--disable-slash-commands`, and a root `SKILL.md` nested-dispatch guard.
- Pin GLM to `glm-5.1` with explicit highest supported reasoning effort, `--reasoning-effort high`.
- Keep Codex-native GLM reviews read-only while Claude Code installs retain `--auto medium` for normal development tasks.

## Notes

Factory Droid docs show `droid exec` supports `--model` / `--reasoning-effort` and that `--auto` controls autonomy rather than reasoning. Local `droid exec --help` reports `glm-5.1` supports reasoning `[off, high]` with default `high`; this PR pins `high` explicitly.

A real `claude-code` wrapper smoke against the native Claude Code CLI was attempted, but this machine is not logged in to Claude Code, so it stopped with `Not logged in · Please run /login`. Wrapper behavior is covered with a fake `claude` executable in tests.

## Verification

- `make test` PASS
- `make lint` PASS
- `make verify-built` PASS
- `af validate --root .` PASS
- `git diff --check` PASS
- fake-home `make install` smoke PASS
- `droid exec --model glm-5.1 --reasoning-effort high --list-tools` PASS
- `droid exec --auto medium --model glm-5.1 --reasoning-effort high --list-tools` PASS
- `trinity doctor --providers glm` PASS
- Trinity fast-review on final head: GLM-5.1/high PASS, DeepSeek PASS
