### PR TITLE
ci: skip Test workflow on docs-only PRs (paths-ignore)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,21 @@ name: Test
 on:
   push:
     branches: [main]
+    # Skip pure-docs pushes — see paths-ignore rationale below.
+    paths-ignore:
+      - 'rules/**'
+      - '*.md'
   pull_request:
+    # Skip CI on pure-docs PRs (status flips, README edits, CHANGELOG, TRN-PRP/PLN/CHG
+    # markdown). Mixed PRs that also touch Makefile/scripts/tests/.github still trigger.
+    # Trinity panel decision matrix (2026-05-07): unanimous Option A, weighted 8.75/8.37/6.62
+    # against B/B+A/C variants. Saves ~6 min macOS wall-clock on the ~70% of PRs that
+    # are pure-docs without losing the cross-platform parity gate on code PRs.
+    # Re-evaluate the glob if `rules/` ever gains executable content (hooks, scripts,
+    # `af validate` in CI) — currently all `.md`, so safe.
+    paths-ignore:
+      - 'rules/**'
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,19 @@ on:
     # Trinity panel decision matrix (2026-05-07): unanimous Option A, weighted 8.75/8.37/6.62
     # against B/B+A/C variants. Saves ~6 min macOS wall-clock on the ~70% of PRs that
     # are pure-docs without losing the cross-platform parity gate on code PRs.
+    #
     # Re-evaluate the glob if `rules/` ever gains executable content (hooks, scripts,
     # `af validate` in CI) — currently all `.md`, so safe.
+    #
+    # FOOT-GUN: if branch protection on `main` is ever configured to require the
+    # `Test (ubuntu-latest)` / `Test (macos-latest)` checks, this `paths-ignore`
+    # makes pure-docs PRs UNMERGEABLE — the skipped checks stay `Pending` forever.
+    # As of 2026-05-07 no branch protection / required checks are configured on main
+    # (only `protect-release-tags` ruleset, which targets tags), so this works today.
+    # If you add required checks later, migrate to a job-level `if:` skip pattern so
+    # the matrix always runs and reports success. See GitHub's docs on "skipping
+    # workflow runs" + the community pattern for required checks on path-filtered
+    # workflows.
     paths-ignore:
       - 'rules/**'
       - '*.md'


### PR DESCRIPTION
## Summary

Add `paths-ignore: ['rules/**', '*.md']` to both `on.push` and `on.pull_request` triggers in `.github/workflows/test.yml`. Pure-docs PRs (PRP/PLN/CHG drafts, README, CHANGELOG, status flips) skip both ubuntu + macOS CI entirely. Mixed PRs touching code still run the full matrix.

## Why

macOS CI runs ~6 min wall-clock per PR even when the diff is 100% docs. Per-step breakdown from a recent docs-only PR:

| Step | Ubuntu | macOS |
|------|--------|-------|
| Install dev deps | 11s | 14s |
| `make test` | 39s | **5m47s** |
| `make coverage` | 31s | ~30s |
| **Total** | 1m26s | ~6m |

The slowness is structural — macOS GitHub runners spawn processes 3–5× slower than Linux, and the 154-test suite is subprocess-heavy. For pure-docs PRs there's no code under test; both runners do 100% busywork.

## Trinity panel decision

Multi-model panel (glm + gemini + deepseek) on 2026-05-07 scored five mitigation options against six weighted criteria (parity gate 30%, wall-clock 25%, complexity 15%, reversibility 10%, cleanliness 10%, cost 10%). Aggregate ranking:

| Option | Mean weighted score |
|--------|---------------------|
| **A — paths-ignore docs (this PR)** | **8.75** ← winner |
| A+B (paths-ignore + scope coverage shim) | 8.37 |
| B (scope shim alone) | 6.62 |
| A+C (paths-ignore + macOS nightly) | 5.83 |
| C (macOS to nightly only) | 5.62 |

All three panelists rejected C variants because surrendering the per-PR cross-platform gate would defeat slice B's purpose. The gate just caught PR #46 R1 (macOS-only SIGINT race) and R2 (release.yml dev-deps drift); it pays for itself.

## Effect

- **Pure-docs PRs** (e.g. the upcoming TRN-2020 closeout, future TRN-2025 / 2026 / 2027 drafts): both ubuntu + macOS CI legs skipped → ~6 min saved per PR.
- **Mixed PRs** touching `Makefile`, `scripts/`, `tests/`, `.github/workflows/`, `install.sh`, `providers/`, etc.: full matrix runs as today.
- **This PR itself** touches `.github/workflows/test.yml` (not in ignore list) → CI will trigger on this PR, validating the YAML.

## Caveats (logged in inline comment)

- Re-evaluate the glob if `rules/` ever gains executable content (hooks, scripts, `af validate` in CI). Currently all `.md` so safe.
- If a doc-build step like `mdbook test` or `af validate --root .` ever moves into CI, paths-ignore would mask real failures on docs PRs.

## Test plan

- [x] YAML structure verified locally: both `push.paths-ignore` and `pull_request.paths-ignore` set to `['rules/**', '*.md']`
- [ ] CI on this PR: triggers (touches workflow file), both legs green
- [ ] Post-merge: next pure-docs PR (the closeout follow-on) skips both CI legs as expected — meta-test that Option A works

## Rollback

Delete the four `paths-ignore` lines (or revert this commit). CI returns to running on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)