### PR TITLE
chore: tidy main — gitignore tmp/, drop empty TRN-9900, move research

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 .claude/
 .omx/
 .worktrees/
+tmp/


### PR DESCRIPTION
## Summary

Housekeeping on `main` after PR #119 (TRN-3040) and PR #120 (TRN-1008 R9) merged. Three small cleanups:

- **`.gitignore`** — add `tmp/` as the canonical local-scratch surface (baselines, coverage dumps, issue drafts).
- **Delete** `rules/TRN-9900-REF-Discussion-Tracker-2026-05-10.md` — empty placeholder body (`<description>` / `<reference content>` placeholders), dated 5 days stale. Was untracked, so no repo trace.
- **Move** `openclaw_code_agent_wrapping_research.md` (1027 lines, Chinese research doc about OpenClaw CLI wrapping) from repo root → `tmp/`. Research scratchpad, not a rule. Was untracked, so no repo trace.

## Why a PR for this

Per session decision (2026-05-15): always open a PR for changes, even small housekeeping ones. The single committed change is `+tmp/` in `.gitignore`; the rest is documented context so reviewers can see what the local working tree looked like.

## Test plan

- [x] `git status` clean after commit
- [x] `tmp/` matches new gitignore rule (already in `git ls-files --others --exclude-standard` returns nothing under tmp/ now)
- [x] No `rules/` file deleted (TRN-9900 was untracked)
- [x] codex-bot review (optional for pure gitignore change, but matches always-PR rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)