### PR TITLE
TRN-3027: amend TRN-1006 SOP — registry.json authoritative for native-CLI pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@
   Closes #39. Foundation for #55.
 
 ### Changed
+- `rules/TRN-1006-SOP-Provider-Model-IDs.md` amended (TRN-3027): pin-location
+  table now references `providers/registry.json` as authoritative for
+  native-CLI providers (codex, glm); Section A steps replace "edit Makefile
+  + install.sh register lines" with "edit `providers/registry.json`" — the
+  install layer derives both from the registry post-TRN-3020. Wrapper
+  providers (deepseek, openrouter, claude-code) keep model pins in
+  `providers/bin/<name>` env blocks until TRN-3026 lands.
 - `tests/test_install_sh.sh` path-sanity guard switched from a deny-list
   (`*' '*|*'?'*|*'#'*`) to a positive allow-list (`[A-Za-z0-9._/+-]+`).
   Catches `[`, `]`, `*`, `;`, `&`, `(`, `)`, quotes, `\`, `%`, and

--- a/rules/TRN-0000-REF-Document-Index.md
+++ b/rules/TRN-0000-REF-Document-Index.md
@@ -51,6 +51,7 @@
 | 3021 | CHG | Expand Doctor Preflight |
 | 3022 | CHG | Normalize Review Result Schema |
 | 3023 | CHG | Sanitize Provider Environment At Spawn Time |
+| 3027 | CHG | SOP 1006 Registry Amendment |
 
 ---
 

--- a/rules/TRN-1006-SOP-Provider-Model-IDs.md
+++ b/rules/TRN-1006-SOP-Provider-Model-IDs.md
@@ -89,24 +89,42 @@ Single source of truth per provider (post-TRN-3020 / TRN-3027):
 | `deepseek` | Model: `providers/bin/deepseek` env block. Bin path: `providers/registry.json` → `providers.deepseek.cli`. (Env-var registry shape — TRN-3026) | `ANTHROPIC_MODEL="deepseek-v4-pro[1m]"`, `ANTHROPIC_SMALL_FAST_MODEL="deepseek-v4-flash"` |
 | `openrouter` | Model: `providers/bin/openrouter` env block. Bin path: `providers/registry.json` → `providers.openrouter.cli`. (Env-var registry shape — TRN-3026) | `ANTHROPIC_MODEL="qwen/qwen3.6-plus:free"`, `ANTHROPIC_SMALL_FAST_MODEL="qwen/qwen3.6-plus:free"` |
 
-**Two distinct patterns**: native CLIs (codex, gemini, glm) take the model as a positional/flag argument in the `cli` string registered via `providers/registry.json`. Anthropic-compat wrappers (deepseek, openrouter, claude-code) take it via `ANTHROPIC_MODEL` env var inside the bin script — the registry stores the bin-script wrapper path, not the model. The `Makefile install` target and `install.sh` both consume `providers/registry.json` via `scripts/install.py`; do NOT edit Makefile or install.sh `register` lines for model bumps — they derive from the registry.
+**Three patterns**:
+
+- **Registry-managed native CLIs** (codex, glm): model is part of the `cli` string in `providers/registry.json`. The `Makefile install` target and `install.sh` both consume the registry via `scripts/install.py`; do NOT edit Makefile or install.sh `register` lines for these — they derive from the registry.
+- **Registry-deferred native CLI** (gemini): registered separately in `Makefile` and `install.sh` as `gemini -p` (no model flag in the registered CLI). The model is selected inside the `.delta.md` prompt (`gemini -m <model>` invocation in the `### New session` block). Gemini joins the registry once TRN-3025 lands a canonical `cli` value.
+- **Anthropic-compat wrappers** (deepseek, openrouter, claude-code): model lives in `ANTHROPIC_MODEL` env var inside `providers/bin/<name>`. The registry stores the bin-script wrapper path, not the model.
 
 ---
 
 ## Steps
 
-The exact procedure depends on which pin location the provider uses. Section A covers native-CLI providers (codex, glm, gemini); Section B covers Anthropic-compat wrappers (deepseek, openrouter); Section C covers verification after `make install`.
+The exact procedure depends on which pin location the provider uses. **Section A** covers registry-managed native-CLI providers (codex, glm). **Section A-bis** covers gemini (registry-deferred). **Section B** covers Anthropic-compat wrappers (deepseek, openrouter, claude-code). **Section C** covers verification after `make install`.
 
-### A. Native-CLI providers (codex, glm)
+### A. Registry-managed native-CLI providers (codex, glm)
 
-1. Edit `providers/registry.json` → `providers.<name>.cli` field. The `Makefile install` target and `install.sh` both read this file via `scripts/install.py` — do NOT also edit `register` lines in those files (they no longer hardcode CLI strings post-TRN-3020).
-2. If the provider has caller-side flags in its `.delta.md` (e.g., `gemini --model <X>`) or in `.agents/trinity.codex.json`, update there too.
+1. Edit `providers/registry.json` → `providers.<name>.cli` field. The `Makefile install` target and `install.sh` both read this file via `scripts/install.py` — do NOT also edit `register` lines in those files (they no longer hardcode CLI strings for codex/glm post-TRN-3020).
+2. If the provider has caller-side flags in its `.delta.md` or in `.agents/trinity.codex.json`, update there too.
 3. Run `make build` (regenerates `providers/<name>.md` if `.delta.md` changed).
 4. Run `make verify-built` (must pass).
 5. Update any test asserting the registered `cli` string (search `tests/` for the old value, including `tests/test_install_sh.sh` T11 and `tests/test_codex_adapter.py` registry assertions).
 6. CHANGELOG `[Unreleased]` entry.
 7. Commit, bump VERSION (TRN-1003), `make release-prep`, push.
-8. Re-run `make install` against `HOME=$(mktemp -d)` to confirm the registered `cli` matches what's in registry.json.
+8. Re-run `make install` against `HOME=$(mktemp -d)` to confirm the registered `cli` matches what's in `providers/registry.json`.
+
+### A-bis. Gemini (registry-deferred until TRN-3025)
+
+Gemini is registered separately in `Makefile` (line ~63) and `install.sh` (line ~96) as `gemini -p`. The model itself is selected inside the `.delta.md` prompt, not in the registered CLI string.
+
+1. Edit `providers/gemini.delta.md` — update the model identifier in the `### New session` invocation (e.g. `gemini -m gemini-3.1-pro-preview -p ...`).
+2. Run `make build` (regenerates `providers/gemini.md`).
+3. Run `make verify-built` (must pass).
+4. Update any test asserting the gemini model string.
+5. CHANGELOG `[Unreleased]` entry.
+6. Commit, bump VERSION, `make release-prep`, push.
+7. Re-run `make install` to refresh `~/.claude/agents/trinity-gemini.md`.
+
+When TRN-3025 lands, this section folds back into Section A.
 
 ### B. Anthropic-compat providers (deepseek, openrouter)
 

--- a/rules/TRN-1006-SOP-Provider-Model-IDs.md
+++ b/rules/TRN-1006-SOP-Provider-Model-IDs.md
@@ -79,17 +79,17 @@ Trinity's wrappers always double-quote the assignment (see `providers/bin/deepse
 
 ## Where Model IDs Are Pinned
 
-Single source of truth per provider:
+Single source of truth per provider (post-TRN-3020 / TRN-3027):
 
-| Provider | Model pin location | Pinned value (as of 2026-05-06) |
+| Provider | Model pin location | Pinned value (as of 2026-05-08) |
 |----------|--------------------|----------------------------------|
-| `codex` | `Makefile` `install` target + `install.sh` `register codex --cli` | `codex exec --skip-git-repo-check -m gpt-5.5` (TRN-2005) |
-| `gemini` | `providers/gemini.delta.md` `### New session` invocation | `gemini-3.1-pro-preview` |
-| `glm` | `Makefile` / `install.sh` `register glm --cli`, `.agents/trinity.codex.json`, and `providers/glm.delta.md` | Claude Code install: `droid exec --auto medium --model glm-5.1 --reasoning-effort high`; Codex review: `droid exec --model glm-5.1 --reasoning-effort high` |
-| `deepseek` | `providers/bin/deepseek` env block | `ANTHROPIC_MODEL="deepseek-v4-pro[1m]"`, `ANTHROPIC_SMALL_FAST_MODEL="deepseek-v4-flash"` |
-| `openrouter` | `providers/bin/openrouter` env block | `ANTHROPIC_MODEL="qwen/qwen3.6-plus:free"`, `ANTHROPIC_SMALL_FAST_MODEL="qwen/qwen3.6-plus:free"` |
+| `codex` | `providers/registry.json` → `providers.codex.cli` | `codex exec --skip-git-repo-check -m gpt-5.5` (TRN-2005) |
+| `gemini` | `providers/gemini.delta.md` `### New session` invocation (registry deferred — TRN-3025) | `gemini-3.1-pro-preview` |
+| `glm` | `providers/registry.json` → `providers.glm.cli` + `.agents/trinity.codex.json` + `providers/glm.delta.md` | Claude Code install: `droid exec --auto medium --model glm-5.1 --reasoning-effort high`; Codex review: `droid exec --model glm-5.1 --reasoning-effort high` |
+| `deepseek` | Model: `providers/bin/deepseek` env block. Bin path: `providers/registry.json` → `providers.deepseek.cli`. (Env-var registry shape — TRN-3026) | `ANTHROPIC_MODEL="deepseek-v4-pro[1m]"`, `ANTHROPIC_SMALL_FAST_MODEL="deepseek-v4-flash"` |
+| `openrouter` | Model: `providers/bin/openrouter` env block. Bin path: `providers/registry.json` → `providers.openrouter.cli`. (Env-var registry shape — TRN-3026) | `ANTHROPIC_MODEL="qwen/qwen3.6-plus:free"`, `ANTHROPIC_SMALL_FAST_MODEL="qwen/qwen3.6-plus:free"` |
 
-**Two distinct patterns**: native CLIs (codex, gemini, glm) take the model as a positional/flag argument in the registered `cli` string. Anthropic-compat wrappers (deepseek, openrouter) take it via `ANTHROPIC_MODEL` env var inside the bin script.
+**Two distinct patterns**: native CLIs (codex, gemini, glm) take the model as a positional/flag argument in the `cli` string registered via `providers/registry.json`. Anthropic-compat wrappers (deepseek, openrouter, claude-code) take it via `ANTHROPIC_MODEL` env var inside the bin script — the registry stores the bin-script wrapper path, not the model. The `Makefile install` target and `install.sh` both consume `providers/registry.json` via `scripts/install.py`; do NOT edit Makefile or install.sh `register` lines for model bumps — they derive from the registry.
 
 ---
 
@@ -99,15 +99,14 @@ The exact procedure depends on which pin location the provider uses. Section A c
 
 ### A. Native-CLI providers (codex, glm)
 
-1. Update the `--cli` value in `Makefile` `install` target.
-2. Update the matching `--cli` value in `install.sh`.
-3. If the provider has caller-side flags in its `.delta.md` (e.g., `gemini --model <X>`), update there too.
-4. Run `make build` (regenerates `providers/<name>.md` if `.delta.md` changed).
-5. Run `make verify-built` (must pass).
-6. Update any test asserting the registered `cli` string (search `tests/` for the old value).
-7. CHANGELOG `[Unreleased]` entry.
-8. Commit, bump VERSION (TRN-1003), `make release-prep`, push.
-9. Re-run `make install` locally to update `~/.claude/trinity.json`.
+1. Edit `providers/registry.json` → `providers.<name>.cli` field. The `Makefile install` target and `install.sh` both read this file via `scripts/install.py` — do NOT also edit `register` lines in those files (they no longer hardcode CLI strings post-TRN-3020).
+2. If the provider has caller-side flags in its `.delta.md` (e.g., `gemini --model <X>`) or in `.agents/trinity.codex.json`, update there too.
+3. Run `make build` (regenerates `providers/<name>.md` if `.delta.md` changed).
+4. Run `make verify-built` (must pass).
+5. Update any test asserting the registered `cli` string (search `tests/` for the old value, including `tests/test_install_sh.sh` T11 and `tests/test_codex_adapter.py` registry assertions).
+6. CHANGELOG `[Unreleased]` entry.
+7. Commit, bump VERSION (TRN-1003), `make release-prep`, push.
+8. Re-run `make install` against `HOME=$(mktemp -d)` to confirm the registered `cli` matches what's in registry.json.
 
 ### B. Anthropic-compat providers (deepseek, openrouter)
 
@@ -135,6 +134,7 @@ grep "ANTHROPIC_MODEL\|ANTHROPIC_SMALL_FAST_MODEL" ~/.claude/skills/trinity/bin/
 - **Never strip the `[…]` suffix** when copying from provider docs. If you see `[1m]`, it stays.
 - **Never write the model ID unquoted** in a shell context. Always use `"…"` or `'…'`.
 - **Never edit `providers/<name>.md` directly** for model changes — those are generated from `<name>.delta.md` (TRN-2004). For deepseek/openrouter, the model lives in `providers/bin/<name>`, not the agent .md.
+- **Never edit Makefile or install.sh `register` lines** for native-CLI model bumps — they derive from `providers/registry.json` via `scripts/install.py` (post-TRN-3020). Edit the registry instead.
 - **One provider per PR** when changing models. Don't bundle a deepseek pin change with an openrouter pin change unless the trigger is the same upstream event.
 - **Provider docs URL** belongs in the CHANGELOG entry, so the rationale ("upstream announced the 1M tier") is recoverable.
 
@@ -166,5 +166,6 @@ Tracked in `Makefile` install target and `install.sh` register call.
 
 | Date | Change | By |
 |------|--------|----|
+| 2026-05-08 | TRN-3027: amended pin-location table + Section A steps + Guard Rails to reflect `providers/registry.json` as authoritative source for native-CLI providers (codex, glm) post-TRN-3020 | Claude Opus 4.7 |
 | 2026-05-06 | Update GLM pin location/value for GLM-5.1 plus explicit highest supported reasoning effort | Codex |
 | 2026-04-26 | Initial version — bracket-suffix convention, pin locations, update steps | Claude Opus 4.7 |

--- a/rules/TRN-3027-CHG-SOP-1006-Registry-Amendment.md
+++ b/rules/TRN-3027-CHG-SOP-1006-Registry-Amendment.md
@@ -1,0 +1,72 @@
+# CHG-3027: TRN-1006 SOP Amendment — Registry as Authoritative Pin Source
+
+**Applies to:** Trinity project (`frankyxhl/trinity`)
+**Last updated:** 2026-05-08
+**Last reviewed:** 2026-05-08
+**Status:** Approved
+**Date:** 2026-05-08
+**Requested by:** TRN-3020 follow-up (deferred from PR #66 round-2 review)
+**Priority:** Low
+**Change Type:** Doc-only amendment
+**Targets:** `rules/TRN-1006-SOP-Provider-Model-IDs.md` (single file)
+**Builds on:** TRN-3020 (introduced `providers/registry.json` as install-time authoritative source)
+
+---
+
+## What
+
+Amend `TRN-1006-SOP-Provider-Model-IDs.md` to reference `providers/registry.json` as the authoritative source for the `cli` string of native-CLI providers (codex, glm). Anthropic-compat wrapper providers (deepseek, openrouter, claude-code) keep their model pins inside `providers/bin/<name>` env blocks — those pins remain out of registry scope until TRN-3026 lands.
+
+Specifically:
+
+1. The pin-location table (current §"Where Model IDs Are Pinned") replaces "Makefile + install.sh register" entries with "providers/registry.json" for codex and glm; deepseek and openrouter rows updated to note registry holds only the bin-script wrapper path.
+2. Section A "Native-CLI providers (codex, glm)" replaces step 1+2 ("update Makefile, update install.sh") with a single step: "edit `providers/registry.json`'s `cli` field". Steps 4-9 unchanged.
+3. Add a Guard Rail bullet: "After editing `providers/registry.json`, run `make install` against `HOME=$(mktemp -d)` to confirm the registered cli matches".
+4. Add a Change History row noting the amendment + reference to this CHG.
+
+## Why
+
+PR #66 (TRN-3020) introduced `providers/registry.json` as the install-time source consumed by `scripts/install.py` (Makefile + install.sh both call it). Before TRN-3020, model pins for native-CLI providers lived in the Makefile and install.sh `register` lines (two locations, drift-prone). After TRN-3020, the registry IS the source — Makefile and install.sh derive from it. TRN-1006 still describes the old two-location pattern. Without the amendment, future model bumps will edit the wrong files (or duplicate effort); the SOP must reflect the post-TRN-3020 reality.
+
+This was explicitly deferred to TRN-3027 in TRN-3020's "Out of Scope" section ("currently lists pin locations + step-by-step pin-update procedure; will become partially obsolete once registry exists. Cannot amend in-CHG without scope creep").
+
+## Out of Scope
+
+- Bringing deepseek/openrouter/claude-code env-var pins into the registry (that's TRN-3026 — needs a registry shape extension for `env_vars` mapping).
+- Adding `gemini` to the registry (deferred to TRN-3025 pending canonical CLI value decision).
+- Amending TRN-1003 (release SOP) — release-prep already references the right files via `make verify-built`; no SOP drift there.
+
+## Surfaces
+
+| # | Surface | Change |
+|---|---------|--------|
+| 1 | `rules/TRN-1006-SOP-Provider-Model-IDs.md` | Pin-location table updated (5 rows), Section A steps 1-2 replaced with single "edit registry.json" step, new Guard Rail bullet, Change History row |
+| 2 | `CHANGELOG.md` | `[Unreleased] ### Changed` entry |
+
+## Acceptance Criteria
+
+- **A1**: Pin-location table row for `codex` reads "providers/registry.json" (was Makefile + install.sh register codex).
+- **A2**: Pin-location table row for `glm` reads "providers/registry.json + providers/glm.delta.md + .agents/trinity.codex.json" (registry replaces Makefile + install.sh; glm has additional caller-side flags in delta + codex config).
+- **A3**: Pin-location table rows for `deepseek` and `openrouter` reference both `providers/bin/<name>` (the model pin) AND `providers/registry.json` (the bin-path entry) — the env-var pin is registry-out-of-scope until TRN-3026.
+- **A4**: Section A step 1 reads "Edit `providers/registry.json`'s `providers.<name>.cli` field" — replaces the previous 2 steps that updated Makefile + install.sh separately.
+- **A5**: New Guard Rail: "After editing `providers/registry.json`, run `make install` against `HOME=$(mktemp -d)` to confirm the registered cli matches".
+- **A6**: Section B (Anthropic-compat providers) — unchanged. Model pins for deepseek/openrouter still live in `providers/bin/<name>`.
+- **A7**: `af validate --root .` still passes (structural validity preserved).
+- **A8**: Change History table appends a 2026-05-08 row referencing this CHG.
+
+## Implementation Order
+
+1. Edit `rules/TRN-1006-SOP-Provider-Model-IDs.md` — table + Section A + Guard Rails + Change History.
+2. Add `CHANGELOG.md` `[Unreleased] ### Changed` entry.
+3. Run `af validate --root .` — confirm 0 issues.
+4. Open PR with `Closes` reference to TRN-3027 follow-up note.
+
+## Risk Assessment
+
+Doc-only change. No code paths affected. No tests change. The only "behavioral" risk is the SOP being internally inconsistent with current code — confirmed not the case (registry IS authoritative as of TRN-3020 merge).
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-08 | Initial draft, marked Approved (doc-only, scope clear from TRN-3020 deferral) | Claude Code |


### PR DESCRIPTION
## Summary

Doc-only follow-up deferred from TRN-3020 (PR #66). Post-TRN-3020, `providers/registry.json` is the install-time authoritative source for native-CLI providers (codex, glm) — `Makefile install` and `install.sh` both consume it via `scripts/install.py`. TRN-1006 SOP still described the pre-TRN-3020 two-location pattern (edit Makefile + install.sh `register` lines), which would direct future model bumps to the wrong files.

## What changes in TRN-1006

- **Pin-location table**: codex / glm rows reference `providers/registry.json` (was Makefile + install.sh register); deepseek / openrouter rows clarify model pin lives in bin script while registry holds bin path
- **Section A steps**: "edit Makefile + edit install.sh" → single "edit `providers/registry.json`" step
- **New Guard Rail**: \"Never edit Makefile or install.sh `register` lines for native-CLI model bumps — they derive from registry.json\"
- **Verification step**: \"`make install` against `HOME=$(mktemp -d)`\" replaces \"re-run `make install` locally\"
- Change History row appended

## Out of scope

- deepseek / openrouter env-var pins → TRN-3026 (needs registry shape extension)
- gemini canonical CLI value → TRN-3025 (rate-limited at TRN-3020 time)

## Test plan
- [x] `af validate --root .` — 117 docs, 0 issues
- [x] `pytest tests/` — 316 passed (no behavioral surface — doc-only)
- [x] No code paths affected, no test changes
- [ ] CI green

## Files
- `rules/TRN-1006-SOP-Provider-Model-IDs.md` — table + Section A + Guard Rails + Change History
- `rules/TRN-3027-CHG-SOP-1006-Registry-Amendment.md` (NEW) — CHG record
- `rules/TRN-0000-REF-Document-Index.md` — auto-regenerated by `af index`
- `CHANGELOG.md` — `[Unreleased] ### Changed` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)