### PR TITLE
TRN-3022: Normalize review result schema for synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@
   surfaced (CHG passes panel + bot review but README/CHANGELOG drifts
   silently). Each new CHG's Acceptance Criteria table now references the
   relevant SOP sections by default. (#65)
+- Structured review output schema (TRN-3022): providers may emit a fenced
+  JSON block (`decision`, `weighted_score`, `blocking`, `advisories`) at
+  the end of review output. Synthesis enriches the Status column with
+  scores and renders a per-provider Findings section when structured data
+  is present. Free-form providers continue to work via legacy returncode
+  fallback. The addendum is code-side, gated on `task_type == "review"`.
+  Closes #39. Foundation for #55.
 
 ### Changed
 - `format_health_results` gains a `verbose` parameter (default False) plus

--- a/README.md
+++ b/README.md
@@ -301,6 +301,13 @@ prepend rubric weights, calibration guidance, the 9.0 PASS threshold, and the
 findings / decision-matrix / weighted-average output schema to the prompt.
 SOP, rubric, threshold, and schema are recorded in `metadata.json`.
 
+**Structured review output** — when using a preset with `task_type: review`,
+Trinity appends a structured-output instruction to the prompt requesting
+providers emit a fenced JSON block (`decision`, `weighted_score`, `blocking`,
+`advisories`). Providers that comply produce enriched `synthesis.md` output
+with per-provider scores and a Findings section. Providers that don't emit
+the block continue to work via legacy returncode-based rendering. (#39)
+
 ### Update a PR after review fixes
 
 ```bash

--- a/providers/_base/common-tail.md
+++ b/providers/_base/common-tail.md
@@ -30,13 +30,6 @@ Return to Claude:
 - Rounds: <number of CLI calls made>
 ```
 
-## Rules
-
-- Always manage sessions (read before, write after)
-- If the provider needs file contents, read the file yourself and include it in the prompt
-- If the provider produces code, verify it looks reasonable before returning
-- Keep your summary focused — Claude doesn't need the full conversation log
-
 ## Structured Review Output (TRN-3022)
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
@@ -54,3 +47,10 @@ Providers that do not emit the block continue to work — synthesis falls back t
 ```
 
 Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+
+## Rules
+
+- Always manage sessions (read before, write after)
+- If the provider needs file contents, read the file yourself and include it in the prompt
+- If the provider produces code, verify it looks reasonable before returning
+- Keep your summary focused — Claude doesn't need the full conversation log

--- a/providers/_base/common-tail.md
+++ b/providers/_base/common-tail.md
@@ -36,3 +36,21 @@ Return to Claude:
 - If the provider needs file contents, read the file yourself and include it in the prompt
 - If the provider produces code, verify it looks reasonable before returning
 - Keep your summary focused — Claude doesn't need the full conversation log
+
+## Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.

--- a/providers/_base/common-tail.md
+++ b/providers/_base/common-tail.md
@@ -34,19 +34,7 @@ Return to Claude:
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
 
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. Required fields: `decision` (`"PASS"` or `"FIX"`), `weighted_score` (number 0.0-10.0), `blocking` (list, may be `[]`), `advisories` (list, may be `[]`). Optional: `confidence` (number 0.0-1.0). Full spec including a concrete valid example: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 
 ## Rules
 

--- a/providers/_base/family-wrapper.md
+++ b/providers/_base/family-wrapper.md
@@ -67,3 +67,21 @@ with open(sys.argv[1]) as f:
             break
 " "$JSONL")
 ```
+
+### Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.

--- a/providers/_base/family-wrapper.md
+++ b/providers/_base/family-wrapper.md
@@ -67,21 +67,3 @@ with open(sys.argv[1]) as f:
             break
 " "$JSONL")
 ```
-
-### Structured Review Output (TRN-3022)
-
-Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
-
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.

--- a/providers/claude-code.md
+++ b/providers/claude-code.md
@@ -204,19 +204,7 @@ Return to Claude:
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
 
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. Required fields: `decision` (`"PASS"` or `"FIX"`), `weighted_score` (number 0.0-10.0), `blocking` (list, may be `[]`), `advisories` (list, may be `[]`). Optional: `confidence` (number 0.0-1.0). Full spec including a concrete valid example: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 
 ## Rules
 

--- a/providers/claude-code.md
+++ b/providers/claude-code.md
@@ -162,24 +162,6 @@ with open(sys.argv[1]) as f:
 " "$JSONL")
 ```
 
-### Structured Review Output (TRN-3022)
-
-Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
-
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
-
 ## Instance Key
 
 Passed by Claude in the prompt. Format:
@@ -224,6 +206,24 @@ Return to Claude:
 - If the provider needs file contents, read the file yourself and include it in the prompt
 - If the provider produces code, verify it looks reasonable before returning
 - Keep your summary focused — Claude doesn't need the full conversation log
+
+## Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 - Always use `run_claude_code -p` for non-interactive mode
 - For resume: `run_claude_code --resume <session_id> -p "<prompt>"`
 - Always read responses from the session JSONL file, never from stdout

--- a/providers/claude-code.md
+++ b/providers/claude-code.md
@@ -200,13 +200,6 @@ Return to Claude:
 - Rounds: <number of CLI calls made>
 ```
 
-## Rules
-
-- Always manage sessions (read before, write after)
-- If the provider needs file contents, read the file yourself and include it in the prompt
-- If the provider produces code, verify it looks reasonable before returning
-- Keep your summary focused — Claude doesn't need the full conversation log
-
 ## Structured Review Output (TRN-3022)
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
@@ -224,6 +217,13 @@ Providers that do not emit the block continue to work — synthesis falls back t
 ```
 
 Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+
+## Rules
+
+- Always manage sessions (read before, write after)
+- If the provider needs file contents, read the file yourself and include it in the prompt
+- If the provider produces code, verify it looks reasonable before returning
+- Keep your summary focused — Claude doesn't need the full conversation log
 - Always use `run_claude_code -p` for non-interactive mode
 - For resume: `run_claude_code --resume <session_id> -p "<prompt>"`
 - Always read responses from the session JSONL file, never from stdout

--- a/providers/claude-code.md
+++ b/providers/claude-code.md
@@ -162,6 +162,24 @@ with open(sys.argv[1]) as f:
 " "$JSONL")
 ```
 
+### Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+
 ## Instance Key
 
 Passed by Claude in the prompt. Format:

--- a/providers/codex.md
+++ b/providers/codex.md
@@ -111,5 +111,23 @@ Return to Claude:
 - If the provider needs file contents, read the file yourself and include it in the prompt
 - If the provider produces code, verify it looks reasonable before returning
 - Keep your summary focused — Claude doesn't need the full conversation log
+
+## Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 - Always use `codex exec --skip-git-repo-check -m gpt-5.5 -c model_reasoning_effort=$EFFORT` (non-interactive mode)
 - Strip metadata headers from Codex output — return only the actual content

--- a/providers/codex.md
+++ b/providers/codex.md
@@ -109,19 +109,7 @@ Return to Claude:
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
 
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. Required fields: `decision` (`"PASS"` or `"FIX"`), `weighted_score` (number 0.0-10.0), `blocking` (list, may be `[]`), `advisories` (list, may be `[]`). Optional: `confidence` (number 0.0-1.0). Full spec including a concrete valid example: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 
 ## Rules
 

--- a/providers/codex.md
+++ b/providers/codex.md
@@ -105,13 +105,6 @@ Return to Claude:
 - Rounds: <number of CLI calls made>
 ```
 
-## Rules
-
-- Always manage sessions (read before, write after)
-- If the provider needs file contents, read the file yourself and include it in the prompt
-- If the provider produces code, verify it looks reasonable before returning
-- Keep your summary focused — Claude doesn't need the full conversation log
-
 ## Structured Review Output (TRN-3022)
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
@@ -129,5 +122,12 @@ Providers that do not emit the block continue to work — synthesis falls back t
 ```
 
 Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+
+## Rules
+
+- Always manage sessions (read before, write after)
+- If the provider needs file contents, read the file yourself and include it in the prompt
+- If the provider produces code, verify it looks reasonable before returning
+- Keep your summary focused — Claude doesn't need the full conversation log
 - Always use `codex exec --skip-git-repo-check -m gpt-5.5 -c model_reasoning_effort=$EFFORT` (non-interactive mode)
 - Strip metadata headers from Codex output — return only the actual content

--- a/providers/deepseek.md
+++ b/providers/deepseek.md
@@ -138,24 +138,6 @@ with open(sys.argv[1]) as f:
 " "$JSONL")
 ```
 
-### Structured Review Output (TRN-3022)
-
-Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
-
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
-
 ## Instance Key
 
 Passed by Claude in the prompt. Format:
@@ -200,6 +182,24 @@ Return to Claude:
 - If the provider needs file contents, read the file yourself and include it in the prompt
 - If the provider produces code, verify it looks reasonable before returning
 - Keep your summary focused — Claude doesn't need the full conversation log
+
+## Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 - Always use `run_deepseek -p` for non-interactive mode
 - For resume: `run_deepseek --resume <session_id> -p "<prompt>"`
 - Always read responses from the session JSONL file, never from stdout

--- a/providers/deepseek.md
+++ b/providers/deepseek.md
@@ -180,19 +180,7 @@ Return to Claude:
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
 
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. Required fields: `decision` (`"PASS"` or `"FIX"`), `weighted_score` (number 0.0-10.0), `blocking` (list, may be `[]`), `advisories` (list, may be `[]`). Optional: `confidence` (number 0.0-1.0). Full spec including a concrete valid example: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 
 ## Rules
 

--- a/providers/deepseek.md
+++ b/providers/deepseek.md
@@ -176,13 +176,6 @@ Return to Claude:
 - Rounds: <number of CLI calls made>
 ```
 
-## Rules
-
-- Always manage sessions (read before, write after)
-- If the provider needs file contents, read the file yourself and include it in the prompt
-- If the provider produces code, verify it looks reasonable before returning
-- Keep your summary focused — Claude doesn't need the full conversation log
-
 ## Structured Review Output (TRN-3022)
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
@@ -200,6 +193,13 @@ Providers that do not emit the block continue to work — synthesis falls back t
 ```
 
 Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+
+## Rules
+
+- Always manage sessions (read before, write after)
+- If the provider needs file contents, read the file yourself and include it in the prompt
+- If the provider produces code, verify it looks reasonable before returning
+- Keep your summary focused — Claude doesn't need the full conversation log
 - Always use `run_deepseek -p` for non-interactive mode
 - For resume: `run_deepseek --resume <session_id> -p "<prompt>"`
 - Always read responses from the session JSONL file, never from stdout

--- a/providers/deepseek.md
+++ b/providers/deepseek.md
@@ -138,6 +138,24 @@ with open(sys.argv[1]) as f:
 " "$JSONL")
 ```
 
+### Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+
 ## Instance Key
 
 Passed by Claude in the prompt. Format:

--- a/providers/gemini.md
+++ b/providers/gemini.md
@@ -95,13 +95,6 @@ Return to Claude:
 - Rounds: <number of CLI calls made>
 ```
 
-## Rules
-
-- Always manage sessions (read before, write after)
-- If the provider needs file contents, read the file yourself and include it in the prompt
-- If the provider produces code, verify it looks reasonable before returning
-- Keep your summary focused — Claude doesn't need the full conversation log
-
 ## Structured Review Output (TRN-3022)
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
@@ -119,5 +112,12 @@ Providers that do not emit the block continue to work — synthesis falls back t
 ```
 
 Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+
+## Rules
+
+- Always manage sessions (read before, write after)
+- If the provider needs file contents, read the file yourself and include it in the prompt
+- If the provider produces code, verify it looks reasonable before returning
+- Keep your summary focused — Claude doesn't need the full conversation log
 - Always use `gemini --model gemini-3.1-pro-preview -p` for non-interactive mode
 - For resume: `gemini --model gemini-3.1-pro-preview -r <index> -p "<prompt>"` (order matters: -r before -p)

--- a/providers/gemini.md
+++ b/providers/gemini.md
@@ -99,19 +99,7 @@ Return to Claude:
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
 
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. Required fields: `decision` (`"PASS"` or `"FIX"`), `weighted_score` (number 0.0-10.0), `blocking` (list, may be `[]`), `advisories` (list, may be `[]`). Optional: `confidence` (number 0.0-1.0). Full spec including a concrete valid example: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 
 ## Rules
 

--- a/providers/gemini.md
+++ b/providers/gemini.md
@@ -101,5 +101,23 @@ Return to Claude:
 - If the provider needs file contents, read the file yourself and include it in the prompt
 - If the provider produces code, verify it looks reasonable before returning
 - Keep your summary focused — Claude doesn't need the full conversation log
+
+## Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 - Always use `gemini --model gemini-3.1-pro-preview -p` for non-interactive mode
 - For resume: `gemini --model gemini-3.1-pro-preview -r <index> -p "<prompt>"` (order matters: -r before -p)

--- a/providers/glm.md
+++ b/providers/glm.md
@@ -94,13 +94,6 @@ Return to Claude:
 - Rounds: <number of CLI calls made>
 ```
 
-## Rules
-
-- Always manage sessions (read before, write after)
-- If the provider needs file contents, read the file yourself and include it in the prompt
-- If the provider produces code, verify it looks reasonable before returning
-- Keep your summary focused — Claude doesn't need the full conversation log
-
 ## Structured Review Output (TRN-3022)
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
@@ -118,5 +111,12 @@ Providers that do not emit the block continue to work — synthesis falls back t
 ```
 
 Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+
+## Rules
+
+- Always manage sessions (read before, write after)
+- If the provider needs file contents, read the file yourself and include it in the prompt
+- If the provider produces code, verify it looks reasonable before returning
+- Keep your summary focused — Claude doesn't need the full conversation log
 - Always use `droid exec --auto medium --model glm-5.1 --reasoning-effort high` (non-interactive mode)
 - If the task description mentions "complex", "large", or "multi-file", use the longer 600000ms timeout

--- a/providers/glm.md
+++ b/providers/glm.md
@@ -98,19 +98,7 @@ Return to Claude:
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
 
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. Required fields: `decision` (`"PASS"` or `"FIX"`), `weighted_score` (number 0.0-10.0), `blocking` (list, may be `[]`), `advisories` (list, may be `[]`). Optional: `confidence` (number 0.0-1.0). Full spec including a concrete valid example: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 
 ## Rules
 

--- a/providers/glm.md
+++ b/providers/glm.md
@@ -100,5 +100,23 @@ Return to Claude:
 - If the provider needs file contents, read the file yourself and include it in the prompt
 - If the provider produces code, verify it looks reasonable before returning
 - Keep your summary focused — Claude doesn't need the full conversation log
+
+## Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 - Always use `droid exec --auto medium --model glm-5.1 --reasoning-effort high` (non-interactive mode)
 - If the task description mentions "complex", "large", or "multi-file", use the longer 600000ms timeout

--- a/providers/openrouter.md
+++ b/providers/openrouter.md
@@ -180,19 +180,7 @@ Return to Claude:
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
 
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. Required fields: `decision` (`"PASS"` or `"FIX"`), `weighted_score` (number 0.0-10.0), `blocking` (list, may be `[]`), `advisories` (list, may be `[]`). Optional: `confidence` (number 0.0-1.0). Full spec including a concrete valid example: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 
 ## Rules
 

--- a/providers/openrouter.md
+++ b/providers/openrouter.md
@@ -176,13 +176,6 @@ Return to Claude:
 - Rounds: <number of CLI calls made>
 ```
 
-## Rules
-
-- Always manage sessions (read before, write after)
-- If the provider needs file contents, read the file yourself and include it in the prompt
-- If the provider produces code, verify it looks reasonable before returning
-- Keep your summary focused — Claude doesn't need the full conversation log
-
 ## Structured Review Output (TRN-3022)
 
 Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
@@ -200,6 +193,13 @@ Providers that do not emit the block continue to work — synthesis falls back t
 ```
 
 Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+
+## Rules
+
+- Always manage sessions (read before, write after)
+- If the provider needs file contents, read the file yourself and include it in the prompt
+- If the provider produces code, verify it looks reasonable before returning
+- Keep your summary focused — Claude doesn't need the full conversation log
 - Always use `run_openrouter -p` for non-interactive mode
 - For resume: `run_openrouter --resume <session_id> -p "<prompt>"`
 - Always read responses from the session JSONL file, never from stdout

--- a/providers/openrouter.md
+++ b/providers/openrouter.md
@@ -138,24 +138,6 @@ with open(sys.argv[1]) as f:
 " "$JSONL")
 ```
 
-### Structured Review Output (TRN-3022)
-
-Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
-
-Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
-
-```json
-{
-  "decision": "PASS" | "FIX",
-  "weighted_score": 0.0-10.0,
-  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
-  "confidence": 0.0-1.0
-}
-```
-
-Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
-
 ## Instance Key
 
 Passed by Claude in the prompt. Format:
@@ -200,6 +182,24 @@ Return to Claude:
 - If the provider needs file contents, read the file yourself and include it in the prompt
 - If the provider produces code, verify it looks reasonable before returning
 - Keep your summary focused — Claude doesn't need the full conversation log
+
+## Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
 - Always use `run_openrouter -p` for non-interactive mode
 - For resume: `run_openrouter --resume <session_id> -p "<prompt>"`
 - Always read responses from the session JSONL file, never from stdout

--- a/providers/openrouter.md
+++ b/providers/openrouter.md
@@ -138,6 +138,24 @@ with open(sys.argv[1]) as f:
 " "$JSONL")
 ```
 
+### Structured Review Output (TRN-3022)
+
+Trinity appends a structured-output instruction to review prompts. When the provider follows the instruction, it emits a fenced JSON block at the end of its output. Trinity's synthesis parser extracts the block and uses it for enriched status rendering and a per-provider Findings section in `synthesis.md`.
+
+Providers that do not emit the block continue to work — synthesis falls back to returncode-based PASS/FAIL. The schema is:
+
+```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": 0.0-10.0,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": 0.0-1.0
+}
+```
+
+Full spec: `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md`.
+
 ## Instance Key
 
 Passed by Claude in the prompt. Format:

--- a/rules/TRN-0000-REF-Document-Index.md
+++ b/rules/TRN-0000-REF-Document-Index.md
@@ -49,6 +49,7 @@
 | 3000 | REF | Code Agent Wrapping Architectures |
 | 3020 | CHG | Consolidate Provider Config |
 | 3021 | CHG | Expand Doctor Preflight |
+| 3022 | CHG | Normalize Review Result Schema |
 | 3023 | CHG | Sanitize Provider Environment At Spawn Time |
 
 ---

--- a/rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md
+++ b/rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md
@@ -106,15 +106,15 @@ Within each finding object:
 2. **Findings section** below the table — rendered ONLY when at least one rc=0 provider has a parsed structured block. For each such provider (in `results` iteration order, per deepseek A1):
    ```
    ### glm — FIX (7.5, 1 blocking, 2 advisories)
-   
+
    **Blocking:**
    - **Late-binding closure** at `scripts/foo.py:142-148` — Capture loop var via default arg
    - **Cross-cutting concern**  (no evidence cited)  — see review prose
-   
+
    **Advisories:**
    - **Style nit**  at `scripts/foo.py:33`
    ```
-   
+
    Rendering rules:
    - `fix` empty/missing → omit trailing ` — <fix>` to avoid dangling em-dash (per deepseek A2)
    - `evidence` empty → render bare title with `(no evidence cited)` annotation; no broken `at \`\`` markdown (per deepseek A3)

--- a/rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md
+++ b/rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md
@@ -1,0 +1,304 @@
+# CHG-3022: Normalize Review Result Schema for Synthesis
+
+**Applies to:** Trinity project (`frankyxhl/trinity`)
+**Last updated:** 2026-05-08
+**Last reviewed:** 2026-05-08
+**Status:** Approved
+**Date:** 2026-05-08
+**Requested by:** Frank Xu (issue #39)
+**Priority:** Medium
+**Change Type:** Feature (additive — preserves all existing free-form behavior)
+**Closes:** #39
+**References:** TRN-3000 (CLI-backend lessons); TRN-3020 (registry); TRN-3021 (doctor preflight); TRN-1007 (PR readiness gate)
+
+---
+
+## What
+
+Define a **structured review output schema** that providers can emit as a fenced JSON block at the end of their review. Add a parser that extracts the block from raw output and a synthesis path that prefers structured fields when present. Existing free-form provider output continues to work — synthesis falls back to today's PASS/FAIL-by-returncode rendering when no schema block is present.
+
+This is the foundation for issue #55 (richer summary output) — once the schema lands, summary rendering can render decision / weighted score / blocking findings / advisories per provider in a comparable form.
+
+**Design hardening (round-2 panel-driven)**: the round-1 panel (3-of-4 FAIL/PASS-with-blocker, codex 7.4 / glm 8.7 / gemini 8.7 / deepseek 9.16) caught 6 substantive design holes that shape the v2 spec:
+
+- **Task-type guard structurally impossible** — `render_prompt(config, root, scope, review_input, strict_review)` (codex.py:1218) has no `task_type` param; the static-template approach would leak the schema addendum into TDD/PRP/general task_types since they all share `review.prompt_template`. Resolved: extend `render_prompt` signature to accept `task_type`; addendum moves from static template into a code-side helper `_review_schema_addendum(task_type)` that returns empty string for non-review.
+- **stderr-side JSON breaks last-block-wins** — `raw_output(stdout, stderr)` (codex.py:1391) concatenates with `\n[stderr]\n` sentinel. A provider CLI that emits a fenced JSON block to stderr (telemetry, debug, error wrappers) would override the canonical stdout block. Resolved: parser splits on the sentinel and scans only the pre-sentinel region.
+- **Returncode precedence undefined** — without explicit precedence, synthesis could show `PASS` while CLI exits 1. Resolved: returncode wins. Status rendering rule pinned in §"Synthesis behavior".
+- **Timeout partial output (rc=124) parsing** is dangerous — partial output may contain a valid JSON block from before the timeout, but the review didn't actually complete. Resolved: parser is called but parsed result is IGNORED for rendering when `returncode != 0`. Findings section excludes non-zero-rc providers.
+- **decision="PASS" + blocking non-empty / score < 9.0** logical inconsistency. Resolved: validator coerces `effective_decision = "FIX"` when `decision == "PASS"` AND (`blocking` non-empty OR `weighted_score < 9.0`). Display uses `effective_decision`. Original `decision` preserved in parsed dict for diagnostics.
+- **`write_synthesis` I/O contract widening** — function now reads raw files from disk; needs OSError/UnicodeDecodeError handling. Resolved: `_safe_read_raw(path)` returns text-or-None; caller falls back to legacy on None.
+
+### Schema (the contract providers should emit) — v2
+
+Schema unchanged from v1 in shape; semantics tightened per panel feedback.
+
+A single fenced JSON code block at the **end** of the review output:
+
+```json
+{
+  "decision": "PASS",
+  "weighted_score": 9.2,
+  "blocking": [],
+  "advisories": [
+    {
+      "title": "Late-binding closure in helper X",
+      "evidence": "scripts/foo.py:142-148",
+      "fix": "Capture loop var via default arg"
+    }
+  ],
+  "confidence": 0.85
+}
+```
+
+Field semantics:
+
+| Field | Type | Required | Behavior on missing-when-block-present |
+|-------|------|----------|---------------------------------------|
+| `decision` | string, `"PASS"` / `"FIX"` (case-insensitive on parse, normalized to upper) | yes | parser returns None → legacy fallback |
+| `weighted_score` | number, 0.0–10.0 | yes | parser returns None → legacy fallback |
+| `blocking` | list of finding objects (empty list OK; null NOT OK) | yes | parser returns None |
+| `advisories` | list of finding objects (empty list OK; null NOT OK) | yes | parser returns None |
+| `confidence` | number, 0.0–1.0 | optional | absent OK; non-number → parser returns None |
+
+**Required-vs-default clarification (round-1 codex B6 / spec contradiction fix)**: when the schema block is **PRESENT** and missing a required field, parser returns None → legacy fallback (no partial-parse). When the schema block is **ABSENT entirely**, parser returns None → legacy fallback. The "default" concept doesn't apply at the parser layer — synthesis defaults are a separate concern (returncode-derived rendering when no parsed dict).
+
+Within each finding object:
+- `title`: string, required. Empty string accepted but discouraged.
+- `evidence`: string, required. Empty string accepted (cross-cutting issues).
+- `fix`: string, optional. Missing or empty → renderer omits the trailing `— fix` clause (no dangling em-dash, per deepseek A2).
+- **Unknown finding-level keys**: ignored (forward-compat parity with top-level — per deepseek A8 / codex A2). Future fields like `severity` / `category` can land additively.
+
+**Effective decision (round-1 codex B5)**: when `decision == "PASS"` AND (`blocking` non-empty OR `weighted_score < 9.0`), the parser sets `effective_decision = "FIX"` on the parsed dict (preserving original `decision` for diagnostics). Synthesis renders `effective_decision`. This catches lazy LLM compliance where the provider declares PASS while listing blocking findings.
+
+Within each finding object:
+- `title`: short one-line label (required)
+- `evidence`: `file:line` or `file:line-line` reference (required, may be empty string for cross-cutting issues)
+- `fix`: one-line suggested remediation (optional)
+
+### Parsing rules — v2
+
+`parse_structured_review(raw_text)` returns a dict-or-None:
+
+1. **Strip stderr region first** (round-1 codex B4 / glm B2): `raw_output(stdout, stderr)` writes `<stdout>\n[stderr]\n<stderr>` (codex.py:1391). If a provider CLI emits a fenced JSON block to stderr (telemetry, debug logs), last-block-wins would pick that block. Parser splits on the literal sentinel `\n[stderr]\n` and scans only the **pre-sentinel** region. If sentinel absent (custom raw_output writers), scan the full text.
+2. **Find last fenced JSON block** with **strict regex**: `(?ims)^```json\s*$\n(.*?)\n^```\s*$` — flags `i` (case-insensitive lang tag), `m` (multiline `^`/`$` anchors), **`s` (DOTALL — REQUIRED so `(.*?)` spans newlines; missing `s` is the entire bug ALL 4 round-2 reviewers flagged independently)**. Language tag `json` REQUIRED (case-insensitive); bare ``` blocks (no language tag) ignored to avoid false positives from prompt's `## Git Diff` ` ```diff ` blocks the model might paraphrase. Last match wins (per deepseek R1 A4).
+3. `json.loads` the captured contents.
+4. Validate against `_validate_review_schema(data)`:
+   - Top-level: dict shape, required fields present, types match, value ranges in spec.
+   - Findings (each item in `blocking` and `advisories`): dict with required `title: str`, `evidence: str` (may be empty); optional `fix: str`. Unknown keys at finding-level ignored (forward-compat).
+   - Unknown keys at top-level ignored.
+5. **Effective-decision coercion**: if validation passes AND `decision == "PASS"` AND (`blocking` non-empty OR `weighted_score < 9.0`), set `effective_decision = "FIX"` on the returned dict. Otherwise `effective_decision = decision`. Original `decision` preserved.
+6. On any parse / validation failure → return `None` (fall back to legacy behavior).
+7. **Never raises** — synthesis must work even on malformed provider output. Wrapped in try/except for `json.JSONDecodeError`, `TypeError`, `ValueError`, `AttributeError`. (Caller handles `OSError` / `UnicodeDecodeError` from raw-file read separately via `_safe_read_raw`.)
+
+### Synthesis behavior — v2
+
+`write_synthesis` enriched in two layers, with explicit returncode precedence (round-1 codex B2/B3):
+
+**Returncode precedence rule (pinned)**: returncode wins for the Status column. Only `rc == 0` providers get structured rendering.
+
+1. **Status column rendering** (per provider):
+   - `rc != 0` (any non-zero, including timeout 124, sigint 130, internal-error -1) → render `FAIL <rc>` regardless of any structured block. Structured data from rc!=0 providers is IGNORED for synthesis (their raw may contain partial pre-timeout output that lies about completion).
+   - `rc == 0` AND structured block parses → render `effective_decision (score, N blocking)`:
+     - `PASS (9.2)` (no blocking, score ≥ 9.0)
+     - `FIX (7.1, 2 blocking)` (effective_decision is FIX — either declared or coerced)
+   - `rc == 0` AND no structured block → render `PASS` (legacy, byte-identical to today).
+
+2. **Findings section** below the table — rendered ONLY when at least one rc=0 provider has a parsed structured block. For each such provider (in `results` iteration order, per deepseek A1):
+   ```
+   ### glm — FIX (7.5, 1 blocking, 2 advisories)
+   
+   **Blocking:**
+   - **Late-binding closure** at `scripts/foo.py:142-148` — Capture loop var via default arg
+   - **Cross-cutting concern**  (no evidence cited)  — see review prose
+   
+   **Advisories:**
+   - **Style nit**  at `scripts/foo.py:33`
+   ```
+   
+   Rendering rules:
+   - `fix` empty/missing → omit trailing ` — <fix>` to avoid dangling em-dash (per deepseek A2)
+   - `evidence` empty → render bare title with `(no evidence cited)` annotation; no broken `at \`\`` markdown (per deepseek A3)
+   - Provider with empty `blocking` + empty `advisories` (structured-but-clean) → render `### glm — PASS (9.2, 0 blocking, 0 advisories)` with no sub-sections (per deepseek A5)
+   - rc != 0 providers → omitted from Findings entirely (their structured data is untrusted)
+   - Providers with rc=0 but no structured block → omitted from Findings (Status column already shows their `PASS` state)
+
+3. **Backwards-compat invariant** (round-1 glm A1, A7): when ALL providers are rc=0-with-no-structured-block, `synthesis.md` is **byte-identical** to today's output (no Findings section, table-only). Implementation: `write_synthesis` early-returns through the legacy path when `not any(parsed)` across all providers.
+
+4. **Raw file I/O** (round-1 glm B1): `_safe_read_raw(path)` returns `str` or `None`. Catches `OSError` (file deleted between `cmd_review` and `write_synthesis`) and `UnicodeDecodeError` (corrupt bytes). On None → that provider falls through to legacy rendering (the parser is never called for that provider).
+
+### Prompt addendum — v2 (code-side helper, not static template)
+
+**Round-1 architectural pivot** (gemini blocker + codex B1 + glm B3): the v1 design embedded the addendum statically in `.agents/trinity.codex.json`'s `review.prompt_template`. That fails on task-type guard: ALL presets (review / tdd / prp / general) route through `cmd_review` → `render_prompt` → the same `review.prompt_template`. Non-review presets would receive the schema instructions inappropriately.
+
+**v2 fix**: addendum lives in code, gated on effective task_type:
+
+- New helper `_review_schema_addendum(task_type) -> str`: returns the addendum text when `task_type == "review"`, empty string otherwise.
+- `render_prompt` signature extends to accept `task_type: str | None = None` param. Existing callers pass None (preserves current behavior — no addendum injected when task_type unknown).
+- `cmd_review` extracts `task_type = preset_metadata.get("task_type")` from `resolve_review_providers`'s 2nd tuple element (already populated; just read it). Passes to `render_prompt`.
+- `render_prompt` appends `_review_schema_addendum(task_type)` to the rendered prompt when non-empty.
+
+`.agents/trinity.codex.json` `review.prompt_template` is NOT modified by this CHG. Custom user templates remain untouched. The addendum is invisible to non-review task types.
+
+Addendum text (returned by `_review_schema_addendum("review")`):
+
+```
+## Required: Structured Output
+
+After your free-form review, emit EXACTLY ONE fenced JSON block at the END of your
+output, matching this schema:
+
+\```json
+{
+  "decision": "PASS" | "FIX",
+  "weighted_score": <0.0-10.0>,
+  "blocking": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "advisories": [{"title": "...", "evidence": "file:line", "fix": "..."}],
+  "confidence": <0.0-1.0, optional>
+}
+\```
+
+Rules:
+- "decision" MUST be "PASS" only when "blocking" is empty AND "weighted_score" >= 9.0.
+  (If you write PASS while "blocking" is non-empty or score < 9.0, Trinity will
+  display your provider as FIX — the consistency is enforced.)
+- "blocking" and "advisories" are required lists (use [] if empty, not null).
+- "evidence" is required per finding; use "" for cross-cutting issues.
+- This block must be the LAST fenced ```json block in your output. Trinity scans
+  for the last match. Earlier illustrative JSON in your prose is fine.
+```
+
+Note: the addendum's example uses `"PASS" | "FIX"` placeholder syntax — providers that lazily echo the example verbatim will fail validation (decision is the literal string `"PASS" | "FIX"`, not a value), and Trinity falls back to legacy. Per deepseek A9 + codex F-list, this is desired behavior.
+
+### What's NOT in this CHG (deliberately deferred)
+
+- **JSON Schema validator dependency** — the inline `_validate_review_schema` is sufficient and avoids adding `jsonschema` to setup (consistent with TRN-3020's choice).
+- **Schema versioning** — no `schema_version` field for v1. If we ever bump the contract, do it then.
+- **Cross-provider finding dedup / clustering** — interesting for #55 (richer summary) but out of scope here. This CHG just *makes findings parseable*; clustering is downstream.
+- **Auto-merge / auto-release on PASS** — explicitly out per #39.
+- **Forcing all providers to emit the schema** — explicitly out per #39 ("not requiring all providers to be perfectly compliant immediately"). Free-form remains valid forever.
+- **Prompt-template variants per task_type** — the schema applies to `review` task_type only; tdd/prp/general task_types keep their existing templates. (Add task-type guard in implementation.)
+- **Plain-text or YAML alternatives** — JSON in a fenced code block is the canonical and only schema. Future CHG can add alternatives if real need.
+
+## Why
+
+Issue #39 documents the gap: providers emit varied free-form output, synthesis can't compare PASS/FIX decisions structurally, and downstream consumers (the panel-review orchestrator, future panel-debate via TRN-3024 #63 MCP bridge) have nothing to programmatically read. A simple JSON contract — opt-in, additive, fall-back-friendly — closes the gap without breaking anything.
+
+This is also a foundation move for issue #55 (richer summary): without normalized findings, #55 can only render free-form prose verbatim. With this CHG, #55 gets per-provider structured comparison rendering for free.
+
+## Impact
+
+### Surfaces touched
+
+| # | Surface | Edit |
+|---|----|----|
+| 1 | `scripts/codex.py` | Add module constants `_REVIEW_PASS_THRESHOLD = 9.0` (shared between coercion logic and addendum text — per glm R2 A3) and `_STDERR_SENTINEL = "\n[stderr]\n"` (mirrors `raw_output` at codex.py:1391-1393 — coupling explicitly documented per glm R2 A6). Add helpers: `_strip_stderr_region(text)`, `_safe_read_raw(path)`, `parse_structured_review(raw_text)` (signature is **only** `(raw_text)` — no `returncode` kwarg; rc filtering happens in `write_synthesis` caller, per codex R2 A1 + glm R2 A1), `_validate_review_schema(data)`, `_review_schema_addendum(task_type)` helpers (~120 lines). Modify `write_synthesis` (line ~1689) for per-provider parsing + rc precedence + Findings section + byte-identical-on-all-legacy fallback (~70 lines). Modify `render_prompt` (line ~1218) signature to accept `task_type: str \| None = None` (default preserves existing callers). **Addendum placement (per glm R2 A2)**: in `render_prompt`, the addendum is appended to the FINAL assembled prompt — after both the `strict_review` block (when present) AND `REVIEW_ONLY_INSTRUCTION` AND `## Review Artifact` body — so the addendum's "LAST in your output" instruction sits literally at the bottom. Modify `cmd_review` (line ~1716) to extract `task_type` from `preset_metadata` and pass through. |
+| 2 | (REMOVED in v2) | The v1 plan modified `.agents/trinity.codex.json`'s `review.prompt_template` statically. v2 moves the addendum into code (`_review_schema_addendum(task_type)` returns empty string for non-review task types), so the static template stays unchanged. Custom user templates also remain unchanged. |
+| 3 | Provider docs (per codex R2 A4 — files pinned via grep) | Doc-only note about the structured-output schema. Pinned location: `providers/_base/family-wrapper.md` if it exists; otherwise add a short section to each direct-invocation provider doc (`providers/glm.md`, `providers/codex.md`, `providers/gemini.md`) referencing the schema. Implementation step: `git ls-files providers/_base/` to confirm `family-wrapper.md` exists before editing. (TRN-3020 §A3.f drift coverage applies — verify post-implementation.) |
+| 4 | `tests/test_review_schema.py` (NEW) | ~25-30 unit tests covering: parser well-formed / malformed / no block / multiple blocks (last wins) / missing required / out-of-range score / unknown top-level key (forward-compat) / unknown finding-level key (forward-compat) / **stderr-side block ignored via sentinel split** / **rc != 0 input → caller ignores parsed result** / **decision="PASS"+blocking-non-empty coerced to effective_decision="FIX"** / decision="PASS"+score<9.0 coerced / lazy-LLM echo of literal `"PASS" \| "FIX"` placeholder rejected / fuzz-style random-bytes input never raises / `_safe_read_raw` returns None on OSError / `_safe_read_raw` returns None on UnicodeDecodeError / `_review_schema_addendum("review")` non-empty / `_review_schema_addendum("tdd")` empty / `_review_schema_addendum(None)` empty / synthesis byte-identical on all-legacy + all-rc-zero / synthesis Findings section omitted when only rc != 0 providers had structured blocks / Findings ordering matches results iteration / empty-fix renders without dangling em-dash / empty-evidence renders bare title with annotation. |
+| 5 | `README.md` | Brief mention of the new structured output in the "Run a review" section (per TRN-1007 §1). |
+| 6 | `CHANGELOG.md` | `[Unreleased]` `### Added` entry naming the schema + code-side addendum. |
+
+Total: 1 new file, 4-5 modified. Net delta ~+200 lines (mostly tests + helper).
+
+### Behavior change
+
+| Pre-CHG | Post-CHG |
+|---------|----------|
+| Providers emit free-form prose; returncode determines PASS/FAIL | Same — free-form still valid; returncode fallback intact |
+| Default prompt template asks for "PASS only if no blocking issues" but doesn't request structure | Default template appends structured-output addendum; providers may comply or not |
+| Synthesis table: `Provider | Status (PASS/FAIL N) | Raw Output` | Same table, but Status enriched with score + blocking count when structured block present; new Findings section appears only when ≥1 provider emitted structured |
+| `synthesis.md` content stable across runs | Still deterministic given identical raw inputs |
+
+**Expected user-visible impact**: providers that follow the new prompt addendum produce richer synthesis. Providers that don't comply (older releases, custom prompts, partial responses) continue producing today's synthesis. Free-form output never breaks.
+
+### CI impact
+
+- New `test_review_schema.py` runs in `make test` (~25-30 unit tests per Surface 4 — count was inconsistent in v2; harmonized in v3).
+- No CI workflow changes.
+
+### Backwards compatibility
+
+- Existing review directories: synthesis re-runs on them produce the same legacy output (no JSON block in raw → fall back).
+- Custom `review.prompt_template` overrides: users who removed the structured addendum (or never had it) continue producing free-form reviews.
+- The `results` dict shape passed to `write_synthesis` is unchanged — synthesis itself reads from `raw` files. So `cmd_review`'s metadata.json schema is unchanged.
+
+### Rollback
+
+Revert this PR. Synthesis reverts to today's PASS/FAIL-only table; the schema-emission addendum disappears from the **rendered review prompt** (the static `review.prompt_template` in `.agents/trinity.codex.json` is untouched by this CHG so there's nothing to revert there); providers stop being asked to emit structure (those that already comply will keep emitting; the parser just won't be there to read). Clean rollback.
+
+## Acceptance Criteria (per TRN-1007)
+
+| # | Check | How | TRN-1007 § |
+|---|-------|-----|------------|
+| A1 | `parse_structured_review` returns parsed dict on well-formed JSON block | Unit test | §2 |
+| A2 | `parse_structured_review` returns `None` on malformed JSON, missing required field, out-of-range score, missing block | Unit tests | §2 |
+| A3 | `parse_structured_review` picks the LAST JSON block when multiple are present | Unit test (illustrative example earlier in raw + canonical at end) | §2 |
+| A4 | `parse_structured_review` is forward-compat: ignores unknown top-level keys | Unit test | §2 |
+| A5 | Synthesis enriches Status column when structured block present (e.g., `PASS (9.2)`, `FIX (7.1, 2 blocking)`) | Unit test asserting rendered output | §2 |
+| A6 | Synthesis renders "Findings" section only when at least one provider emitted structured | Unit test (mixed + all-legacy + all-structured cases) | §2 |
+| A7 | Synthesis falls back to legacy table on all-legacy raw inputs (byte-identical to current output for the table portion) | Unit test pinning legacy snapshot | §2 |
+| A8 | `_review_schema_addendum("review")` returns non-empty addendum text containing the schema fields; `_review_schema_addendum("tdd")` and `_review_schema_addendum(None)` return empty string | Unit test (per round-1 universal blocker — task-type guard moved code-side) | §2 |
+| A8b | `.agents/trinity.codex.json` `review.prompt_template` is UNCHANGED by this CHG (no in-place modification — addendum lives in code) | Unit test asserting canonical template content | §2 |
+| A8c | `render_prompt(..., task_type="review")` includes the addendum; `render_prompt(..., task_type=None)` and `render_prompt(..., task_type="tdd")` do not | Unit test | §2 |
+| A8d | Parser strips stderr region: an `\n[stderr]\n` sentinel followed by a fenced JSON block on stderr does NOT win last-block-wins (round-1 codex B4 / glm B2) | Unit test | §2 |
+| A8e | `write_synthesis` renders `FAIL <rc>` for rc != 0 providers regardless of any structured block in their raw (round-1 codex B2/B3 — returncode precedence) | Unit test (rc=1 + valid PASS schema → "FAIL 1"; rc=124 + valid PASS schema → "FAIL 124") | §2 |
+| A8e2 | rc=124 timeout file containing a syntactically valid PASS schema → `parse_structured_review` returns dict (parser is rc-agnostic, per codex R2 A1) but `write_synthesis` IGNORES it and renders "FAIL 124" with no Findings entry for that provider (per glm R2 A5 explicit test) | Unit test | §2 |
+| A8d2 | Parser regex matches MULTI-LINE JSON blocks (the canonical case): given a fenced ` ```json` block containing the **valid** schema example from §"Schema" lines 37-51 (real values: `"decision": "PASS"`, `"weighted_score": 9.2`, populated `blocking[]`/`advisories[]`, `"confidence": 0.85`) with newlines between fields, `parse_structured_review` returns the parsed dict. NOTE: do NOT use the addendum's placeholder example (lines 150-158) as the fixture — it contains literal placeholder syntax (`"PASS" \| "FIX"`, `<0.0-10.0>`) which A8h explicitly requires the parser to REJECT. The two test invariants would conflict on the same fixture (per codex round-3 catch). (Per **all 4** round-2 reviewers' B1/B7/NB1 — DOTALL flag missing in v2 spec; v3 uses `(?ims)`.) | Unit test feeding the §"Schema" valid example block | §2 |
+| A8f | Effective-decision coercion: `decision="PASS"` + `blocking` non-empty → `effective_decision="FIX"` (and Status renders FIX, count visible). Same for score < 9.0 (round-1 codex B5) | Unit tests for both inconsistency cases | §2 |
+| A8g | `_safe_read_raw(path)` returns None on OSError (file deleted) and on UnicodeDecodeError (corrupt bytes); caller falls through to legacy without raising (round-1 glm B1) | Unit tests | §2 |
+| A8h | Lazy-LLM echo of the literal placeholder string `"PASS" | "FIX"` is rejected at validation → None → legacy fallback (round-1 deepseek A9 / codex F-list) | Unit test | §2 |
+| A8i | `_REVIEW_PASS_THRESHOLD` constant is the single source of truth: (a) coercion uses it (decision="PASS" + score < `_REVIEW_PASS_THRESHOLD` → effective FIX); (b) addendum text generates the literal threshold from it (no hardcoded "9.0" string in the addendum source). Test substitutes the constant via monkeypatch and asserts both paths reflect the new value (round-3 codex advisory). | Unit test | §2 |
+| A9 | Existing tests pass (`make test`, `make lint`, `make coverage` ≥ 80%, `af validate --root .`) | Local + CI | §2 |
+| A10 | Manual smoke: a tiny review run on a fixed scope produces synthesis.md containing a Findings section if at least one provider complies; produces today's table-only output if none comply | Manual; documented in PR body | §5 |
+| A11 | `README.md` "Run a review" section mentions the structured-output schema briefly | Manual review | §1 |
+| A12 | `CHANGELOG.md` `[Unreleased]` `### Added` entry | Manual review | §1 |
+
+### TRN-1007 dogfood mapping
+
+- §1 README: ✅ A11
+- §1 CHANGELOG: ✅ A12
+- §1 SKILL/providers: ✅ providers/_base/family-wrapper.md doc tweak (Surface 3)
+- §2 verification: ✅ A9
+- §3 drift: ➖ N/A — no provider CLI changes; if Surface 3 changes prompt-related text, TRN-3020 A3.f covers verification
+- §4 6-step methodology: applied during code-review
+- §5 manual smoke: ✅ A10
+- §6 identity: gh auth status → ryosaeba1985 (verified at PR-open)
+- §7 branch hygiene: branch `codex/trn-3022-review-schema`; rebased on origin/main pre-push (per TRN-3021 R5 lesson — must verify against `origin/main` before R1 dispatch, not local main)
+
+## Authority
+
+Standalone single-slice CHG. Operator defaults: identity `ryosaeba1985`, branch `codex/trn-3022-review-schema`, plan-review and code-review via Trinity panel with **all active providers PASS individually at ≥9.0** gate.
+
+Round-1+ panel composition: glm + gemini + deepseek + codex (4 providers; gemini's quota status will be checked by attempting; if it fails, fall back to 3-panel).
+
+### Code-review prompt addendum (7-step methodology rule + PR #68 lessons)
+
+From PR #60/#61/#64/#67/#68. Latest additions:
+
+7. **Self-application check** — apply the new SOP/feature to itself; would it have caught its own omissions?
+8. **(NEW after PR #68)** **`git status -uno` against `origin/main` before R1 dispatch** — PR #68 (TRN-3021) had deepseek correctly flag a "phantom TRN-1007 reference" 3 rounds in a row because the orchestrator's branch was created off stale local main. False-positive dismissal cost 2 panel rounds.
+9. **(NEW after PR #68)** **Codex bot has been catching real semantic-correctness issues even after 4-provider panel approval** (auth-leak / overlap / display-mismatch / substring-trap on PR #68; 7 consecutive findings on PR #60). Plan should explicitly enumerate "what could go wrong post-merge that the panel might miss" — caller-flow / sibling-code / display-vs-exit consistency / value-handling-helper-mirrors / unverified-comment-invariants.
+
+Specifically for THIS CHG:
+
+- (1) caller flow: `cmd_review` → providers run, write `raw/<provider>.txt` → `write_synthesis(review_dir, scope, results)` → `parse_structured_review(raw_text)` per provider → enriched table + optional Findings section.
+- (2) writer schema: `parse_structured_review` returns dict-or-None with explicit fields per spec; `_validate_review_schema` rejects malformed.
+- (3) sibling sites: `cmd_status` reads `synthesis.md` for display — verify it doesn't break on the new sections (it just prints the file). `cmd_review`'s metadata.json schema is unchanged.
+- (4) sibling helpers: any other place that parses provider raw output? `cmd_status`'s `_print_review_summary` reads `synthesis.md` and `metadata.json`; doesn't touch raw. No siblings to update.
+- (5) comment-stated invariants: `parse_structured_review` docstring claims "never raises" — paired with a fuzz-style test feeding random bytes.
+- (6) backwards-compat: existing `synthesis.md` shapes preserved when no structured block; `cmd_review` metadata.json schema unchanged.
+- (7) self-application: would the new schema, applied to a Trinity panel review of THIS CHG, have caught issues like "the prompt template change might confuse providers running on cached/older prompt"? Probably no — that's a deployment concern, not a schema concern. Schema's self-application is moot.
+- (8) `git status -uno` against `origin/main` before R1: VERIFIED — branch `codex/trn-3022-review-schema` is at `b003cc5` (== origin/main, post-PR-#68 merge); only tracked modification is `rules/TRN-0000-REF-Document-Index.md` (auto-regenerated by `af index`).
+- (9) "what could go wrong post-merge": (a) provider emits malformed JSON → parser returns None, fallback works; (b) provider emits multiple JSON blocks → last wins; (c) provider's score is 11.0 → out-of-range → None; (d) provider emits the schema in the MIDDLE of output (not at end) → still parsed because we scan for last `^```json` block; (e) `write_synthesis` writes a file with absent provider — handled by per-provider iteration that defaults to legacy on None.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-08 | Initial draft per COR-1616 step 3, with PR #60/#61/#64/#67/#68 9-step methodology rule embedded (PR #68 added steps 8 and 9: git-status-vs-origin-main check + post-merge-failure-mode enumeration). Tight scope: schema, parser, synthesis enrichment, opt-in prompt addendum. Deferred: JSON Schema dep, schema versioning, dedup/clustering, task-type variants. | Claude Opus 4.7 |
+| 2026-05-08 | **Status**: Proposed → Approved. Plan-review round 4 (codex-only re-dispatch): codex **9.2 PASS** (was 8.8). All 4 R3 findings RESOLVED with line citations. 5 R4 advisories noted for code-review (numeric-bool rejection test, Markdown sanitization for title/evidence/fix, raw-path resolution test, "6-step" → "9-step" wording, "WILL DO" → "verified"). All 4 panel members now PASS individually at ≥9.0: gemini 9.5 (R2), codex 9.2 (R4), glm 9.2 (R2), deepseek 9.10 (R2). Mean **9.255**. Gate met after 4 plan-review rounds. Ready to implement. | Claude Opus 4.7 |
+| 2026-05-08 | Plan-review round 3 (codex-only re-dispatch — gemini 9.5 / glm 9.2 / deepseek 9.10 already PASSed conditional on DOTALL fix): codex 8.8 FAIL (was 8.2; ALL 5 R2 blockers RESOLVED, but 1 NEW catch — A8d2 vs A8h fixture conflict: A8d2 said "feed addendum's example" but addendum example uses placeholder syntax that A8h requires parser to REJECT). Round-4 fixes: (1) A8d2 repointed to §"Schema" valid example (lines 37-51) with explicit NOTE not to use the placeholder example; (2) Rollback wording fixed: "rendered review prompt" not "default prompt template" (template is untouched by CHG); (3) Test count harmonized: ~25-30 in both Surface 4 and CI Impact section; (4) New A8i: `_REVIEW_PASS_THRESHOLD` constant single-source-of-truth test (coercion + addendum both use it, no hardcoded literal in addendum text). | Claude Opus 4.7 |
+| 2026-05-08 | Plan-review round 2 (4-provider panel re-dispatch): all 4 caught **the same regex DOTALL bug** (gemini B1, codex B7, deepseek B1, glm NB1) — `(?im)` lacks `s` flag so `(.*?)` can't span newlines → parser silently fails on every multi-line JSON block (i.e., every realistic schema emission). One-character fix: `(?ims)`. Plus all R1 blockers from R1 (3-of-4 FAILed) confirmed RESOLVED by all reviewers individually with line citations. Round-2 scores: gemini 9.5 PASS-with-blocker, glm 9.2 PASS, deepseek 9.10 PASS, codex 8.2 FAIL. **Round 3 fixes** (all CHG-text only — no architectural change): (1) regex flag `(?im)` → `(?ims)` in parsing rules step 2; (2) parser signature drift — `parse_structured_review(raw_text)` only, drop `*, returncode` kwarg from Surface 1 (rc filtering belongs in `write_synthesis` caller); (3) addendum placement explicit — appended AFTER strict_review block + REVIEW_ONLY_INSTRUCTION + ## Review Artifact body so "LAST in your output" instruction is truly last in the rendered prompt (glm R2 A2); (4) `_REVIEW_PASS_THRESHOLD = 9.0` shared constant between coercion logic and addendum text (glm R2 A3); (5) `_STDERR_SENTINEL` constant explicitly couples to `raw_output` at codex.py:1391-1393 (glm R2 A6); (6) Surface 3 file pinned via grep (codex R2 A4); (7) custom-template behavior: code-side addendum applies regardless of `prompt_template` customization (codex R2 A2 — limitation acknowledged; opt-out via setting non-review task_type, future config flag deferred); (8) end-of-output vs last-block-wins: prompt instruction says "LAST" (provider-facing), parser uses last-block-wins (lenient on misbehaving — per codex R2 A3, different concerns); (9) new ACs A8d2 (multi-line regex test), A8e2 (rc=124 + valid JSON → FAIL 124 explicit). | Claude Opus 4.7 |
+| 2026-05-08 | Plan-review round 1 (4-provider panel): deepseek 9.16 PASS, gemini 8.7 PASS-with-blocker, glm 8.7 FAIL, **codex 7.4 FAIL** (mean 8.49). 3-of-4 caught structural / semantic blockers. **Round 2 substantial rewrite** addressing 6 cross-confirmed concerns: (1) **Task-type guard structurally impossible** (gemini/codex/glm) — `render_prompt` had no `task_type` param; static template would leak into TDD/PRP/general. Fix: extend `render_prompt` signature to accept `task_type`; addendum moves from static template into a code-side helper `_review_schema_addendum(task_type)` returning empty for non-review. `.agents/trinity.codex.json` is now UNCHANGED. (2) **stderr-side JSON breaks last-block-wins** (codex B4 / glm B2) — `raw_output` writes `<stdout>\n[stderr]\n<stderr>`. Fix: parser splits on the sentinel and scans only pre-sentinel region. (3) **Returncode precedence undefined** (codex B2) — synthesis could lie about CLI exit. Fix: rc != 0 → `FAIL <rc>` regardless of structured; only rc=0 providers get structured rendering. (4) **rc=124 timeout partial output is dangerous** (codex B3) — partial output may contain valid JSON but review didn't complete. Fix: parsed result IGNORED for rendering when rc != 0. Findings section excludes non-zero-rc providers. (5) **decision="PASS" + blocking non-empty / score < 9.0** logical inconsistency (codex B5). Fix: validator coerces `effective_decision = "FIX"`; original `decision` preserved for diagnostics; display uses `effective_decision`. (6) **`write_synthesis` I/O contract widening** (glm B1) — function reads raw files. Fix: `_safe_read_raw(path)` returns text-or-None on OSError/UnicodeDecodeError. (7) **Required-vs-default contradiction** (codex B6). Fix: removed "Default if missing" column for required fields; clarified parser-layer vs synthesis-layer fallback semantics. Plus advisories adopted: deepseek A1 (Findings ordering = results iteration order), A2 (empty-fix omits em-dash), A3 (empty-evidence renders bare title), A4 (strict regex `^```json\s*$ ... ^```\s*$`, lang tag REQUIRED), A8 (forward-compat extends to finding-level keys), A9 (literal placeholder echo rejected). New ACs A8/A8b–A8h cover the architectural fixes. | Claude Opus 4.7 |

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1547,11 +1547,15 @@ def _validate_review_schema(data):
     if not isinstance(decision, str) or decision.upper() not in ("PASS", "FIX"):
         return False
 
-    # weighted_score — reject bools (True/False are int subclasses) and NaN/Inf
+    # weighted_score — reject bools (True/False are int subclasses) and NaN/Inf.
+    # math.isfinite() on huge ints raises OverflowError, so guard with isinstance(float).
+    # Ints are always finite by definition; oversized ints fall through to range check.
     ws = data.get("weighted_score")
     if isinstance(ws, bool) or not isinstance(ws, (int, float)):
         return False
-    if not math.isfinite(ws) or ws < 0.0 or ws > 10.0:
+    if isinstance(ws, float) and not math.isfinite(ws):
+        return False
+    if ws < 0.0 or ws > 10.0:
         return False
 
     # blocking and advisories
@@ -1571,12 +1575,14 @@ def _validate_review_schema(data):
             if fix is not None and not isinstance(fix, str):
                 return False
 
-    # confidence (optional) — reject bools and NaN/Inf
+    # confidence (optional) — reject bools and NaN/Inf (same overflow guard as weighted_score).
     conf = data.get("confidence")
     if conf is not None:
         if isinstance(conf, bool) or not isinstance(conf, (int, float)):
             return False
-        if not math.isfinite(conf) or conf < 0.0 or conf > 1.0:
+        if isinstance(conf, float) and not math.isfinite(conf):
+            return False
+        if conf < 0.0 or conf > 1.0:
             return False
 
     return True
@@ -1620,7 +1626,7 @@ def parse_structured_review(raw_text):
             data["effective_decision"] = data["decision"]
 
         return data
-    except (json.JSONDecodeError, TypeError, ValueError, AttributeError):
+    except (json.JSONDecodeError, TypeError, ValueError, AttributeError, OverflowError):
         return None
 
 

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1637,6 +1637,7 @@ def _review_schema_addendum(task_type):
     Addendum is appended at the end of the rendered prompt so providers emit
     the JSON block as the LAST thing in their output.
     """
+    task_type = (task_type or "").lower()
     if task_type != "review":
         return ""
 
@@ -1877,6 +1878,32 @@ def _sanitize_md(text):
     return text.replace("\n", " ") if "\n" in text else text
 
 
+def _render_finding_items(label, items):
+    """Render a labeled list of finding items (blocking or advisories).
+
+    Returns a list of lines including the **Label:** header, one bullet per
+    item, and a trailing blank line. Returns an empty list if items is empty.
+    """
+    if not items:
+        return []
+    lines = [f"**{label}:**"]
+    for item in items:
+        title = _sanitize_md(item.get("title", ""))
+        evidence = _sanitize_md(item.get("evidence", ""))
+        fix = item.get("fix")
+        if fix:
+            fix = _sanitize_md(fix)
+        if evidence:
+            line = f"- **{title}** at `{evidence}`"
+        else:
+            line = f"- **{title}** (no evidence cited)"
+        if fix:
+            line += f" — {fix}"
+        lines.append(line)
+    lines.append("")
+    return lines
+
+
 def _render_findings_for(result, parsed):
     """Render a single provider's structured findings block.
 
@@ -1894,38 +1921,8 @@ def _render_findings_for(result, parsed):
         f"({score}, {len(blocking)} blocking, {len(advisories)} advisories)"
     )
     lines.append("")
-    if blocking:
-        lines.append("**Blocking:**")
-        for item in blocking:
-            title = _sanitize_md(item.get("title", ""))
-            evidence = _sanitize_md(item.get("evidence", ""))
-            fix = item.get("fix")
-            if fix:
-                fix = _sanitize_md(fix)
-            if evidence:
-                line = f"- **{title}** at `{evidence}`"
-            else:
-                line = f"- **{title}** (no evidence cited)"
-            if fix:
-                line += f" — {fix}"
-            lines.append(line)
-        lines.append("")
-    if advisories:
-        lines.append("**Advisories:**")
-        for item in advisories:
-            title = _sanitize_md(item.get("title", ""))
-            evidence = _sanitize_md(item.get("evidence", ""))
-            fix = item.get("fix")
-            if fix:
-                fix = _sanitize_md(fix)
-            if evidence:
-                line = f"- **{title}** at `{evidence}`"
-            else:
-                line = f"- **{title}** (no evidence cited)"
-            if fix:
-                line += f" — {fix}"
-            lines.append(line)
-        lines.append("")
+    lines.extend(_render_finding_items("Blocking", blocking))
+    lines.extend(_render_finding_items("Advisories", advisories))
     return lines
 
 
@@ -1990,13 +1987,13 @@ def write_synthesis(review_dir, scope, results):
         "| Provider | Status | Raw Output |",
         "|----------|--------|------------|",
     ]
-    for result in results:
+    for i, result in enumerate(results):
         rc = result.get("returncode", -1)
         if rc != 0:
             # Returncode precedence: rc wins regardless of structured content.
             status = f"FAIL {rc}"
         else:
-            parsed = parsed_per_provider[results.index(result)]
+            parsed = parsed_per_provider[i]
             if parsed is not None:
                 eff = parsed["effective_decision"]
                 score = parsed["weighted_score"]

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1511,8 +1511,13 @@ def _strip_stderr_region(text):
     written by raw_output() at this module. If the sentinel is present,
     only the pre-sentinel region (stdout) is scanned for structured blocks.
     If absent (custom raw-output writers), the full text is returned.
+
+    Uses rfind() (last match) rather than find() because stdout itself may
+    legitimately contain the sentinel string — e.g., a provider quoting the
+    raw-output delimiter while reviewing this file. The real boundary is
+    always the LAST occurrence (the one appended by raw_output()).
     """
-    idx = text.find(_STDERR_SENTINEL)
+    idx = text.rfind(_STDERR_SENTINEL)
     if idx == -1:
         return text
     return text[:idx]

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -46,7 +46,7 @@ REVIEW_ONLY_INSTRUCTION = (
 )
 PROCESS_GROUP_KILL_GRACE_SECONDS = 5
 _REVIEW_PASS_THRESHOLD = 9.0
-_STDERR_SENTINEL = "\n[stderr]\n"
+_STDERR_SENTINEL = "\n%%TRINITY-RAW-STDERR-BOUNDARY-9c3d2a1f7e%%\n"
 STRICT_REVIEW_TEMPLATES = {
     ("COR-1602", "COR-1609"): {
         "pass_threshold": 9.0,
@@ -1398,15 +1398,13 @@ def cleanup_active_processes(registry):
 
 
 def raw_output(stdout, stderr):
-    # TRN-3022 coupling: the "\n[stderr]\n" sentinel written here is
-    # consumed by _strip_stderr_region — do NOT change the sentinel
-    # format without updating that helper and _STDERR_SENTINEL.
-    # Always append the sentinel (even with empty stderr) so the sentinel
-    # is unambiguously a delimiter, never absent. _strip_stderr_region
-    # uses rfind() to locate the last occurrence; without the always-write
-    # invariant, a stdout that mentions the sentinel string could be
-    # truncated when stderr was empty (no real delimiter to anchor against).
-    return (stdout or "") + "\n[stderr]\n" + (stderr or "")
+    # TRN-3022 coupling: the _STDERR_SENTINEL written here is consumed by
+    # _strip_stderr_region — do NOT change the sentinel format without
+    # updating both. The sentinel is a unique marker (random hex tag) so
+    # neither stdout nor stderr can plausibly contain a colliding string.
+    # Always append the sentinel (even with empty stderr) so the boundary
+    # exists unambiguously.
+    return (stdout or "") + _STDERR_SENTINEL + (stderr or "")
 
 
 def timeout_partial_output(exc, stdout=None, stderr=None):
@@ -1509,15 +1507,11 @@ _SCHEMA_BLOCK_RE = re.compile(
 def _strip_stderr_region(text):
     """Strip the stderr tail appended by raw_output().
 
-    TRN-3022 coupling: the sentinel _STDERR_SENTINEL ("\n[stderr]\n") is
-    written by raw_output() at this module. If the sentinel is present,
-    only the pre-sentinel region (stdout) is scanned for structured blocks.
-    If absent (custom raw-output writers), the full text is returned.
-
-    Uses rfind() (last match) rather than find() because stdout itself may
-    legitimately contain the sentinel string — e.g., a provider quoting the
-    raw-output delimiter while reviewing this file. The real boundary is
-    always the LAST occurrence (the one appended by raw_output()).
+    TRN-3022 coupling: the sentinel _STDERR_SENTINEL is a unique marker
+    written by raw_output() at this module. It contains a random hex tag,
+    so a colliding string in either stdout or stderr is astronomically
+    unlikely. The pre-sentinel region (stdout) is scanned for structured
+    blocks. If absent (custom raw-output writers), the full text is returned.
     """
     idx = text.rfind(_STDERR_SENTINEL)
     if idx == -1:

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -44,6 +44,8 @@ REVIEW_ONLY_INSTRUCTION = (
     "on the provided diff, file snapshots, and review context.\n"
 )
 PROCESS_GROUP_KILL_GRACE_SECONDS = 5
+_REVIEW_PASS_THRESHOLD = 9.0
+_STDERR_SENTINEL = "\n[stderr]\n"
 STRICT_REVIEW_TEMPLATES = {
     ("COR-1602", "COR-1609"): {
         "pass_threshold": 9.0,
@@ -1215,7 +1217,9 @@ def render_strict_review_instructions(strict_review):
     return "\n".join(lines) + "\n"
 
 
-def render_prompt(config, root, scope, review_input, strict_review=None):
+def render_prompt(
+    config, root, scope, review_input, strict_review=None, *, task_type=None
+):
     diff = review_input["diff"]
     files = review_input["files"]
     template = config.get("review", {}).get("prompt_template", "{diff}\n\n{files}\n")
@@ -1226,14 +1230,18 @@ def render_prompt(config, root, scope, review_input, strict_review=None):
         .replace("{files}", files)
     )
     if strict_review is None:
-        return REVIEW_ONLY_INSTRUCTION + "\n" + prompt
-    return (
-        render_strict_review_instructions(strict_review)
-        + "\n"
-        + REVIEW_ONLY_INSTRUCTION
-        + "\n## Review Artifact\n\n"
-        + prompt
-    )
+        base = REVIEW_ONLY_INSTRUCTION + "\n" + prompt
+    else:
+        base = (
+            render_strict_review_instructions(strict_review)
+            + "\n"
+            + REVIEW_ONLY_INSTRUCTION
+            + "\n## Review Artifact\n\n"
+            + prompt
+        )
+    # TRN-3022: schema addendum appended AFTER all other sections so
+    # the "LAST in your output" instruction is truly at the bottom.
+    return base + _review_schema_addendum(task_type)
 
 
 def slugify(value):
@@ -1389,6 +1397,9 @@ def cleanup_active_processes(registry):
 
 
 def raw_output(stdout, stderr):
+    # TRN-3022 coupling: the "\n[stderr]\n" sentinel written here is
+    # consumed by _strip_stderr_region — do NOT change the sentinel
+    # format without updating that helper and _STDERR_SENTINEL.
     output = stdout or ""
     if stderr:
         output += "\n[stderr]\n" + stderr
@@ -1481,6 +1492,174 @@ def build_provider_env(base_env=None):
             continue
         sanitized[key] = value
     return sanitized
+
+
+# ---------------------------------------------------------------------------
+# TRN-3022: structured review result schema — parser + helpers
+# ---------------------------------------------------------------------------
+
+_SCHEMA_BLOCK_RE = re.compile(
+    r"(?ims)^```json\s*$\n(.*?)\n^```\s*$",
+)
+
+
+def _strip_stderr_region(text):
+    """Strip the stderr tail appended by raw_output().
+
+    TRN-3022 coupling: the sentinel _STDERR_SENTINEL ("\n[stderr]\n") is
+    written by raw_output() at this module. If the sentinel is present,
+    only the pre-sentinel region (stdout) is scanned for structured blocks.
+    If absent (custom raw-output writers), the full text is returned.
+    """
+    idx = text.find(_STDERR_SENTINEL)
+    if idx == -1:
+        return text
+    return text[:idx]
+
+
+def _safe_read_raw(path):
+    """Read a raw provider file, returning text or None on failure.
+
+    Catches OSError (file deleted/moved between run and synthesis) and
+    UnicodeDecodeError (corrupt bytes). Returns None on failure — caller
+    falls through to legacy rendering.
+    """
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _validate_review_schema(data):
+    """Validate a parsed JSON dict against the TRN-3022 review schema.
+
+    Returns True if valid, False otherwise. Never raises.
+    Checks: top-level dict, required fields, types, ranges, finding shapes.
+    Unknown top-level and finding-level keys are ignored (forward-compat).
+    Rejects numeric bools (isinstance(True, int) is True in Python).
+    """
+    if not isinstance(data, dict):
+        return False
+
+    # decision
+    decision = data.get("decision")
+    if not isinstance(decision, str) or decision.upper() not in ("PASS", "FIX"):
+        return False
+
+    # weighted_score — reject bools (True/False are int subclasses)
+    ws = data.get("weighted_score")
+    if isinstance(ws, bool) or not isinstance(ws, (int, float)):
+        return False
+    if ws < 0.0 or ws > 10.0:
+        return False
+
+    # blocking and advisories
+    for key in ("blocking", "advisories"):
+        val = data.get(key)
+        if not isinstance(val, list):
+            return False
+        for item in val:
+            if not isinstance(item, dict):
+                return False
+            if not isinstance(item.get("title"), str):
+                return False
+            if not isinstance(item.get("evidence"), str):
+                return False
+            # fix is optional; if present must be str
+            fix = item.get("fix")
+            if fix is not None and not isinstance(fix, str):
+                return False
+
+    # confidence (optional)
+    conf = data.get("confidence")
+    if conf is not None:
+        if isinstance(conf, bool) or not isinstance(conf, (int, float)):
+            return False
+        if conf < 0.0 or conf > 1.0:
+            return False
+
+    return True
+
+
+def parse_structured_review(raw_text):
+    """Parse a structured review schema block from raw provider output.
+
+    Returns a dict with schema fields + effective_decision, or None on any
+    failure. Never raises — synthesis must work on malformed provider output.
+
+    Steps:
+      1. Strip stderr region via _strip_stderr_region.
+      2. Find last fenced ```json block via regex (DOTALL).
+      3. json.loads contents.
+      4. Validate via _validate_review_schema.
+      5. Coerce effective_decision if needed.
+    """
+    try:
+        stdout_region = _strip_stderr_region(raw_text)
+
+        matches = _SCHEMA_BLOCK_RE.findall(stdout_region)
+        if not matches:
+            return None
+
+        last_block = matches[-1]
+        data = json.loads(last_block)
+
+        if not _validate_review_schema(data):
+            return None
+
+        # Normalize decision to uppercase.
+        data["decision"] = data["decision"].upper()
+
+        # Effective-decision coercion.
+        if data["decision"] == "PASS" and (
+            data["blocking"] or data["weighted_score"] < _REVIEW_PASS_THRESHOLD
+        ):
+            data["effective_decision"] = "FIX"
+        else:
+            data["effective_decision"] = data["decision"]
+
+        return data
+    except (json.JSONDecodeError, TypeError, ValueError, AttributeError):
+        return None
+
+
+def _review_schema_addendum(task_type):
+    """Return the structured-output prompt addendum for review task types.
+
+    Returns empty string for non-review task types (tdd, prp, general, None).
+    Addendum is appended at the end of the rendered prompt so providers emit
+    the JSON block as the LAST thing in their output.
+    """
+    if task_type != "review":
+        return ""
+
+    threshold = _REVIEW_PASS_THRESHOLD
+    return (
+        "\n## Required: Structured Output\n"
+        "\n"
+        "After your free-form review, emit EXACTLY ONE fenced JSON block at the END of your\n"
+        "output, matching this schema:\n"
+        "\n"
+        "```json\n"
+        "{\n"
+        f'  "decision": "PASS" | "FIX",\n'
+        f'  "weighted_score": <0.0-{threshold}>,\n'
+        f'  "blocking": [{{"title": "...", "evidence": "file:line", "fix": "..."}}],\n'
+        f'  "advisories": [{{"title": "...", "evidence": "file:line", "fix": "..."}}],\n'
+        f'  "confidence": <0.0-1.0, optional>\n'
+        "}\n"
+        "```\n"
+        "\n"
+        "Rules:\n"
+        f'- "decision" MUST be "PASS" only when "blocking" is empty AND "weighted_score" >= {threshold}.\n'
+        '  (If you write PASS while "blocking" is non-empty or score < '
+        f"{threshold}, Trinity will\n"
+        "  display your provider as FIX — the consistency is enforced.)\n"
+        '- "blocking" and "advisories" are required lists (use [] if empty, not null).\n'
+        '- "evidence" is required per finding; use "" for cross-cutting issues.\n'
+        "- This block must be the LAST fenced ```json block in your output. Trinity scans\n"
+        "  for the last match. Earlier illustrative JSON in your prose is fine.\n"
+    )
 
 
 def run_provider(provider, provider_config, prompt_path, review_dir, root, registry):
@@ -1686,7 +1865,114 @@ def write_incomplete(
     )
 
 
+def _sanitize_md(text):
+    """Strip embedded newlines from Markdown-rendered finding fields."""
+    return text.replace("\n", " ") if "\n" in text else text
+
+
+def _render_findings_for(result, parsed):
+    """Render a single provider's structured findings block.
+
+    Returns a list of lines for the Findings section, or an empty list
+    if the provider has no findings to render (structured-but-clean).
+    """
+    provider = result["provider"]
+    eff = parsed["effective_decision"]
+    score = parsed["weighted_score"]
+    blocking = parsed.get("blocking", [])
+    advisories = parsed.get("advisories", [])
+    lines = []
+    lines.append(
+        f"### {provider} — {eff} "
+        f"({score}, {len(blocking)} blocking, {len(advisories)} advisories)"
+    )
+    lines.append("")
+    if blocking:
+        lines.append("**Blocking:**")
+        for item in blocking:
+            title = _sanitize_md(item.get("title", ""))
+            evidence = _sanitize_md(item.get("evidence", ""))
+            fix = item.get("fix")
+            if fix:
+                fix = _sanitize_md(fix)
+            if evidence:
+                line = f"- **{title}** at `{evidence}`"
+            else:
+                line = f"- **{title}** (no evidence cited)"
+            if fix:
+                line += f" — {fix}"
+            lines.append(line)
+        lines.append("")
+    if advisories:
+        lines.append("**Advisories:**")
+        for item in advisories:
+            title = _sanitize_md(item.get("title", ""))
+            evidence = _sanitize_md(item.get("evidence", ""))
+            fix = item.get("fix")
+            if fix:
+                fix = _sanitize_md(fix)
+            if evidence:
+                line = f"- **{title}** at `{evidence}`"
+            else:
+                line = f"- **{title}** (no evidence cited)"
+            if fix:
+                line += f" — {fix}"
+            lines.append(line)
+        lines.append("")
+    return lines
+
+
 def write_synthesis(review_dir, scope, results):
+    # TRN-3022: parse structured review schema per provider.
+    # rc != 0 → FAIL <rc> regardless of structured content.
+    # rc == 0 + parsed → enriched status.
+    # rc == 0 + no parsed → legacy PASS.
+    parsed_per_provider = []
+    for result in results:
+        rc = result.get("returncode", -1)
+        if rc == 0:
+            raw_path = review_dir / result["raw"]
+            raw_text = _safe_read_raw(raw_path)
+            if raw_text is not None:
+                parsed_per_provider.append(parse_structured_review(raw_text))
+            else:
+                parsed_per_provider.append(None)
+        else:
+            parsed_per_provider.append(None)
+
+    any_structured = any(p is not None for p in parsed_per_provider)
+
+    # Legacy path: byte-identical to pre-TRN-3022 output.
+    if not any_structured:
+        lines = [
+            "# Trinity Review Synthesis",
+            "",
+            f"Scope: {scope or '.'}",
+            "",
+            "## Provider Status",
+            "",
+            "| Provider | Status | Raw Output |",
+            "|----------|--------|------------|",
+        ]
+        for result in results:
+            status = (
+                "PASS" if result["returncode"] == 0 else f"FAIL {result['returncode']}"
+            )
+            lines.append(f"| {result['provider']} | {status} | `{result['raw']}` |")
+        lines.extend(
+            [
+                "",
+                "## Notes",
+                "",
+                "This synthesis is deterministic. Inspect raw provider outputs for findings and conflicts.",
+                "",
+            ]
+        )
+        path = review_dir / "synthesis.md"
+        path.write_text("\n".join(lines) + "\n")
+        return
+
+    # Enriched path: at least one provider has structured output.
     lines = [
         "# Trinity Review Synthesis",
         "",
@@ -1698,8 +1984,37 @@ def write_synthesis(review_dir, scope, results):
         "|----------|--------|------------|",
     ]
     for result in results:
-        status = "PASS" if result["returncode"] == 0 else f"FAIL {result['returncode']}"
+        rc = result.get("returncode", -1)
+        if rc != 0:
+            # Returncode precedence: rc wins regardless of structured content.
+            status = f"FAIL {rc}"
+        else:
+            parsed = parsed_per_provider[results.index(result)]
+            if parsed is not None:
+                eff = parsed["effective_decision"]
+                score = parsed["weighted_score"]
+                n_blocking = len(parsed.get("blocking", []))
+                if eff == "FIX":
+                    status = f"FIX ({score}, {n_blocking} blocking)"
+                else:
+                    status = f"PASS ({score})"
+            else:
+                status = "PASS"
         lines.append(f"| {result['provider']} | {status} | `{result['raw']}` |")
+
+    # Findings section — only rc=0 providers with parsed results.
+    has_findings = False
+    for i, result in enumerate(results):
+        parsed = parsed_per_provider[i]
+        rc = result.get("returncode", -1)
+        if rc == 0 and parsed is not None:
+            if not has_findings:
+                lines.append("")
+                lines.append("## Findings")
+                lines.append("")
+                has_findings = True
+            lines.extend(_render_findings_for(result, parsed))
+
     lines.extend(
         [
             "",
@@ -1743,7 +2058,14 @@ def cmd_review(args):
     review_dir = make_review_dir(out_base, args.scope)
 
     try:
-        prompt = render_prompt(config, root, args.scope, review_input, strict_review)
+        prompt = render_prompt(
+            config,
+            root,
+            args.scope,
+            review_input,
+            strict_review,
+            task_type=preset_metadata.get("task_type") if preset_metadata else None,
+        )
         prompt_path = review_dir / "prompt.md"
         progress("writing prompt")
         prompt_path.write_text(prompt)

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1401,10 +1401,12 @@ def raw_output(stdout, stderr):
     # TRN-3022 coupling: the "\n[stderr]\n" sentinel written here is
     # consumed by _strip_stderr_region — do NOT change the sentinel
     # format without updating that helper and _STDERR_SENTINEL.
-    output = stdout or ""
-    if stderr:
-        output += "\n[stderr]\n" + stderr
-    return output
+    # Always append the sentinel (even with empty stderr) so the sentinel
+    # is unambiguously a delimiter, never absent. _strip_stderr_region
+    # uses rfind() to locate the last occurrence; without the always-write
+    # invariant, a stdout that mentions the sentinel string could be
+    # truncated when stderr was empty (no real delimiter to anchor against).
+    return (stdout or "") + "\n[stderr]\n" + (stderr or "")
 
 
 def timeout_partial_output(exc, stdout=None, stderr=None):

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1645,16 +1645,29 @@ def _review_schema_addendum(task_type):
     return (
         "\n## Required: Structured Output\n"
         "\n"
-        "After your free-form review, emit EXACTLY ONE fenced JSON block at the END of your\n"
-        "output, matching this schema:\n"
+        "After your free-form review, emit EXACTLY ONE fenced JSON block at the END\n"
+        'of your output. Required fields: `decision` ("PASS" or "FIX"),\n'
+        "`weighted_score` (number 0.0-10.0), `blocking` (list, may be `[]`),\n"
+        "`advisories` (list, may be `[]`). Optional: `confidence` (number 0.0-1.0).\n"
+        "Each finding in blocking/advisories is an object with `title` (str),\n"
+        '`evidence` (str, file:line, may be `""`), and optional `fix` (str).\n'
+        "\n"
+        "Concrete example — REPLACE values with your actual verdict; do NOT copy\n"
+        "this block verbatim:\n"
         "\n"
         "```json\n"
         "{\n"
-        f'  "decision": "PASS" | "FIX",\n'
-        '  "weighted_score": <0.0-10.0>,\n'
-        f'  "blocking": [{{"title": "...", "evidence": "file:line", "fix": "..."}}],\n'
-        f'  "advisories": [{{"title": "...", "evidence": "file:line", "fix": "..."}}],\n'
-        f'  "confidence": <0.0-1.0, optional>\n'
+        '  "decision": "FIX",\n'
+        '  "weighted_score": 7.5,\n'
+        '  "blocking": [\n'
+        "    {\n"
+        '      "title": "Race condition in worker shutdown",\n'
+        '      "evidence": "scripts/foo.py:142",\n'
+        '      "fix": "Acquire lock before signaling done"\n'
+        "    }\n"
+        "  ],\n"
+        '  "advisories": [],\n'
+        '  "confidence": 0.85\n'
         "}\n"
         "```\n"
         "\n"

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -8,6 +8,7 @@ import difflib
 import fnmatch
 import importlib.util
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -1546,11 +1547,11 @@ def _validate_review_schema(data):
     if not isinstance(decision, str) or decision.upper() not in ("PASS", "FIX"):
         return False
 
-    # weighted_score — reject bools (True/False are int subclasses)
+    # weighted_score — reject bools (True/False are int subclasses) and NaN/Inf
     ws = data.get("weighted_score")
     if isinstance(ws, bool) or not isinstance(ws, (int, float)):
         return False
-    if ws < 0.0 or ws > 10.0:
+    if not math.isfinite(ws) or ws < 0.0 or ws > 10.0:
         return False
 
     # blocking and advisories
@@ -1570,12 +1571,12 @@ def _validate_review_schema(data):
             if fix is not None and not isinstance(fix, str):
                 return False
 
-    # confidence (optional)
+    # confidence (optional) — reject bools and NaN/Inf
     conf = data.get("confidence")
     if conf is not None:
         if isinstance(conf, bool) or not isinstance(conf, (int, float)):
             return False
-        if conf < 0.0 or conf > 1.0:
+        if not math.isfinite(conf) or conf < 0.0 or conf > 1.0:
             return False
 
     return True
@@ -1643,7 +1644,7 @@ def _review_schema_addendum(task_type):
         "```json\n"
         "{\n"
         f'  "decision": "PASS" | "FIX",\n'
-        f'  "weighted_score": <0.0-{threshold}>,\n'
+        '  "weighted_score": <0.0-10.0>,\n'
         f'  "blocking": [{{"title": "...", "evidence": "file:line", "fix": "..."}}],\n'
         f'  "advisories": [{{"title": "...", "evidence": "file:line", "fix": "..."}}],\n'
         f'  "confidence": <0.0-1.0, optional>\n'

--- a/tests/test_codex_review_dispatch.py
+++ b/tests/test_codex_review_dispatch.py
@@ -154,7 +154,7 @@ def test_review_max_parallel_one_keeps_sequential_behavior(tmp_path):
     assert starts["deepseek"] >= ends["glm"]
     raw = (review_dir_from(result) / "raw" / "glm.txt").read_text()
     assert "provider=glm" in raw
-    assert "[stderr]" in raw
+    assert "TRINITY-RAW-STDERR-BOUNDARY" in raw
     assert "stderr=glm" in raw
 
 

--- a/tests/test_review_schema.py
+++ b/tests/test_review_schema.py
@@ -381,6 +381,21 @@ def test_a8d_stderr_block_ignored():
     assert result["weighted_score"] == 9.0
 
 
+def test_a8d4_raw_output_always_appends_sentinel():
+    """raw_output() must ALWAYS append the sentinel, even when stderr is
+    empty, so _strip_stderr_region (which uses rfind) can rely on the
+    sentinel being a real delimiter rather than possibly absent.
+    """
+    raw_output = codex_mod.raw_output
+    assert raw_output("hello", "") == "hello\n[stderr]\n"
+    assert raw_output("hello", None) == "hello\n[stderr]\n"
+    assert raw_output("hello", "err") == "hello\n[stderr]\nerr"
+    assert raw_output("", "err") == "\n[stderr]\nerr"
+    # No sentinel-in-stdout false-positive even with empty stderr:
+    raw = raw_output("a```json\n{}\n```\n[stderr]\nb", "")
+    assert raw.endswith("\n[stderr]\n"), "appended sentinel must be at the END"
+
+
 def test_a8d3_stdout_quoting_stderr_sentinel_does_not_truncate():
     """Stdout may legitimately contain the literal '\\n[stderr]\\n' string
     (e.g., a provider quoting the delimiter while reviewing this file).

--- a/tests/test_review_schema.py
+++ b/tests/test_review_schema.py
@@ -557,6 +557,28 @@ def test_numeric_bool_confidence_rejected():
     assert parse_structured_review(text) is None
 
 
+def test_nan_weighted_score_rejected():
+    text = '```json\n{"decision": "PASS", "weighted_score": NaN, "blocking": [], "advisories": []}\n```'
+    assert parse_structured_review(text) is None
+
+
+def test_infinity_weighted_score_rejected():
+    text = '```json\n{"decision": "PASS", "weighted_score": Infinity, "blocking": [], "advisories": []}\n```'
+    assert parse_structured_review(text) is None
+
+
+def test_nan_confidence_rejected():
+    text = '```json\n{"decision": "PASS", "weighted_score": 9.5, "blocking": [], "advisories": [], "confidence": NaN}\n```'
+    assert parse_structured_review(text) is None
+
+
+def test_addendum_score_range_uses_full_domain():
+    """Score domain (0.0-10.0) is independent of PASS threshold (9.0)."""
+    addendum = _review_schema_addendum("review")
+    assert "<0.0-10.0>" in addendum
+    assert "<0.0-9.0>" not in addendum
+
+
 # ---------------------------------------------------------------------------
 # Markdown sanitization
 # ---------------------------------------------------------------------------

--- a/tests/test_review_schema.py
+++ b/tests/test_review_schema.py
@@ -429,9 +429,9 @@ def test_a8e_rc124_timeout_fail(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_a8e2_parser_returns_dict_for_rc124_raw():
+def test_a8e2_parser_accepts_well_formed_pass_regardless_of_caller_rc():
     """Parser is rc-agnostic: it returns the dict even for timeout output.
-    The caller (write_synthesis) decides to ignore it."""
+    The caller (write_synthesis) decides whether to use it."""
     result = parse_structured_review(WELL_FORMED_BLOCK)
     assert result is not None
     assert result["decision"] == "PASS"
@@ -717,3 +717,78 @@ def test_case_insensitive_decision():
     result = parse_structured_review(text)
     assert result is not None
     assert result["decision"] == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: Multi-provider all-legacy A7 byte-identical
+# ---------------------------------------------------------------------------
+
+
+def test_a7_multi_provider_all_legacy_byte_identical(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "glm.txt").write_text("just prose from glm")
+    (raw_dir / "codex.txt").write_text("just prose from codex")
+    (raw_dir / "deepseek.txt").write_text("just prose from deepseek")
+    results = [
+        _make_result("glm", returncode=0, raw="raw/glm.txt"),
+        _make_result("codex", returncode=0, raw="raw/codex.txt"),
+        _make_result("deepseek", returncode=0, raw="raw/deepseek.txt"),
+    ]
+    write_synthesis(tmp_path, "spikes/test", results)
+    content = (tmp_path / "synthesis.md").read_text()
+    expected_lines = [
+        "# Trinity Review Synthesis",
+        "",
+        "Scope: spikes/test",
+        "",
+        "## Provider Status",
+        "",
+        "| Provider | Status | Raw Output |",
+        "|----------|--------|------------|",
+        "| glm | PASS | `raw/glm.txt` |",
+        "| codex | PASS | `raw/codex.txt` |",
+        "| deepseek | PASS | `raw/deepseek.txt` |",
+        "",
+        "## Notes",
+        "",
+        "This synthesis is deterministic. Inspect raw provider outputs for findings and conflicts.",
+        "",
+    ]
+    assert content == "\n".join(expected_lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: _validate_review_schema NaN/Inf rejection
+# ---------------------------------------------------------------------------
+
+
+def test_validate_review_schema_rejects_nan_weighted_score():
+    data = {
+        "decision": "PASS",
+        "weighted_score": float("nan"),
+        "blocking": [],
+        "advisories": [],
+    }
+    assert _validate_review_schema(data) is False
+
+
+def test_validate_review_schema_rejects_inf_weighted_score():
+    data = {
+        "decision": "PASS",
+        "weighted_score": float("inf"),
+        "blocking": [],
+        "advisories": [],
+    }
+    assert _validate_review_schema(data) is False
+
+
+# ---------------------------------------------------------------------------
+# Fix 7: _review_schema_addendum accepts uppercase task_type
+# ---------------------------------------------------------------------------
+
+
+def test_review_schema_addendum_accepts_uppercase_task_type():
+    text = _review_schema_addendum("REVIEW")
+    assert text != ""
+    assert "decision" in text

--- a/tests/test_review_schema.py
+++ b/tests/test_review_schema.py
@@ -575,8 +575,22 @@ def test_nan_confidence_rejected():
 def test_addendum_score_range_uses_full_domain():
     """Score domain (0.0-10.0) is independent of PASS threshold (9.0)."""
     addendum = _review_schema_addendum("review")
-    assert "<0.0-10.0>" in addendum
-    assert "<0.0-9.0>" not in addendum
+    assert "0.0-10.0" in addendum
+    assert "0.0-9.0" not in addendum
+
+
+def test_addendum_concrete_example_is_valid_json():
+    """The example block in the addendum must parse — providers may copy it."""
+    addendum = _review_schema_addendum("review")
+    import re
+
+    blocks = re.findall(r"```json\n(.*?)\n```", addendum, re.DOTALL)
+    assert blocks, "addendum must contain at least one ```json block"
+    for block in blocks:
+        data = json.loads(block)
+        assert _validate_review_schema(data), (
+            f"example block does not validate: {block}"
+        )
 
 
 def test_oversized_int_weighted_score_rejected_without_raising():

--- a/tests/test_review_schema.py
+++ b/tests/test_review_schema.py
@@ -381,6 +381,30 @@ def test_a8d_stderr_block_ignored():
     assert result["weighted_score"] == 9.0
 
 
+def test_a8d3_stdout_quoting_stderr_sentinel_does_not_truncate():
+    """Stdout may legitimately contain the literal '\\n[stderr]\\n' string
+    (e.g., a provider quoting the delimiter while reviewing this file).
+    The real boundary is always the LAST occurrence (rfind), so the JSON
+    block emitted AFTER the quoted sentinel must still be parsed.
+    """
+    real_json = json.dumps(
+        {
+            "decision": "PASS",
+            "weighted_score": 9.5,
+            "blocking": [],
+            "advisories": [],
+        }
+    )
+    text = (
+        "Reviewer prose discussing the delimiter:\n[stderr]\nthen the actual\n"
+        f"verdict block follows.\n\n```json\n{real_json}\n```\n"
+        "[stderr]\nactual stderr content here"
+    )
+    result = parse_structured_review(text)
+    assert result is not None
+    assert result["weighted_score"] == 9.5
+
+
 # ---------------------------------------------------------------------------
 # A8d2: multi-line JSON regex (DOTALL) — uses §"Schema" example
 # ---------------------------------------------------------------------------

--- a/tests/test_review_schema.py
+++ b/tests/test_review_schema.py
@@ -579,6 +579,19 @@ def test_addendum_score_range_uses_full_domain():
     assert "<0.0-9.0>" not in addendum
 
 
+def test_oversized_int_weighted_score_rejected_without_raising():
+    """Huge ints would raise OverflowError in math.isfinite — must not propagate."""
+    huge = "9" * 1000
+    text = f'```json\n{{"decision": "PASS", "weighted_score": {huge}, "blocking": [], "advisories": []}}\n```'
+    assert parse_structured_review(text) is None
+
+
+def test_oversized_int_confidence_rejected_without_raising():
+    huge = "9" * 1000
+    text = f'```json\n{{"decision": "PASS", "weighted_score": 9.5, "blocking": [], "advisories": [], "confidence": {huge}}}\n```'
+    assert parse_structured_review(text) is None
+
+
 # ---------------------------------------------------------------------------
 # Markdown sanitization
 # ---------------------------------------------------------------------------

--- a/tests/test_review_schema.py
+++ b/tests/test_review_schema.py
@@ -1,0 +1,684 @@
+"""Unit tests for TRN-3022 review result schema normalization.
+
+Covers A1–A8i + edge cases:
+- A1: parse returns dict on well-formed
+- A2: parse returns None on malformed/missing/out-of-range/no-block
+- A3: LAST block wins
+- A4: forward-compat (unknown top-level + finding-level keys)
+- A5: synthesis enriches Status column
+- A6: Findings section only when >=1 structured
+- A7: byte-identical legacy fallback
+- A8: _review_schema_addendum("review") non-empty; "tdd"/None empty
+- A8b: .agents/trinity.codex.json prompt_template UNCHANGED
+- A8c: render_prompt(task_type="review") includes addendum; None/tdd do not
+- A8d: stderr sentinel split
+- A8d2: multi-line JSON regex (DOTALL)
+- A8e: rc!=0 → FAIL <rc> regardless of structured
+- A8e2: rc=124 + valid PASS → FAIL 124, parser returns dict but ignored
+- A8f: effective_decision coercion (PASS+blocking, PASS+score<9)
+- A8g: _safe_read_raw returns None on OSError/UnicodeDecodeError
+- A8h: lazy-LLM literal placeholder rejected
+- A8i: _REVIEW_PASS_THRESHOLD monkeypatch
+- Numeric-bool rejection
+- Markdown sanitization
+- Raw-path resolution
+- Findings ordering
+- Empty-fix / empty-evidence rendering
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import codex as codex_mod  # noqa: E402
+
+parse_structured_review = codex_mod.parse_structured_review
+_validate_review_schema = codex_mod._validate_review_schema
+_strip_stderr_region = codex_mod._strip_stderr_region
+_safe_read_raw = codex_mod._safe_read_raw
+_review_schema_addendum = codex_mod._review_schema_addendum
+_render_findings_for = codex_mod._render_findings_for
+write_synthesis = codex_mod.write_synthesis
+render_prompt = codex_mod.render_prompt
+_REVIEW_PASS_THRESHOLD = codex_mod._REVIEW_PASS_THRESHOLD
+_STDERR_SENTINEL = codex_mod._STDERR_SENTINEL
+
+# The §"Schema" valid example from the CHG (multi-line, real values).
+SCHEMA_EXAMPLE = json.dumps(
+    {
+        "decision": "PASS",
+        "weighted_score": 9.2,
+        "blocking": [],
+        "advisories": [
+            {
+                "title": "Late-binding closure in helper X",
+                "evidence": "scripts/foo.py:142-148",
+                "fix": "Capture loop var via default arg",
+            }
+        ],
+        "confidence": 0.85,
+    },
+    indent=2,
+)
+
+WELL_FORMED_BLOCK = f"Review prose here.\n\n```json\n{SCHEMA_EXAMPLE}\n```"
+
+
+def _make_result(provider, returncode=0, raw="raw/glm.txt"):
+    return {
+        "provider": provider,
+        "returncode": returncode,
+        "raw": raw,
+        "started_at": "2026-01-01T00:00:00",
+        "finished_at": "2026-01-01T00:01:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# A1: well-formed parse
+# ---------------------------------------------------------------------------
+
+
+def test_a1_well_formed_returns_dict():
+    result = parse_structured_review(WELL_FORMED_BLOCK)
+    assert result is not None
+    assert result["decision"] == "PASS"
+    assert result["weighted_score"] == 9.2
+    assert result["effective_decision"] == "PASS"
+    assert result["advisories"][0]["title"] == "Late-binding closure in helper X"
+
+
+# ---------------------------------------------------------------------------
+# A2: malformed / missing / out-of-range / no-block
+# ---------------------------------------------------------------------------
+
+
+def test_a2_malformed_json_returns_none():
+    text = "```json\n{not valid json}\n```"
+    assert parse_structured_review(text) is None
+
+
+def test_a2_missing_decision_returns_none():
+    text = '```json\n{"weighted_score": 9.0, "blocking": [], "advisories": []}\n```'
+    assert parse_structured_review(text) is None
+
+
+def test_a2_missing_weighted_score_returns_none():
+    text = '```json\n{"decision": "PASS", "blocking": [], "advisories": []}\n```'
+    assert parse_structured_review(text) is None
+
+
+def test_a2_score_out_of_range_returns_none():
+    text = '```json\n{"decision": "PASS", "weighted_score": 11.0, "blocking": [], "advisories": []}\n```'
+    assert parse_structured_review(text) is None
+
+
+def test_a2_negative_score_returns_none():
+    text = '```json\n{"decision": "PASS", "weighted_score": -1.0, "blocking": [], "advisories": []}\n```'
+    assert parse_structured_review(text) is None
+
+
+def test_a2_no_block_returns_none():
+    assert parse_structured_review("Just prose, no JSON block.") is None
+
+
+def test_a2_blocking_null_returns_none():
+    text = '```json\n{"decision": "PASS", "weighted_score": 9.0, "blocking": null, "advisories": []}\n```'
+    assert parse_structured_review(text) is None
+
+
+def test_a2_missing_title_in_finding_returns_none():
+    text = '```json\n{"decision": "FIX", "weighted_score": 7.0, "blocking": [{"evidence": "f:1"}], "advisories": []}\n```'
+    assert parse_structured_review(text) is None
+
+
+# ---------------------------------------------------------------------------
+# A3: LAST block wins
+# ---------------------------------------------------------------------------
+
+
+def test_a3_last_block_wins():
+    first = json.dumps(
+        {"decision": "FIX", "weighted_score": 5.0, "blocking": [], "advisories": []}
+    )
+    second = json.dumps(
+        {"decision": "PASS", "weighted_score": 9.5, "blocking": [], "advisories": []}
+    )
+    text = f"```json\n{first}\n```\n\nSome prose\n\n```json\n{second}\n```"
+    result = parse_structured_review(text)
+    assert result is not None
+    assert result["weighted_score"] == 9.5
+
+
+# ---------------------------------------------------------------------------
+# A4: forward-compat (unknown keys)
+# ---------------------------------------------------------------------------
+
+
+def test_a4_unknown_top_level_keys_ignored():
+    text = (
+        "```json\n"
+        + json.dumps(
+            {
+                "decision": "PASS",
+                "weighted_score": 9.0,
+                "blocking": [],
+                "advisories": [],
+                "future_field": "ignored",
+            }
+        )
+        + "\n```"
+    )
+    result = parse_structured_review(text)
+    assert result is not None
+    assert "future_field" in result
+
+
+def test_a4_unknown_finding_level_keys_ignored():
+    text = (
+        "```json\n"
+        + json.dumps(
+            {
+                "decision": "FIX",
+                "weighted_score": 7.0,
+                "blocking": [{"title": "bug", "evidence": "f:1", "severity": "high"}],
+                "advisories": [],
+            }
+        )
+        + "\n```"
+    )
+    result = parse_structured_review(text)
+    assert result is not None
+    assert result["blocking"][0]["severity"] == "high"
+
+
+# ---------------------------------------------------------------------------
+# A5: synthesis enriches Status column
+# ---------------------------------------------------------------------------
+
+
+def test_a5_enriched_pass_status(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "glm.txt").write_text(WELL_FORMED_BLOCK)
+    results = [_make_result("glm", returncode=0, raw="raw/glm.txt")]
+    write_synthesis(tmp_path, "spikes/test", results)
+    content = (tmp_path / "synthesis.md").read_text()
+    assert "PASS (9.2)" in content
+
+
+def test_a5_enriched_fix_status(tmp_path):
+    fix_block = json.dumps(
+        {
+            "decision": "FIX",
+            "weighted_score": 7.1,
+            "blocking": [{"title": "bug", "evidence": "f:1"}],
+            "advisories": [],
+        }
+    )
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "glm.txt").write_text(f"```json\n{fix_block}\n```")
+    results = [_make_result("glm", returncode=0, raw="raw/glm.txt")]
+    write_synthesis(tmp_path, "spikes/test", results)
+    content = (tmp_path / "synthesis.md").read_text()
+    assert "FIX (7.1, 1 blocking)" in content
+
+
+# ---------------------------------------------------------------------------
+# A6: Findings section only when >=1 structured
+# ---------------------------------------------------------------------------
+
+
+def test_a6_findings_present_when_structured(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "glm.txt").write_text(WELL_FORMED_BLOCK)
+    (raw_dir / "codex.txt").write_text("just prose")
+    results = [
+        _make_result("glm", returncode=0, raw="raw/glm.txt"),
+        _make_result("codex", returncode=0, raw="raw/codex.txt"),
+    ]
+    write_synthesis(tmp_path, "spikes/test", results)
+    content = (tmp_path / "synthesis.md").read_text()
+    assert "## Findings" in content
+    assert "### glm" in content
+    # codex has no structured block → no findings subsection
+    assert "### codex" not in content
+
+
+def test_a6_no_findings_when_all_legacy(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "glm.txt").write_text("just prose")
+    results = [_make_result("glm", returncode=0, raw="raw/glm.txt")]
+    write_synthesis(tmp_path, "spikes/test", results)
+    content = (tmp_path / "synthesis.md").read_text()
+    assert "## Findings" not in content
+
+
+# ---------------------------------------------------------------------------
+# A7: byte-identical legacy fallback
+# ---------------------------------------------------------------------------
+
+
+def test_a7_byte_identical_legacy(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "glm.txt").write_text("just prose")
+    results = [_make_result("glm", returncode=0, raw="raw/glm.txt")]
+    write_synthesis(tmp_path, "spikes/test", results)
+    content = (tmp_path / "synthesis.md").read_text()
+    expected_lines = [
+        "# Trinity Review Synthesis",
+        "",
+        "Scope: spikes/test",
+        "",
+        "## Provider Status",
+        "",
+        "| Provider | Status | Raw Output |",
+        "|----------|--------|------------|",
+        "| glm | PASS | `raw/glm.txt` |",
+        "",
+        "## Notes",
+        "",
+        "This synthesis is deterministic. Inspect raw provider outputs for findings and conflicts.",
+        "",
+    ]
+    assert content == "\n".join(expected_lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# A8: _review_schema_addendum task-type guard
+# ---------------------------------------------------------------------------
+
+
+def test_a8_review_returns_nonempty():
+    text = _review_schema_addendum("review")
+    assert text != ""
+    assert "decision" in text
+    assert "weighted_score" in text
+
+
+def test_a8_tdd_returns_empty():
+    assert _review_schema_addendum("tdd") == ""
+
+
+def test_a8_none_returns_empty():
+    assert _review_schema_addendum(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# A8b: .agents/trinity.codex.json prompt_template UNCHANGED
+# ---------------------------------------------------------------------------
+
+
+def test_a8b_template_unchanged():
+    config_path = ROOT / ".agents" / "trinity.codex.json"
+    config = json.loads(config_path.read_text())
+    template = config.get("review", {}).get("prompt_template", "")
+    assert "Structured Output" not in template
+    assert "decision" not in template
+
+
+# ---------------------------------------------------------------------------
+# A8c: render_prompt task_type gating
+# ---------------------------------------------------------------------------
+
+
+def test_a8c_review_includes_addendum():
+    config = {"review": {"prompt_template": "{diff}\n{files}"}}
+    review_input = {"diff": "diff content", "files": "file content"}
+    prompt = render_prompt(
+        config, ROOT, "spikes/test", review_input, task_type="review"
+    )
+    assert "Structured Output" in prompt
+
+
+def test_a8c_none_excludes_addendum():
+    config = {"review": {"prompt_template": "{diff}\n{files}"}}
+    review_input = {"diff": "diff content", "files": "file content"}
+    prompt = render_prompt(config, ROOT, "spikes/test", review_input, task_type=None)
+    assert "Structured Output" not in prompt
+
+
+def test_a8c_tdd_excludes_addendum():
+    config = {"review": {"prompt_template": "{diff}\n{files}"}}
+    review_input = {"diff": "diff content", "files": "file content"}
+    prompt = render_prompt(config, ROOT, "spikes/test", review_input, task_type="tdd")
+    assert "Structured Output" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# A8d: stderr sentinel split
+# ---------------------------------------------------------------------------
+
+
+def test_a8d_stderr_block_ignored():
+    stdout_json = json.dumps(
+        {
+            "decision": "PASS",
+            "weighted_score": 9.0,
+            "blocking": [],
+            "advisories": [],
+        }
+    )
+    stderr_json = json.dumps(
+        {
+            "decision": "FIX",
+            "weighted_score": 3.0,
+            "blocking": [{"title": "stderr bug", "evidence": "f:1"}],
+            "advisories": [],
+        }
+    )
+    text = f"```json\n{stdout_json}\n```\n[stderr]\n```json\n{stderr_json}\n```"
+    result = parse_structured_review(text)
+    assert result is not None
+    assert result["weighted_score"] == 9.0
+
+
+# ---------------------------------------------------------------------------
+# A8d2: multi-line JSON regex (DOTALL) — uses §"Schema" example
+# ---------------------------------------------------------------------------
+
+
+def test_a8d2_multiline_json_parsed():
+    """All 4 panel reviewers caught the missing DOTALL flag in v2.
+    This test would have caught it: the §"Schema" example is multi-line."""
+    text = f"Some review text\n\n```json\n{SCHEMA_EXAMPLE}\n```\n"
+    result = parse_structured_review(text)
+    assert result is not None
+    assert result["decision"] == "PASS"
+    assert result["weighted_score"] == 9.2
+    assert result["confidence"] == 0.85
+
+
+# ---------------------------------------------------------------------------
+# A8e: returncode precedence
+# ---------------------------------------------------------------------------
+
+
+def test_a8e_rc_nonzero_fail_regardless_of_structured(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "glm.txt").write_text(WELL_FORMED_BLOCK)
+    results = [_make_result("glm", returncode=1, raw="raw/glm.txt")]
+    write_synthesis(tmp_path, "spikes/test", results)
+    content = (tmp_path / "synthesis.md").read_text()
+    assert "FAIL 1" in content
+    assert "PASS (9.2)" not in content
+
+
+def test_a8e_rc124_timeout_fail(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "glm.txt").write_text(WELL_FORMED_BLOCK)
+    results = [_make_result("glm", returncode=124, raw="raw/glm.txt")]
+    write_synthesis(tmp_path, "spikes/test", results)
+    content = (tmp_path / "synthesis.md").read_text()
+    assert "FAIL 124" in content
+    assert "## Findings" not in content
+
+
+# ---------------------------------------------------------------------------
+# A8e2: rc=124 + valid JSON → parser returns dict but caller ignores
+# ---------------------------------------------------------------------------
+
+
+def test_a8e2_parser_returns_dict_for_rc124_raw():
+    """Parser is rc-agnostic: it returns the dict even for timeout output.
+    The caller (write_synthesis) decides to ignore it."""
+    result = parse_structured_review(WELL_FORMED_BLOCK)
+    assert result is not None
+    assert result["decision"] == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# A8f: effective_decision coercion
+# ---------------------------------------------------------------------------
+
+
+def test_a8f_pass_with_blocking_coerced_to_fix():
+    text = (
+        "```json\n"
+        + json.dumps(
+            {
+                "decision": "PASS",
+                "weighted_score": 9.5,
+                "blocking": [{"title": "bug", "evidence": "f:1"}],
+                "advisories": [],
+            }
+        )
+        + "\n```"
+    )
+    result = parse_structured_review(text)
+    assert result is not None
+    assert result["decision"] == "PASS"
+    assert result["effective_decision"] == "FIX"
+
+
+def test_a8f_pass_with_low_score_coerced_to_fix():
+    text = (
+        "```json\n"
+        + json.dumps(
+            {
+                "decision": "PASS",
+                "weighted_score": 8.5,
+                "blocking": [],
+                "advisories": [],
+            }
+        )
+        + "\n```"
+    )
+    result = parse_structured_review(text)
+    assert result is not None
+    assert result["decision"] == "PASS"
+    assert result["effective_decision"] == "FIX"
+
+
+# ---------------------------------------------------------------------------
+# A8g: _safe_read_raw
+# ---------------------------------------------------------------------------
+
+
+def test_a8g_missing_file_returns_none(tmp_path):
+    assert _safe_read_raw(tmp_path / "nonexistent.txt") is None
+
+
+def test_a8g_unicode_decode_error_returns_none(tmp_path):
+    bad = tmp_path / "bad.txt"
+    bad.write_bytes(b"\xff\xfe invalid utf-8 \x80\x81")
+    assert _safe_read_raw(bad) is None
+
+
+def test_a8g_valid_file_returns_text(tmp_path):
+    f = tmp_path / "good.txt"
+    f.write_text("hello")
+    assert _safe_read_raw(f) == "hello"
+
+
+# ---------------------------------------------------------------------------
+# A8h: lazy-LLM placeholder rejected
+# ---------------------------------------------------------------------------
+
+
+def test_a8h_literal_placeholder_rejected():
+    text = '```json\n{"decision": "PASS" | "FIX", "weighted_score": 9.0, "blocking": [], "advisories": []}\n```'
+    assert parse_structured_review(text) is None
+
+
+# ---------------------------------------------------------------------------
+# A8i: _REVIEW_PASS_THRESHOLD monkeypatch
+# ---------------------------------------------------------------------------
+
+
+def test_a8i_threshold_monkeypatch(monkeypatch):
+    """Both coercion and addendum must use the constant."""
+    monkeypatch.setattr(codex_mod, "_REVIEW_PASS_THRESHOLD", 7.0)
+
+    # Coercion: score 8.0 is now >= 7.0, so PASS stays PASS.
+    text = (
+        "```json\n"
+        + json.dumps(
+            {
+                "decision": "PASS",
+                "weighted_score": 8.0,
+                "blocking": [],
+                "advisories": [],
+            }
+        )
+        + "\n```"
+    )
+    result = parse_structured_review(text)
+    assert result is not None
+    assert result["effective_decision"] == "PASS"
+
+    # Addendum reflects new threshold.
+    addendum = _review_schema_addendum("review")
+    assert ">= 7.0" in addendum
+
+
+# ---------------------------------------------------------------------------
+# Numeric-bool rejection
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_bool_weighted_score_rejected():
+    text = '```json\n{"decision": "PASS", "weighted_score": true, "blocking": [], "advisories": []}\n```'
+    assert parse_structured_review(text) is None
+
+
+def test_numeric_bool_confidence_rejected():
+    text = '```json\n{"decision": "PASS", "weighted_score": 9.0, "blocking": [], "advisories": [], "confidence": true}\n```'
+    assert parse_structured_review(text) is None
+
+
+# ---------------------------------------------------------------------------
+# Markdown sanitization
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_newlines_stripped_in_title(tmp_path):
+    parsed = {
+        "effective_decision": "FIX",
+        "weighted_score": 7.0,
+        "blocking": [{"title": "bug\ninjection", "evidence": "f:1"}],
+        "advisories": [],
+    }
+    lines = _render_findings_for(
+        _make_result("glm", returncode=0),
+        parsed,
+    )
+    joined = "\n".join(lines)
+    assert "bug\ninjection" not in joined
+    assert "bug injection" in joined
+
+
+# ---------------------------------------------------------------------------
+# Raw-path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_raw_path_relative_to_review_dir(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "glm.txt").write_text(WELL_FORMED_BLOCK)
+    # result["raw"] is "raw/glm.txt" (relative to review_dir)
+    raw_path = tmp_path / "raw" / "glm.txt"
+    text = _safe_read_raw(raw_path)
+    assert text is not None
+    assert "decision" in text
+
+
+# ---------------------------------------------------------------------------
+# Findings ordering matches results iteration
+# ---------------------------------------------------------------------------
+
+
+def test_findings_ordering_matches_results(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    for name in ("glm", "codex", "deepseek"):
+        block = json.dumps(
+            {
+                "decision": "FIX",
+                "weighted_score": 7.0,
+                "blocking": [{"title": f"{name} bug", "evidence": "f:1"}],
+                "advisories": [],
+            }
+        )
+        (raw_dir / f"{name}.txt").write_text(f"```json\n{block}\n```")
+
+    results = [
+        _make_result("glm", returncode=0, raw="raw/glm.txt"),
+        _make_result("codex", returncode=0, raw="raw/codex.txt"),
+        _make_result("deepseek", returncode=0, raw="raw/deepseek.txt"),
+    ]
+    write_synthesis(tmp_path, "spikes/test", results)
+    content = (tmp_path / "synthesis.md").read_text()
+    glm_pos = content.index("### glm")
+    codex_pos = content.index("### codex")
+    deepseek_pos = content.index("### deepseek")
+    assert glm_pos < codex_pos < deepseek_pos
+
+
+# ---------------------------------------------------------------------------
+# Empty-fix / empty-evidence rendering
+# ---------------------------------------------------------------------------
+
+
+def test_empty_fix_omits_emdash():
+    parsed = {
+        "effective_decision": "FIX",
+        "weighted_score": 7.0,
+        "blocking": [{"title": "bug", "evidence": "f:1"}],
+        "advisories": [],
+    }
+    lines = _render_findings_for(_make_result("glm"), parsed)
+    # Only check finding bullet lines (skip headline with " — FIX")
+    bullet_lines = [line for line in lines if line.startswith("- **")]
+    assert len(bullet_lines) == 1
+    # No " — " em-dash separator in the bullet (fix is absent).
+    assert " — " not in bullet_lines[0]
+
+
+def test_empty_evidence_renders_no_evidence_cited():
+    parsed = {
+        "effective_decision": "FIX",
+        "weighted_score": 7.0,
+        "blocking": [{"title": "cross-cutting", "evidence": ""}],
+        "advisories": [],
+    }
+    lines = _render_findings_for(_make_result("glm"), parsed)
+    joined = "\n".join(lines)
+    assert "(no evidence cited)" in joined
+
+
+# ---------------------------------------------------------------------------
+# Fuzz test: never raises
+# ---------------------------------------------------------------------------
+
+
+def test_fuzz_random_bytes_never_raises():
+    import os
+
+    for _ in range(50):
+        raw = os.urandom(256).decode("latin-1")
+        # Must not raise.
+        parse_structured_review(raw)
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitive decision
+# ---------------------------------------------------------------------------
+
+
+def test_case_insensitive_decision():
+    text = '```json\n{"decision": "pass", "weighted_score": 9.0, "blocking": [], "advisories": []}\n```'
+    result = parse_structured_review(text)
+    assert result is not None
+    assert result["decision"] == "PASS"

--- a/tests/test_review_schema.py
+++ b/tests/test_review_schema.py
@@ -375,7 +375,7 @@ def test_a8d_stderr_block_ignored():
             "advisories": [],
         }
     )
-    text = f"```json\n{stdout_json}\n```\n[stderr]\n```json\n{stderr_json}\n```"
+    text = f"```json\n{stdout_json}\n```{_STDERR_SENTINEL}```json\n{stderr_json}\n```"
     result = parse_structured_review(text)
     assert result is not None
     assert result["weighted_score"] == 9.0
@@ -387,20 +387,20 @@ def test_a8d4_raw_output_always_appends_sentinel():
     sentinel being a real delimiter rather than possibly absent.
     """
     raw_output = codex_mod.raw_output
-    assert raw_output("hello", "") == "hello\n[stderr]\n"
-    assert raw_output("hello", None) == "hello\n[stderr]\n"
-    assert raw_output("hello", "err") == "hello\n[stderr]\nerr"
-    assert raw_output("", "err") == "\n[stderr]\nerr"
+    assert raw_output("hello", "") == "hello" + _STDERR_SENTINEL
+    assert raw_output("hello", None) == "hello" + _STDERR_SENTINEL
+    assert raw_output("hello", "err") == "hello" + _STDERR_SENTINEL + "err"
+    assert raw_output("", "err") == _STDERR_SENTINEL + "err"
     # No sentinel-in-stdout false-positive even with empty stderr:
-    raw = raw_output("a```json\n{}\n```\n[stderr]\nb", "")
-    assert raw.endswith("\n[stderr]\n"), "appended sentinel must be at the END"
+    raw = raw_output("a```json\n{}\n```\nfoo bar baz", "")
+    assert raw.endswith(_STDERR_SENTINEL), "appended sentinel must be at the END"
 
 
-def test_a8d3_stdout_quoting_stderr_sentinel_does_not_truncate():
-    """Stdout may legitimately contain the literal '\\n[stderr]\\n' string
-    (e.g., a provider quoting the delimiter while reviewing this file).
-    The real boundary is always the LAST occurrence (rfind), so the JSON
-    block emitted AFTER the quoted sentinel must still be parsed.
+def test_a8d3_stdout_quoting_legacy_marker_does_not_truncate():
+    """Stdout may contain the legacy '\\n[stderr]\\n' string (e.g., a
+    reviewer quoting prior raw-output format). The actual sentinel is a
+    unique hex-tagged marker, so legacy text in stdout cannot be confused
+    with the boundary.
     """
     real_json = json.dumps(
         {
@@ -412,12 +412,45 @@ def test_a8d3_stdout_quoting_stderr_sentinel_does_not_truncate():
     )
     text = (
         "Reviewer prose discussing the delimiter:\n[stderr]\nthen the actual\n"
-        f"verdict block follows.\n\n```json\n{real_json}\n```\n"
-        "[stderr]\nactual stderr content here"
+        f"verdict block follows.\n\n```json\n{real_json}\n```"
+        + _STDERR_SENTINEL
+        + "actual stderr content here"
     )
     result = parse_structured_review(text)
     assert result is not None
     assert result["weighted_score"] == 9.5
+
+
+def test_a8d5_stderr_side_json_block_ignored():
+    """Bot R9 scenario: stderr contains a fenced JSON block. The unique
+    sentinel guarantees rfind() locks onto the appended boundary, so
+    stderr-side blocks never enter the parse region.
+    """
+    stderr_json = json.dumps(
+        {
+            "decision": "FIX",
+            "weighted_score": 3.0,
+            "blocking": [{"title": "stderr-side noise", "evidence": "f:1"}],
+            "advisories": [],
+        }
+    )
+    # Stdout has no schema; stderr has a FIX verdict.
+    raw_output = codex_mod.raw_output
+    text = raw_output(
+        "ordinary review prose with no fenced verdict",
+        f"warning: deprecated\n```json\n{stderr_json}\n```",
+    )
+    result = parse_structured_review(text)
+    assert result is None, "stderr-side JSON must be ignored"
+
+
+def test_a8d6_sentinel_is_unique_marker():
+    """The sentinel must be unique enough that ordinary provider output
+    cannot collide with it (TRN-3022 R10 hardening).
+    """
+    assert "TRINITY-RAW-STDERR-BOUNDARY" in _STDERR_SENTINEL
+    # Any legacy-format text must NOT be the sentinel:
+    assert _STDERR_SENTINEL != "\n[stderr]\n"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements [TRN-3022](../blob/codex/trn-3022-review-schema/rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md) — provider review outputs now emit a structured JSON block; synthesis parses + renders consistently with returncode precedence and FIX coercion for inconsistent PASS results.

- **Schema**: providers emit a fenced ```` ```json ```` block at end of stdout with `decision` (PASS/FIX), `weighted_score` (0-10), `blocking[]`, `advisories[]`, optional `confidence`
- **Parser** (`parse_structured_review`): never raises, last-block-wins, splits on `\n[stderr]\n` sentinel before scanning, returns dict-or-None
- **Synthesis**: returncode wins (rc!=0 → `FAIL N`), only rc=0 providers get structured rendering, byte-identical legacy fallback when no structured providers
- **Effective-decision coercion**: PASS+blocking-non-empty OR score<9.0 → FIX (preserves original `decision`)
- **Code-side addendum** (`_review_schema_addendum`) appended to `render_prompt` only for `task_type=\"review\"` — no static template changes to `.agents/trinity.codex.json`
- **Numeric-bool rejection**: `weighted_score: True` rejected via `isinstance(_, bool)` guard
- **Markdown sanitization**: `\n` in title/evidence/fix replaced with space before rendering
- **Raw-path resolution**: `_safe_read_raw(review_dir / result[\"raw\"])` — relative to review_dir, not cwd

## Plan-review gate

| Provider | Score | Decision |
|----------|-------|----------|
| gemini | 9.5 | PASS |
| codex | 9.2 | PASS |
| glm | 9.2 | PASS |
| deepseek | 9.10 | PASS |
| **Mean** | **9.255** | **All ≥9.0 individual** |

4 plan-review rounds. R1 caught 6 architectural blockers (returncode precedence undefined, PASS+blocking inconsistency, write_synthesis I/O contract widening, task-type guard impossible with static template, stderr-side JSON breaks last-block-wins). R2 caught regex DOTALL bug (`(?im)` → `(?ims)`). R3 fixed A8d2/A8h fixture conflict. R4 met gate.

## Test plan
- [x] `pytest tests/` — 301 passed (256 prior + 45 new)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `make coverage` — 84% TOTAL (≥80% target)
- [x] `af validate --root .` — 116 docs, 0 issues
- [ ] CI green
- [ ] Codex bot review addressed

## Files

- `scripts/codex.py` — constants + 5 helpers + render_prompt/cmd_review/write_synthesis modifications (+334 lines)
- `tests/test_review_schema.py` — 45 unit tests (NEW)
- `providers/_base/family-wrapper.md` — schema reference section
- `README.md` — Run a review section note
- `CHANGELOG.md` — `[Unreleased] ### Added`
- `rules/TRN-3022-CHG-Normalize-Review-Result-Schema.md` (NEW) + index row

🤖 Generated with [Claude Code](https://claude.com/claude-code)