### PR TITLE
refactor(#77): extract _load_version() to shared scripts/_version.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
   rationale and surfaces.
 
 ### Changed
+- `scripts/_version.py` — new shared module exposing `load_version()`. The
+  identical inlined `_load_version()` helper that lived in `scripts/session.py`,
+  `scripts/config.py`, `scripts/discover.py`, `scripts/install.py`, and
+  `scripts/codex.py` (5 copies × ~8 lines each = ~40 LoC) is gone; each call
+  site now imports `load_version` from `_version` (dual-mode: direct script
+  exec + package import). Pure DRY refactor — no behavior change, same
+  importlib mechanism for reading `scripts/__init__.py`. Closes #77.
 - `rules/TRN-1008-SOP-Multi-Agent-Review-Loop.md` adopts PKG `COR-1617 §11
   Retrospective` (alfred v1.16.0). NEW `### 11. Retrospective` subsection
   inserted before Loop restart; existing `### 11. Loop restart` renumbered

--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,7 @@ _download() {
 
 _download "SKILL.md"                  "${HOME}/.claude/skills/trinity/SKILL.md"
 _download "scripts/__init__.py"       "${HOME}/.claude/skills/trinity/scripts/__init__.py"
+_download "scripts/_version.py"       "${HOME}/.claude/skills/trinity/scripts/_version.py"
 _download "scripts/session.py"        "${HOME}/.claude/skills/trinity/scripts/session.py"
 _download "scripts/config.py"         "${HOME}/.claude/skills/trinity/scripts/config.py"
 _download "scripts/discover.py"       "${HOME}/.claude/skills/trinity/scripts/discover.py"

--- a/scripts/_version.py
+++ b/scripts/_version.py
@@ -1,0 +1,17 @@
+"""Shared version loader for trinity scripts.
+
+Reads __version__ from scripts/__init__.py via importlib so each script
+can be invoked directly (python scripts/foo.py) without requiring
+package-import context.
+"""
+
+import importlib.util
+import os
+
+
+def load_version():
+    init_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "__init__.py")
+    spec = importlib.util.spec_from_file_location("_scripts_init", init_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.__version__

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -6,7 +6,6 @@ import concurrent.futures
 import datetime as dt
 import difflib
 import fnmatch
-import importlib.util
 import json
 import math
 import os
@@ -19,6 +18,11 @@ import subprocess
 import sys
 import threading
 import time
+
+try:
+    from _version import load_version
+except ModuleNotFoundError:
+    from scripts._version import load_version
 
 
 DEFAULT_CONFIG = Path("~/.codex/trinity.json").expanduser()
@@ -82,15 +86,7 @@ STRICT_REVIEW_TEMPLATES = {
 }
 
 
-def _load_version():
-    init_file = Path(__file__).resolve().parent / "__init__.py"
-    spec = importlib.util.spec_from_file_location("_scripts_init", str(init_file))
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod.__version__
-
-
-__version__ = _load_version()
+__version__ = load_version()
 
 
 def run_git(root, args, allow_error=False):

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -20,9 +20,9 @@ import threading
 import time
 
 try:
+    from ._version import load_version
+except ImportError:
     from _version import load_version
-except ModuleNotFoundError:
-    from scripts._version import load_version
 
 
 DEFAULT_CONFIG = Path("~/.codex/trinity.json").expanduser()

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -12,9 +12,9 @@ import os
 import sys
 
 try:
+    from ._version import load_version
+except ImportError:
     from _version import load_version
-except ModuleNotFoundError:
-    from scripts._version import load_version
 
 __version__ = load_version()
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -7,21 +7,16 @@ Usage:
     config.py merge [--global-config <path>] [--project-dir <dir>]
 """
 
-import importlib.util
 import json
 import os
 import sys
 
+try:
+    from _version import load_version
+except ModuleNotFoundError:
+    from scripts._version import load_version
 
-def _load_version():
-    _init = os.path.join(os.path.dirname(os.path.abspath(__file__)), "__init__.py")
-    _spec = importlib.util.spec_from_file_location("_scripts_init", _init)
-    _mod = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_mod)
-    return _mod.__version__
-
-
-__version__ = _load_version()
+__version__ = load_version()
 
 
 def load_json_file(path):

--- a/scripts/discover.py
+++ b/scripts/discover.py
@@ -7,22 +7,17 @@ Usage:
     discover.py list [--global-config <path>] [--project-dir <dir>]
 """
 
-import importlib.util
 import json
 import os
 import subprocess
 import sys
 
+try:
+    from _version import load_version
+except ModuleNotFoundError:
+    from scripts._version import load_version
 
-def _load_version():
-    _init = os.path.join(os.path.dirname(os.path.abspath(__file__)), "__init__.py")
-    _spec = importlib.util.spec_from_file_location("_scripts_init", _init)
-    _mod = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_mod)
-    return _mod.__version__
-
-
-__version__ = _load_version()
+__version__ = load_version()
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 CONFIG_SCRIPT = os.path.join(SCRIPT_DIR, "config.py")

--- a/scripts/discover.py
+++ b/scripts/discover.py
@@ -13,9 +13,9 @@ import subprocess
 import sys
 
 try:
+    from ._version import load_version
+except ImportError:
     from _version import load_version
-except ModuleNotFoundError:
-    from scripts._version import load_version
 
 __version__ = load_version()
 

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -15,9 +15,9 @@ import sys
 import tempfile
 
 try:
+    from ._version import load_version
+except ImportError:
     from _version import load_version
-except ModuleNotFoundError:
-    from scripts._version import load_version
 
 __version__ = load_version()
 

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -9,22 +9,17 @@ Usage:
     install.py register-from-registry <registry_path> [--global-config <path>]
 """
 
-import importlib.util
 import json
 import os
 import sys
 import tempfile
 
+try:
+    from _version import load_version
+except ModuleNotFoundError:
+    from scripts._version import load_version
 
-def _load_version():
-    _init = os.path.join(os.path.dirname(os.path.abspath(__file__)), "__init__.py")
-    _spec = importlib.util.spec_from_file_location("_scripts_init", _init)
-    _mod = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_mod)
-    return _mod.__version__
-
-
-__version__ = _load_version()
+__version__ = load_version()
 
 try:
     import fcntl

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -16,9 +16,9 @@ import sys
 import time
 
 try:
+    from ._version import load_version
+except ImportError:
     from _version import load_version
-except ModuleNotFoundError:
-    from scripts._version import load_version
 
 __version__ = load_version()
 

--- a/scripts/session.py
+++ b/scripts/session.py
@@ -10,22 +10,17 @@ Usage:
     session.py heartbeat <output_file>
 """
 
-import importlib.util
 import json
 import os
 import sys
 import time
 
+try:
+    from _version import load_version
+except ModuleNotFoundError:
+    from scripts._version import load_version
 
-def _load_version():
-    _init = os.path.join(os.path.dirname(os.path.abspath(__file__)), "__init__.py")
-    _spec = importlib.util.spec_from_file_location("_scripts_init", _init)
-    _mod = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_mod)
-    return _mod.__version__
-
-
-__version__ = _load_version()
+__version__ = load_version()
 
 try:
     import fcntl

--- a/tests/test_install_sh.sh
+++ b/tests/test_install_sh.sh
@@ -58,6 +58,7 @@ t1_happy_path() {
     EXPECTED_FILES=(
         ".claude/skills/trinity/SKILL.md"
         ".claude/skills/trinity/scripts/__init__.py"
+        ".claude/skills/trinity/scripts/_version.py"
         ".claude/skills/trinity/scripts/session.py"
         ".claude/skills/trinity/scripts/config.py"
         ".claude/skills/trinity/scripts/discover.py"


### PR DESCRIPTION
## Summary

Extracts the duplicated `_load_version()` helper (5 inlined copies in `scripts/{session,config,discover,install,codex}.py`) into one shared `scripts/_version.py` module exposing `load_version()`.

Pure DRY refactor — same importlib mechanism, no behavior change.

Closes #77.

## Why

When `__version__`'s storage mechanism ever changes, 5 copies drift unless updated in lockstep. Single source of truth eliminates that hazard.

## Implementation notes

- **New module**: `scripts/_version.py` — single `load_version()` function. Uses the same `importlib.util.spec_from_file_location(...)` pattern reading `scripts/__init__.py`. Self-locating via `__file__`.
- **Dual-mode import**: each consumer uses `try: from _version import load_version / except ModuleNotFoundError: from scripts._version import load_version`. Reason: two tests (`test_codex_review_dispatch.py`, `test_bdd_scenarios.py`) do `from scripts import codex` — package-import mode where `_version` isn't on top-level sys.path. The fallback covers both modes without sys.path manipulation.
- **`importlib.util` import removed** from all 5 consumers (was only used by `_load_version`).

## Diff stat

```
CHANGELOG.md        |  7 +++++++
scripts/codex.py    | 16 ++++++----------
scripts/config.py   | 15 +++++----------
scripts/discover.py | 15 +++++----------
scripts/install.py  | 15 +++++----------
scripts/session.py  | 15 +++++----------
scripts/_version.py | new, 18 lines
```

Net: same total LoC, but single source of truth + 4 lines fewer imports across consumers.

## TRN-1008 phase notes

- §1 rocket-gate **bypassed** — user-directed pick ("pick #77" in chat), per §1 normative bypass clause.
- §1.5 comprehension check: PROCEED (issue body has clear scope, AC, expected outcome, repro plan).
- §4 plan-review (fast-review tier) **skipped** — mechanical DRY with grep-checkable AC, no behavior/schema/public-surface change. Matches TRN-1008 "When NOT to Use" intent.
- §8 codex-bot review on this PR will be the primary review gate.

## Acceptance criteria (from issue #77)

- [x] `scripts/_version.py` exists with a single version-loading function
- [x] All 5 listed scripts import from `_version`; `grep -rn '_load_version\b' scripts/` returns no matches
- [x] `pytest tests/` is green — 371 passed in 30.38s
- [x] `ruff check` + `ruff format --check` clean
- [x] `make verify-built` clean — `build_providers --check: OK`
- [x] `af validate --root .` clean — 145 documents checked, 0 issues
- [x] CHANGELOG `[Unreleased] ### Changed` entry added

## Smoke test

```bash
$ python3 scripts/session.py --version
3.2.0
$ python3 scripts/config.py --version
3.2.0
$ python3 scripts/discover.py --version
3.2.0
$ python3 scripts/install.py --version
3.2.0
$ python3 scripts/codex.py --version
3.2.0
```

## Test plan

- [x] `pytest tests/` — 371 passed
- [x] `ruff check + ruff format --check` — clean
- [x] `make verify-built` — OK
- [x] `af validate` — clean
- [x] Manual `--version` smoke on all 5 scripts
- [ ] codex-bot review pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)