### PR TITLE
feat(TRN-2018 M1): live review metadata + incremental logs + status refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## [Unreleased]
 
 ### Added
+- TRN-2018 M1 — review status observability. `trinity status` now renders a
+  live `Live state:` section when reading M1 metadata, showing each provider
+  in `queued` / `running` / `finished` / `failed` / `timed_out` state with
+  `pid`, `rc`, and elapsed seconds (when set). Pre-M1 metadata still renders
+  via the legacy `Providers:` section unchanged. `metadata.json` is now
+  written by `init_metadata` before `run_providers` and updated atomically
+  via `_review_metadata.update_provider_state` as each provider transitions
+  through its lifecycle, so observers no longer have to wait for the entire
+  review to finish to see state.
+- Incremental `logs/<provider>.std{out,err}.log` files written during
+  `trinity review`. Stdout/stderr stream to line-buffered file handles
+  while the provider runs; the existing `raw/<provider>.txt` artifact is
+  composed from these logs after completion and preserves the
+  `_STDERR_SENTINEL` boundary contract (TRN-3022 coupling).
 - `trinity session-path <provider>[:<instance>]` — resolve absolute JSONL
   transcript path for a Trinity session. Unblocks token-efficiency audits
   and replay debugging. Closes #108.
@@ -16,6 +30,19 @@
   rationale and surfaces.
 
 ### Changed
+- TRN-2018 M1 — `trinity status` (and `trinity status --latest`) behavior
+  change: missing or empty `.trinity/reviews/` directory now exits **0**
+  with `no reviews found` on **stdout** (was: exit 1 with
+  `no reviews dir at <path>` / `no reviews under <path>` on stderr). Per
+  CHG-2018 §Status Command contract.
+- TRN-2018 M1 — `make_review_dir` (scripts/codex.py:1261) now creates
+  `logs/` alongside `raw/` when constructing the review directory.
+- TRN-2018 M1 — interrupted reviews (`KeyboardInterrupt` / `ReviewInterrupted`)
+  now leave both `metadata.json` (init-time state with `status=running` and
+  `provider_states` for each selected provider) and `incomplete.json`
+  (cleanup status). Previously: interrupted reviews left only `incomplete.json`.
+  `_print_review_summary` continues to surface `incomplete.json`'s status as
+  the top-level verdict, so this change is internal to the artifact layout.
 - `scripts/_version.py` — new shared module exposing `load_version()`. The
   identical inlined `_load_version()` helper that lived in `scripts/session.py`,
   `scripts/config.py`, `scripts/discover.py`, `scripts/install.py`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@
   through its lifecycle, so observers no longer have to wait for the entire
   review to finish to see state.
 - Incremental `logs/<provider>.std{out,err}.log` files written during
-  `trinity review`. Stdout/stderr stream to line-buffered file handles
-  while the provider runs; the existing `raw/<provider>.txt` artifact is
-  composed from these logs after completion and preserves the
-  `_STDERR_SENTINEL` boundary contract (TRN-3022 coupling).
+  `trinity review`. Stdout streams through a PTY-backed reader so
+  line-buffered child processes flush progress before exit; stderr streams
+  to its own log file. The existing `raw/<provider>.txt` artifact is composed
+  from these logs after completion and preserves the `_STDERR_SENTINEL`
+  boundary contract (TRN-3022 coupling).
 - `trinity session-path <provider>[:<instance>]` — resolve absolute JSONL
   transcript path for a Trinity session. Unblocks token-efficiency audits
   and replay debugging. Closes #108.

--- a/README.md
+++ b/README.md
@@ -341,7 +341,8 @@ Latest review: .trinity/reviews/20260516-120000-rules  (started 2m ago)
 ```
 
 Provider stdout/stderr stream to `.trinity/reviews/<id>/logs/<provider>.std{out,err}.log`
-while the review runs — `tail -f` works on those files for live progress. The
+while the review runs — `tail -f` works on those files for live progress. Stdout
+uses a PTY-backed reader so line-buffered CLIs flush progress before exit. The
 post-completion `raw/<provider>.txt` is composed from the same logs and remains
 backward-compatible. If no reviews exist, `trinity status` exits 0 with `no
 reviews found`.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,39 @@ providers emit a fenced JSON block (`decision`, `weighted_score`, `blocking`,
 with per-provider scores and a Findings section. Providers that don't emit
 the block continue to work via legacy returncode-based rendering. (#39)
 
+### Check review status
+
+```bash
+trinity status              # newest review (default; --latest is reserved for forward-compat)
+trinity status --latest     # explicit; same as bare `trinity status` today
+```
+
+`trinity status` summarises the most recent review under `.trinity/reviews/`.
+With TRN-2018 M1, it shows a **Live state** section for in-progress reviews —
+each provider with its current state (`queued`/`running`/`finished`/`failed`/
+`timed_out`), pid when running, return code when terminal, and elapsed time:
+
+```text
+Latest review: .trinity/reviews/20260516-120000-rules  (started 2m ago)
+  Scope: rules/   Mode: working-tree   Preset: fast-review
+
+  Live state:
+    glm        running  pid=12345  elapsed 2m 03s
+    deepseek   queued
+
+  Providers:
+    (no results in metadata)
+
+  Synthesis: missing
+  Status: running
+```
+
+Provider stdout/stderr stream to `.trinity/reviews/<id>/logs/<provider>.std{out,err}.log`
+while the review runs — `tail -f` works on those files for live progress. The
+post-completion `raw/<provider>.txt` is composed from the same logs and remains
+backward-compatible. If no reviews exist, `trinity status` exits 0 with `no
+reviews found`.
+
 ### Update a PR after review fixes
 
 ```bash

--- a/rules/TRN-2018-CHG-Review-Status-Observability.md
+++ b/rules/TRN-2018-CHG-Review-Status-Observability.md
@@ -1,0 +1,438 @@
+# CHG-2018: Review Status Observability
+
+**Applies to:** Trinity project (`frankyxhl/trinity`)
+**Last updated:** 2026-05-16
+**Last reviewed:** 2026-05-16
+**Status:** Approved
+**Date:** 2026-05-05
+**Requested by:** Frank
+**Implementer:** Codex
+**Priority:** High
+**Change Type:** Normal
+**Related:** TRN-2011, TRN-2013, TRN-2014, TRN-2015
+
+---
+
+## What
+
+Improve Codex-native `trinity review` observability so long-running provider
+reviews are inspectable while they run instead of appearing as one opaque
+blocking process.
+
+Target user-facing capabilities:
+
+```bash
+trinity status --latest
+trinity status --latest --watch
+trinity review --detach --preset fast-review --scope .
+trinity wait <review-id> --timeout 60
+```
+
+The minimal useful version is intentionally smaller:
+
+1. Live `metadata.json` updates while `trinity review` is running.
+2. `trinity status --latest` for the newest review directory.
+3. Provider stdout/stderr files written incrementally as soon as a provider
+   starts.
+
+---
+
+## Why
+
+Today `trinity review` blocks until every provider finishes. When a provider is
+slow or silent, Codex has to infer health by inspecting processes, review
+directories, raw files, and timeout values manually. This makes progress updates
+less reliable and makes it harder to distinguish:
+
+- a slow but healthy model,
+- a provider waiting on auth or permission handling,
+- a hung CLI,
+- a provider that has already timed out,
+- and a review that finished but has not yet been summarized.
+
+First-class status data lets Codex and humans answer "what is still running?"
+without guessing.
+
+---
+
+## Requirements
+
+### Live Review Metadata
+
+Write `metadata.json` when the review directory is created and update it as
+providers move through lifecycle states.
+
+Required top-level fields:
+
+- `review_id`
+- `review_dir`
+- `status`: `queued`, `running`, `finished`, `failed`, `timed_out`, `stalled`
+- `scope`
+- `root`
+- `started_at`
+- `finished_at`
+- `providers`: existing backward-compatible list of provider names, unchanged
+  from current metadata shape
+- `provider_states`: object keyed by provider name, containing live state
+- `input`
+- `preset`
+- `results`
+
+Backward compatibility requirement: this CHG must not remove or reshape current
+top-level metadata keys. Existing `providers` remains a list. Rich provider
+state goes under the new `provider_states` key.
+
+Top-level timestamp and status semantics:
+
+- `started_at` is set when `metadata.json` is first written, before any provider
+  starts.
+- `finished_at` is `null` until all selected providers reach a terminal state
+  and `synthesis.md` has been written.
+- `results` is initialized as `[]` and appended to after each provider reaches a
+  terminal state.
+- top-level `status` is `running` while any provider is queued/running/stalled,
+  and becomes `finished` when every provider is `finished`; it becomes `failed`
+  or `timed_out` if any provider reaches that terminal state.
+
+Provider state should include:
+
+- provider name
+- status: `queued`, `running`, `finished`, `failed`, `timed_out`, `stalled`
+- pid when known
+- started / finished timestamps
+- elapsed seconds
+- timeout seconds
+- timeout deadline
+- heartbeat timestamp
+- stdout/stderr paths
+- raw output path
+- return code when finished
+
+### Incremental Provider Logs
+
+Create provider-specific files under `logs/` as soon as each provider starts:
+
+```text
+logs/glm.stdout.log
+logs/glm.stderr.log
+logs/deepseek.stdout.log
+logs/deepseek.stderr.log
+```
+
+The existing `raw/<provider>.txt` compatibility artifact should still be written
+after the provider finishes. Its format must remain compatible with the current
+implementation: stdout first, followed by `\n[stderr]\n` and stderr only when
+stderr is non-empty.
+
+### Status Command
+
+Add:
+
+```bash
+trinity status --latest
+```
+
+It should find the newest review under the configured review output directory
+and print a concise status summary:
+
+```text
+review 20260505-181600-. running
+deepseek running 02:31/10:00 pid=40179 last_output=18:15:20
+glm queued
+```
+
+`--watch` is a later-phase enhancement unless it falls out naturally from the
+same implementation with low complexity.
+
+The `review_id` is the review directory basename created by `make_review_dir()`,
+including any collision suffix, for example `20260505-181600-.` or
+`20260505-181600-.-2`. `review_dir` is the absolute review directory path.
+Provider `stdout_path`, `stderr_path`, and `raw` paths are relative to
+`review_dir`, matching the current `results[].raw` convention. `trinity status
+--latest` finds the newest review directory under the configured
+`review.output_dir` by directory modified time, then reads its `metadata.json`.
+If no review directories exist, it exits 0 and prints `no reviews found`.
+
+`last_output` in status output is derived from the newest stdout/stderr log file
+modified time for that provider. Timestamps should use Trinity's existing local
+ISO seconds format unless a later CHG standardizes timezone-aware timestamps.
+
+### Events
+
+Append machine-readable lifecycle events to `events.jsonl`:
+
+```json
+{"event":"provider_started","provider":"deepseek","pid":40179}
+{"event":"provider_heartbeat","provider":"deepseek","elapsed_seconds":120}
+{"event":"provider_finished","provider":"deepseek","status":"finished"}
+```
+
+Events are useful for polling scripts and debugging but should not become the
+only source of truth; `metadata.json` remains the current-state snapshot. A
+crash between appending an event and updating metadata may create divergence;
+status commands should trust `metadata.json` for current state and treat
+`events.jsonl` as audit history.
+
+### Stalled Detection
+
+If a provider produces no output and no heartbeat for a configured duration,
+mark it `stalled`.
+
+Milestone 2 introduces `review.stall_threshold_seconds`, defaulting to `60`.
+Milestone 4 may add CLI/operator tuning, but Milestone 2 must have a documented
+default and config key before stalled detection ships.
+
+Do not kill stalled providers by default. Killing requires an explicit future
+flag such as:
+
+```bash
+trinity review --fail-on-stall
+```
+
+In the current sequential execution model, only one provider is `running` at a
+time; later providers remain `queued`. This still improves observability for the
+active provider and makes timeout/stall diagnosis explicit. Provider parallelism
+is not part of this CHG.
+
+`stalled` is a transient provider state. If new stdout/stderr output appears
+before timeout, the provider transitions back to `running`; otherwise it
+eventually transitions to `timed_out`.
+
+---
+
+## Milestones
+
+### Milestone 1: Minimal Observability
+
+Goal: eliminate most manual process/file guessing while keeping review execution
+blocking and sequential as it is today.
+
+Scope:
+
+1. Create `metadata.json` before provider execution.
+2. Update provider states before start and after completion.
+3. Stream stdout/stderr to provider log files during execution.
+4. Preserve `raw/<provider>.txt` and `synthesis.md` compatibility.
+5. Add `trinity status --latest`.
+6. Add tests for live metadata shape, provider log files, status output, and
+   backward-compatible raw/synthesis artifacts.
+7. Add a backward-compatibility test asserting current consumers still see:
+   - `providers` as a list,
+   - `preset`,
+   - `input`,
+   - `results`,
+   - result entries with `provider`, `returncode`, `raw`, `started_at`, and
+     `finished_at`.
+
+Non-goals:
+
+- No detach mode.
+- No background process management.
+- No provider parallelism change.
+- No automatic kill-on-stall.
+
+Implementation note: create `logs/` in `make_review_dir()` alongside the
+existing `raw/` directory, so status readers can rely on stable artifact
+locations from the start of the review.
+
+### Milestone 2: Events and Stalled Signals
+
+Goal: make polling and stuck-provider diagnosis robust.
+
+Scope:
+
+1. Add `events.jsonl`.
+2. Add heartbeat updates while provider processes run.
+3. Detect stale output/heartbeat age and mark providers `stalled`.
+4. Add status output for `stalled`, `timed_out`, and `failed` providers.
+5. Add tests using fake provider scripts that sleep, emit partial output, hang,
+   and exceed timeout.
+6. Add `review.stall_threshold_seconds` config with default `60`.
+
+Non-goals:
+
+- Still no detached process orchestration.
+- Stalled state is informational only.
+
+Heartbeat mechanism: use a main-thread polling loop around `Popen.poll()` that
+periodically updates metadata and checks stdout/stderr log file modified times.
+Default polling interval is 2 seconds. Heartbeat updates and stall checks share
+that polling cycle. No watcher threads or daemon process in this milestone.
+
+### Milestone 3: Detached Execution and Wait
+
+Goal: let Codex launch a review, regain control, then poll or wait explicitly.
+
+Scope:
+
+1. Add `trinity review --detach`.
+2. Add `trinity wait <review-id> --timeout <seconds>`.
+3. Add `trinity status --latest --watch`.
+4. Record parent/child process metadata needed for detached review tracking.
+5. Add tests for detached review lifecycle with fake provider scripts.
+
+Non-goals:
+
+- No daemon.
+- No cross-machine status storage.
+- No provider cancellation UI unless explicitly added later.
+
+### Milestone 4: Cleanup and Operator Controls
+
+Goal: complete operational ergonomics after the main observability path is
+stable.
+
+Scope:
+
+1. Add optional `--fail-on-stall`.
+2. Add CLI/operator override for stall threshold if config-only tuning is not
+   enough.
+3. Add cleanup guidance for old review directories.
+4. Consider `trinity status <review-id>` if `--latest` is insufficient.
+
+---
+
+## Phased Implementation Plan
+
+### Phase 0: CHG Review and Scope Lock
+
+1. Review this CHG with `trinity review --preset fast-review`.
+2. Decide whether Milestone 1 should include `events.jsonl`; default answer is
+   no unless reviewers find it cheap and low risk.
+   Events are deferred by default because Milestone 1 should validate the
+   metadata state model independently before introducing a second append-only
+   write path.
+3. Confirm no schema compatibility promises beyond local Trinity artifacts.
+
+### Phase 1: Metadata State Model
+
+1. RED: add tests for initial `metadata.json` written before provider execution.
+2. RED: add tests for provider state transitions: queued -> running ->
+   finished/failed/timed_out.
+3. GREEN: add helper functions for review id, metadata loading/writing, and
+   atomic metadata updates.
+4. REFACTOR: keep metadata helpers independent from provider CLI execution.
+
+Atomic metadata update mechanism: write JSON to a temporary file in the same
+review directory, flush it, then replace `metadata.json` with `os.replace()`.
+Milestone 1 does not need file locking because provider execution remains
+sequential in one process. Later status readers in Milestone 3 will see either
+the old complete metadata file or the new complete metadata file, never a
+partial write.
+
+### Phase 2: Incremental Logs
+
+1. RED: add fake provider tests proving stdout/stderr files exist while or
+   immediately after provider execution starts.
+2. GREEN: change provider execution from `subprocess.run(..., stdout=PIPE,
+   stderr=PIPE)` to `subprocess.Popen` with stdout/stderr file handles.
+   Open log files with line buffering, for example `open(path, "w",
+   buffering=1)`, and flush handles in the polling loop so small provider
+   output appears on disk promptly.
+3. GREEN: compose legacy `raw/<provider>.txt` from the stdout/stderr logs after
+   completion.
+4. Implement timeout manually with `Popen.wait(timeout=...)`; on timeout, kill
+   the child, mark provider `timed_out`, write return code `124`, and preserve
+   any partial stdout/stderr logs.
+   - Send `terminate()` first.
+   - If the process does not exit within 5 seconds, send `kill()`.
+   - After the process exits or is killed, close stdout/stderr file handles
+     before composing `raw/<provider>.txt`.
+5. Preserve current failure semantics for missing commands (`127`) and normal
+   non-zero return codes. If `Popen()` raises `FileNotFoundError`, create empty
+   stdout/stderr log files, write the existing command-not-found message to
+   `raw/<provider>.txt`, and record return code `127`.
+6. Verify timeout behavior still writes the expected raw output and metadata.
+
+### Phase 3: `trinity status --latest`
+
+1. RED: add tests for finding the newest review directory under the configured
+   output path.
+2. RED: add tests for rendering running, queued, finished, failed, and timed-out
+   provider states from `metadata.json`.
+3. GREEN: add `status` subcommand with `--latest` in `build_parser()`.
+4. GREEN: keep output human-readable and intentionally compact.
+
+### Phase 4: Documentation and Install Smoke
+
+1. Update README and Codex skill docs with the new status workflow.
+2. Add changelog entry.
+3. Run `make install-codex`.
+4. Verify `trinity status --latest` against a fake or low-risk review.
+
+---
+
+## Impact Analysis
+
+- **Systems affected:** `scripts/codex.py`, `bin/trinity` behavior through the
+  installed script, Codex adapter docs, README, tests, and review artifact
+  layout under `.trinity/reviews/`.
+- **Systems intentionally preserved:** existing `trinity review --providers`,
+  `--preset`, `--base/--head`, `--pr`, provider preflight, prompt rendering,
+  raw provider output under `raw/`, and deterministic `synthesis.md`.
+- **Downtime required:** No.
+- **Backward compatibility:** Existing consumers of `raw/<provider>.txt`,
+  `prompt.md`, `metadata.json`, and `synthesis.md` should continue to work.
+  `metadata.json` may gain fields but should not remove current top-level keys
+  without a separate breaking-change CHG.
+- **Main risks:** corrupt live metadata if a process exits mid-write, misleading
+  status if timestamps are stale, leaking provider stderr details into
+  user-facing output, and increasing complexity around timeouts.
+- **Rollback plan:** revert status subcommand, live metadata helpers,
+  incremental log writing, docs, and tests. Blocking `trinity review` can return
+  to writing metadata only after all providers complete.
+
+---
+
+## Testing / Verification
+
+Expected Milestone 1 evidence:
+
+- `.venv/bin/pytest tests/test_codex_adapter.py -q`
+- targeted fake-provider tests for:
+  - live metadata initialization,
+  - pre-execution metadata is valid JSON and has all providers queued,
+  - running/finished/failed/timed_out states,
+  - stdout/stderr log creation,
+  - `providers` remains a list and `provider_states` contains rich state,
+  - existing `scope`, `root`, `preset`, `input`, and `results` keys remain
+    present,
+  - legacy `raw/<provider>.txt` preservation,
+  - `trinity status --latest` rendering.
+- `make test`
+- `make lint`
+- `af validate --root .`
+- `make install-codex`
+- `trinity review --preset fast-review --scope <small-safe-scope>`
+- `trinity status --latest`
+
+---
+
+## Approval
+
+- [x] Approved for implementation (Milestone 1 scope; M2-M4 deferred)
+- [ ] Implemented
+- [ ] Verified locally
+- [ ] PR opened
+
+---
+
+## Execution Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-05-05 | Created CHG from business requirement in `tmp/trinity-review-status-improvements.md` | Proposed |
+| 2026-05-05 | Reviewed with Trinity fast-review | GLM/DeepSeek requested schema precision, backward compatibility tests, log path, raw format, atomic writes, Popen timeout detail, and sequential-execution caveat |
+| 2026-05-05 | Re-reviewed with Trinity fast-review | GLM/DeepSeek requested final clarifications for stall threshold, timestamp semantics, transient stalled state, log buffering, results lifecycle, and no-review status behavior |
+| 2026-05-16 | Approved for M1 implementation; M2-M4 deferred. Phase C execution plan v2 cleared trinity fast-review (glm 9.58 / deepseek 9.50, both PASS, ≥9.5 strict gate) | Frank + Claude |
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-05 | Initial CHG with milestone and phase split | Codex |
+| 2026-05-05 | Revised after Trinity fast-review findings | Codex |
+| 2026-05-05 | Revised after second Trinity fast-review findings | Codex |
+| 2026-05-16 | Status: Proposed → Approved (M1 scope); recorded fast-review v2 plan PASS in Execution Log | Claude Opus 4.7 |

--- a/rules/TRN-2018-CHG-Review-Status-Observability.md
+++ b/rules/TRN-2018-CHG-Review-Status-Observability.md
@@ -325,10 +325,10 @@ partial write.
 1. RED: add fake provider tests proving stdout/stderr files exist while or
    immediately after provider execution starts.
 2. GREEN: change provider execution from `subprocess.run(..., stdout=PIPE,
-   stderr=PIPE)` to `subprocess.Popen` with stdout/stderr file handles.
-   Open log files with line buffering, for example `open(path, "w",
-   buffering=1)`, and flush handles in the polling loop so small provider
-   output appears on disk promptly.
+   stderr=PIPE)` to `subprocess.Popen` with live log sinks. Route stdout
+   through a PTY-backed reader into `logs/<provider>.stdout.log` so child
+   processes that line-buffer on `isatty()` flush progress before exit; route
+   stderr to `logs/<provider>.stderr.log` with line-buffered file handles.
 3. GREEN: compose legacy `raw/<provider>.txt` from the stdout/stderr logs after
    completion.
 4. Implement timeout manually with `Popen.wait(timeout=...)`; on timeout, kill
@@ -336,8 +336,8 @@ partial write.
    any partial stdout/stderr logs.
    - Send `terminate()` first.
    - If the process does not exit within 5 seconds, send `kill()`.
-   - After the process exits or is killed, close stdout/stderr file handles
-     before composing `raw/<provider>.txt`.
+   - After the process exits or is killed, close stdout/stderr sinks before
+     composing `raw/<provider>.txt`.
 5. Preserve current failure semantics for missing commands (`127`) and normal
    non-zero return codes. If `Popen()` raises `FileNotFoundError`, create empty
    stdout/stderr log files, write the existing command-not-found message to

--- a/scripts/_review_metadata.py
+++ b/scripts/_review_metadata.py
@@ -144,6 +144,31 @@ def update_provider_state(review_dir: Path, provider: str, **fields) -> None:
         _write_atomic(review_dir, data)
 
 
+def append_result(review_dir: Path, result: dict) -> None:
+    """Append one provider result entry to metadata["results"] under lock.
+
+    Called by run_provider on each terminal return path so status readers
+    can discover completed providers' artifacts (raw path, returncode,
+    timestamps) without waiting for the full review to finalize. This is
+    important for parallel reviews where one provider may finish minutes
+    before another.
+
+    finalize_metadata later overwrites results with the ordered list from
+    run_providers, so duplicate appends are not a concern — final state is
+    canonical regardless.
+
+    Defensive: silently no-op if metadata.json doesn't exist (mirrors
+    update_provider_state for unit-test ergonomics).
+    """
+    with _lock_for(review_dir):
+        try:
+            data = read_metadata(review_dir)
+        except FileNotFoundError:
+            return
+        data.setdefault("results", []).append(result)
+        _write_atomic(review_dir, data)
+
+
 def finalize_metadata(review_dir: Path, results: list[dict]) -> None:
     """Set finished_at + results + recompute top-level status.
 

--- a/scripts/_review_metadata.py
+++ b/scripts/_review_metadata.py
@@ -155,10 +155,7 @@ def finalize_metadata(review_dir: Path, results: list[dict]) -> None:
         data = read_metadata(review_dir)
         data["finished_at"] = _now_iso()
         data["results"] = list(results)
-        terminal = [
-            s.get("status")
-            for s in data.get("provider_states", {}).values()
-        ]
+        terminal = [s.get("status") for s in data.get("provider_states", {}).values()]
         if "failed" in terminal:
             data["status"] = "failed"
         elif "timed_out" in terminal:

--- a/scripts/_review_metadata.py
+++ b/scripts/_review_metadata.py
@@ -95,6 +95,7 @@ def init_metadata(
     scope: str,
     root: str,
     input: dict,
+    strict_review: dict | None = None,
 ) -> None:
     """Write the initial metadata.json before any provider executes.
 
@@ -103,6 +104,11 @@ def init_metadata(
     test_codex_adapter, downstream consumers) see no missing keys; M1
     additions (review_id, review_dir, status, started_at, finished_at,
     provider_states) are additive.
+
+    `strict_review` (codex R5 P2 fix): when present, merged into the
+    initial atomic write so callers don't need a follow-up write_text
+    that would race against status readers. finalize_metadata reads +
+    mutates only finished_at/results/status, preserving strict_review.
     """
     data = {
         "review_id": review_id,
@@ -118,6 +124,8 @@ def init_metadata(
         "results": [],
         "provider_states": {p: {"status": "queued"} for p in providers},
     }
+    if strict_review is not None:
+        data["strict_review"] = strict_review
     with _lock_for(review_dir):
         _write_atomic(review_dir, data)
 

--- a/scripts/_review_metadata.py
+++ b/scripts/_review_metadata.py
@@ -1,0 +1,168 @@
+"""TRN-2018 M1: live review metadata helpers.
+
+Owns atomic read/write of `<review_dir>/metadata.json` plus per-review-dir
+locking. `run_providers` (scripts/codex.py:1802) uses
+`ThreadPoolExecutor(max_workers)` so per-provider state updates execute
+in parallel; without locking, the read-modify-write pattern in
+`update_provider_state` would race and silently drop concurrent updates.
+
+Public surface:
+- init_metadata(review_dir, *, review_id, review_dir_str, providers,
+                preset, scope, root, input) -> None
+- update_provider_state(review_dir, provider, **fields) -> None
+- finalize_metadata(review_dir, results) -> None
+- read_metadata(review_dir) -> dict   (single 100ms retry on JSONDecodeError)
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+_locks: dict[str, threading.Lock] = {}
+_locks_guard = threading.Lock()
+
+
+def _lock_for(review_dir: Path) -> threading.Lock:
+    key = str(review_dir)
+    with _locks_guard:
+        lock = _locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _locks[key] = lock
+        return lock
+
+
+def _now_iso() -> str:
+    return dt.datetime.now().isoformat(timespec="seconds")
+
+
+def _metadata_path(review_dir: Path) -> Path:
+    return review_dir / "metadata.json"
+
+
+def read_metadata(review_dir: Path) -> dict:
+    """Read metadata.json, retrying once after 100ms on JSONDecodeError.
+
+    The retry guards against a status reader catching an atomic mid-write
+    on filesystems where a brief inconsistency is observable. After the
+    single retry, decode errors propagate.
+    """
+    path = _metadata_path(review_dir)
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError:
+        time.sleep(0.1)
+        return json.loads(path.read_text())
+
+
+def _write_atomic(review_dir: Path, data: dict) -> None:
+    """Atomic write via tempfile + os.replace().
+
+    Caller must hold _lock_for(review_dir).
+    """
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".metadata.", suffix=".json.tmp", dir=str(review_dir)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, _metadata_path(review_dir))
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+
+
+def init_metadata(
+    review_dir: Path,
+    *,
+    review_id: str,
+    review_dir_str: str,
+    providers: list[str],
+    preset,
+    scope: str,
+    root: str,
+    input: dict,
+) -> None:
+    """Write the initial metadata.json before any provider executes.
+
+    Top-level shape preserves all keys currently written post-completion
+    by cmd_review (codex.py:2254-2261) so existing readers (status,
+    test_codex_adapter, downstream consumers) see no missing keys; M1
+    additions (review_id, review_dir, status, started_at, finished_at,
+    provider_states) are additive.
+    """
+    data = {
+        "review_id": review_id,
+        "review_dir": review_dir_str,
+        "status": "running",
+        "started_at": _now_iso(),
+        "finished_at": None,
+        "scope": scope,
+        "root": root,
+        "providers": list(providers),
+        "preset": preset,
+        "input": input,
+        "results": [],
+        "provider_states": {p: {"status": "queued"} for p in providers},
+    }
+    with _lock_for(review_dir):
+        _write_atomic(review_dir, data)
+
+
+def update_provider_state(review_dir: Path, provider: str, **fields) -> None:
+    """Read-modify-write for one provider's state entry under lock.
+
+    Used by run_provider's transition points (queued→running on Popen
+    start; running→finished/failed/timed_out on each return path in
+    scripts/codex.py L1732/1745/1769).
+
+    Defensive: silently no-op if metadata.json doesn't exist. The
+    production flow always calls init_metadata first, but unit tests
+    that exercise run_provider in isolation (test_provider_env.py)
+    bypass init.
+    """
+    with _lock_for(review_dir):
+        try:
+            data = read_metadata(review_dir)
+        except FileNotFoundError:
+            return
+        state = data.setdefault("provider_states", {}).setdefault(provider, {})
+        state.update(fields)
+        _write_atomic(review_dir, data)
+
+
+def finalize_metadata(review_dir: Path, results: list[dict]) -> None:
+    """Set finished_at + results + recompute top-level status.
+
+    Status precedence: failed > timed_out > finished. Any 'failed' provider
+    flips top-level to 'failed'; otherwise any 'timed_out' makes it
+    'timed_out'; otherwise 'finished'.
+    """
+    with _lock_for(review_dir):
+        data = read_metadata(review_dir)
+        data["finished_at"] = _now_iso()
+        data["results"] = list(results)
+        terminal = [
+            s.get("status")
+            for s in data.get("provider_states", {}).values()
+        ]
+        if "failed" in terminal:
+            data["status"] = "failed"
+        elif "timed_out" in terminal:
+            data["status"] = "timed_out"
+        else:
+            data["status"] = "finished"
+        _write_atomic(review_dir, data)

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -2379,12 +2379,20 @@ def cmd_review(args):
             review_dir,
             root,
         )
-        progress("writing metadata")
-        _rm.finalize_metadata(review_dir, results)
+        # TRN-2018 R7 fix (codex R6 P2): per CHG L88-89, top-level
+        # `finished_at` stays null until synthesis.md is written.
+        # finalize_metadata must run AFTER write_synthesis succeeds so
+        # a concurrent `trinity status` poll never observes
+        # status=finished while synthesis.md is missing. If
+        # write_synthesis raises, finalize is skipped; the exception
+        # handler writes incomplete.json and metadata.json stays in
+        # `status=running` for the partial review.
         progress("writing synthesis")
         summary, synthesis_path = write_synthesis(
             review_dir, args.scope, results, strict_review=strict_review
         )
+        progress("writing metadata")
+        _rm.finalize_metadata(review_dir, results)
         # TRN-3028: emit the completion line directly to stderr without the
         # `trinity: ` progress prefix so callers can key off the documented
         # "trinity review: <verdict> — ..." prefix at the START of the line.

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -5,10 +5,12 @@ import argparse
 import concurrent.futures
 import datetime as dt
 import difflib
+import errno
 import fnmatch
 import json
 import math
 import os
+import pty
 from pathlib import Path
 import re
 import shlex
@@ -18,6 +20,7 @@ import subprocess
 import sys
 import threading
 import time
+import tty
 
 try:
     from ._version import load_version
@@ -1431,6 +1434,36 @@ def timeout_partial_output(exc, stdout=None, stderr=None):
     )
 
 
+def _set_raw_pty(fd):
+    """Disable PTY newline translation while keeping child stdout as a TTY."""
+    try:
+        tty.setraw(fd)
+    except OSError:
+        pass
+
+
+def _copy_pty_to_file(master_fd, output_path, errors):
+    try:
+        with open(output_path, "ab", buffering=0) as out:
+            while True:
+                try:
+                    chunk = os.read(master_fd, 4096)
+                except OSError as exc:
+                    if exc.errno == errno.EIO:
+                        break
+                    raise
+                if not chunk:
+                    break
+                out.write(chunk)
+    except Exception as exc:
+        errors.append(exc)
+    finally:
+        try:
+            os.close(master_fd)
+        except OSError:
+            pass
+
+
 _UNIVERSAL_ENV_KEEP_LITERAL = frozenset(
     {
         "PATH",
@@ -1702,22 +1735,10 @@ def _review_schema_addendum(task_type, strict_review=None):
 
 
 def run_provider(provider, provider_config, prompt_path, review_dir, root, registry):
-    # TRN-2018 M1: stdout/stderr stream to logs/<p>.std{out,err}.log via
-    # line-buffered file handles so `trinity status` and external watchers
-    # can read partial output while the provider runs. raw/<p>.txt is
-    # composed from the (closed) log files after completion for backward
-    # compat with downstream consumers.
-    #
-    # KNOWN M1 LIMITATION (codex R4 P2 advisory):
-    # `buffering=1` only affects the parent file object. Child processes
-    # that block-buffer stdout when not connected to a TTY (typical for
-    # Python/Node wrappers without explicit flush) won't actually emit
-    # to disk until they exit or fill their buffer — so live log
-    # visibility for those providers is best-effort. PTY-based or
-    # stdbuf/unbuffer strategies are deferred to M2 (CHG-2018 milestone 2
-    # ships heartbeat polling + stall detection where this matters most).
-    # Shell-style providers (the fake fixtures + most CLI tools that
-    # write small lines) work as intended on M1.
+    # TRN-2018 M1: stdout streams through a PTY into logs/<p>.stdout.log so
+    # child processes that line-buffer on isatty() emit live output instead of
+    # block-buffering until exit. stderr still streams to its own log file.
+    # raw/<p>.txt is composed from closed logs for backward compatibility.
     raw_path = review_dir / "raw" / f"{provider}.txt"
     # Defensive: production cmd_review path creates logs/ via make_review_dir,
     # but unit tests that build review_dir manually may skip it.
@@ -1736,20 +1757,36 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
     progress(f"starting provider {provider} timeout={timeout}s")
     popen = None
     outcome = None  # tuple describing terminal state; consumed below for raw compose
-    with (
-        open(stdout_path, "w", buffering=1, encoding="utf-8") as fout,
-        open(stderr_path, "w", buffering=1, encoding="utf-8") as ferr,
-    ):
+    stdout_path.write_bytes(b"")
+    stdout_master_fd = None
+    stdout_slave_fd = None
+    stdout_thread = None
+    stdout_reader_errors = []
+    try:
+        stdout_master_fd, stdout_slave_fd = pty.openpty()
+        _set_raw_pty(stdout_slave_fd)
+    except OSError as exc:
+        raise RuntimeError(f"failed to create PTY for provider stdout: {exc}") from exc
+    with open(stderr_path, "w", buffering=1, encoding="utf-8") as ferr:
         try:
             popen = subprocess.Popen(
                 cmd,
                 cwd=str(root),
-                stdout=fout,
+                stdout=stdout_slave_fd,
                 stderr=ferr,
                 text=True,
                 start_new_session=True,
                 env=build_provider_env(),
             )
+            os.close(stdout_slave_fd)
+            stdout_slave_fd = None
+            stdout_thread = threading.Thread(
+                target=_copy_pty_to_file,
+                args=(stdout_master_fd, stdout_path, stdout_reader_errors),
+                daemon=True,
+            )
+            stdout_thread.start()
+            stdout_master_fd = None
             registry.add(provider, popen, started)
             _rm.update_provider_state(
                 review_dir,
@@ -1820,12 +1857,27 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
             raise
         finally:
             try:
-                fout.flush()
                 ferr.flush()
             except Exception:
                 pass
+            if stdout_slave_fd is not None:
+                try:
+                    os.close(stdout_slave_fd)
+                except OSError:
+                    pass
+            if stdout_master_fd is not None:
+                try:
+                    os.close(stdout_master_fd)
+                except OSError:
+                    pass
+            if stdout_thread is not None:
+                stdout_thread.join()
             if popen is not None:
                 registry.remove(provider, popen)
+    if stdout_reader_errors:
+        raise RuntimeError(
+            f"provider {provider} stdout reader failed: {stdout_reader_errors[0]}"
+        )
 
     # Log file handles are now closed; compose raw_path from disk content.
     # TRN-2018 R3 fix (codex R2 P2): append the result entry to metadata

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1751,14 +1751,19 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
             )
             popen.wait(timeout=timeout)
             finished = timestamp()
+            # TRN-2018 M1: derive terminal state from returncode. A clean
+            # exit with rc != 0 is `failed`, not `finished`. finalize_metadata's
+            # top-level status precedence (failed > timed_out > finished)
+            # then correctly surfaces `failed` for any provider with non-zero rc.
+            terminal_state = "finished" if popen.returncode == 0 else "failed"
             progress(
-                f"provider {provider} finished returncode={popen.returncode} "
+                f"provider {provider} {terminal_state} returncode={popen.returncode} "
                 f"elapsed={elapsed_seconds(started_monotonic)}s"
             )
             _rm.update_provider_state(
                 review_dir,
                 provider,
-                status="finished",
+                status=terminal_state,
                 returncode=popen.returncode,
                 finished_at=finished,
             )

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -2672,8 +2672,11 @@ def _print_review_summary(review_dir):
         # write_synthesis()) as a user interruption.
         overall = incomplete_status
     elif not results:
-        # Empty results list isn't "completed" — no providers ran.
-        overall = "unknown (no results)"
+        # TRN-2018 M1: when init_metadata has written the M1 top-level status
+        # field, prefer it (e.g. "running" mid-review) over "unknown (no
+        # results)". Pre-M1 metadata lacks the top-level status key.
+        m1_status = metadata.get("status")
+        overall = m1_status if m1_status else "unknown (no results)"
     elif any(r.get("returncode") != 0 for r in results):
         # Any non-success rc (non-zero OR missing — None != 0) → partial.
         # The visual marker for rc=None is ✗, so the overall status must

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1707,6 +1707,17 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
     # can read partial output while the provider runs. raw/<p>.txt is
     # composed from the (closed) log files after completion for backward
     # compat with downstream consumers.
+    #
+    # KNOWN M1 LIMITATION (codex R4 P2 advisory):
+    # `buffering=1` only affects the parent file object. Child processes
+    # that block-buffer stdout when not connected to a TTY (typical for
+    # Python/Node wrappers without explicit flush) won't actually emit
+    # to disk until they exit or fill their buffer — so live log
+    # visibility for those providers is best-effort. PTY-based or
+    # stdbuf/unbuffer strategies are deferred to M2 (CHG-2018 milestone 2
+    # ships heartbeat polling + stall detection where this matters most).
+    # Shell-style providers (the fake fixtures + most CLI tools that
+    # write small lines) work as intended on M1.
     raw_path = review_dir / "raw" / f"{provider}.txt"
     # Defensive: production cmd_review path creates logs/ via make_review_dir,
     # but unit tests that build review_dir manually may skip it.

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1814,8 +1814,12 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
     # Log file handles are now closed; compose raw_path from disk content.
     if outcome[0] == "finished":
         _, rc, finished = outcome
-        stdout_text = stdout_path.read_text(errors="replace") if stdout_path.exists() else ""
-        stderr_text = stderr_path.read_text(errors="replace") if stderr_path.exists() else ""
+        stdout_text = (
+            stdout_path.read_text(errors="replace") if stdout_path.exists() else ""
+        )
+        stderr_text = (
+            stderr_path.read_text(errors="replace") if stderr_path.exists() else ""
+        )
         raw_path.write_text(raw_output(stdout_text, stderr_text))
         return {
             "provider": provider,
@@ -1836,8 +1840,12 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
         }
     # timeout
     _, exc, timeout_val, finished = outcome
-    stdout_text = stdout_path.read_text(errors="replace") if stdout_path.exists() else ""
-    stderr_text = stderr_path.read_text(errors="replace") if stderr_path.exists() else ""
+    stdout_text = (
+        stdout_path.read_text(errors="replace") if stdout_path.exists() else ""
+    )
+    stderr_text = (
+        stderr_path.read_text(errors="replace") if stderr_path.exists() else ""
+    )
     partial = timeout_partial_output(exc, stdout_text, stderr_text)
     output = f"ERROR: timeout after {timeout_val}s\n{exc}\n"
     if partial:
@@ -2330,9 +2338,7 @@ def cmd_review(args):
             # threading it into metadata after init.
             data = _rm.read_metadata(review_dir)
             data["strict_review"] = {
-                key: value
-                for key, value in strict_review.items()
-                if key != "template"
+                key: value for key, value in strict_review.items() if key != "template"
             }
             (review_dir / "metadata.json").write_text(
                 json.dumps(data, indent=2, ensure_ascii=False) + "\n"
@@ -2351,9 +2357,7 @@ def cmd_review(args):
         if strict_review is not None:
             data = _rm.read_metadata(review_dir)
             data["strict_review"] = {
-                key: value
-                for key, value in strict_review.items()
-                if key != "template"
+                key: value for key, value in strict_review.items() if key != "template"
             }
             (review_dir / "metadata.json").write_text(
                 json.dumps(data, indent=2, ensure_ascii=False) + "\n"
@@ -2595,6 +2599,30 @@ def _print_review_summary(review_dir):
     print(f"Latest review: {review_dir}  (started {ago})")
     print(f"  Scope: {scope}   Mode: {mode}   Preset: {preset}")
     print()
+    # TRN-2018 M1: live provider_states section. Rendered when the metadata
+    # was written by init_metadata/update_provider_state (M1+ reviews).
+    # Pre-M1 metadata lacks this key; rendering falls through to the legacy
+    # `Providers:` section below.
+    provider_states = metadata.get("provider_states")
+    if provider_states:
+        print("  Live state:")
+        ls_name_width = max([10] + [len(p) for p in provider_states.keys()])
+        for prov, state in provider_states.items():
+            status_str = state.get("status", "?")
+            bits = [f"{prov:{ls_name_width}s}", status_str]
+            pid = state.get("pid")
+            if pid is not None:
+                bits.append(f"pid={pid}")
+            rc = state.get("returncode")
+            if rc is not None:
+                bits.append(f"rc={rc}")
+            ls_elapsed = _format_duration(
+                _format_elapsed(state.get("started_at"), state.get("finished_at"))
+            )
+            if ls_elapsed and ls_elapsed != "?":
+                bits.append(f"elapsed {ls_elapsed}")
+            print("    " + "  ".join(bits))
+        print()
     print("  Providers:")
     if not results:
         print("    (no results in metadata)")
@@ -2665,12 +2693,13 @@ def cmd_status(args):
     # `cmd_review` actually writes artifacts.
     root = resolve_health_root(args.root)
     reviews_dir = root / ".trinity" / "reviews"
+    # TRN-2018 M1 behavior change (per CHG L154): missing or empty reviews
+    # dir now exits 0 with `no reviews found` on stdout. Previous behavior:
+    # exit 1 with `no reviews dir at <path>` or `no reviews under <path>`
+    # on stderr. Flagged in CHANGELOG.
     if not reviews_dir.is_dir():
-        print(
-            f"trinity: no reviews dir at {reviews_dir}",
-            file=sys.stderr,
-        )
-        return 1
+        print("no reviews found")
+        return 0
 
     # Sort key: (timestamp_prefix, mtime). The fixed-width
     # %Y%m%d-%H%M%S prefix gives chronological order across distinct
@@ -2692,11 +2721,8 @@ def cmd_status(args):
         reverse=True,
     )
     if not candidates:
-        print(
-            f"trinity: no reviews under {reviews_dir}",
-            file=sys.stderr,
-        )
-        return 1
+        print("no reviews found")
+        return 0
     return _print_review_summary(candidates[0])
 
 

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -21,8 +21,10 @@ import time
 
 try:
     from ._version import load_version
+    from . import _review_metadata as _rm
 except ImportError:
     from _version import load_version
+    import _review_metadata as _rm
 
 
 DEFAULT_CONFIG = Path("~/.codex/trinity.json").expanduser()
@@ -1270,6 +1272,7 @@ def make_review_dir(out_dir, scope):
         except FileExistsError:
             continue
         (review_dir / "raw").mkdir()
+        (review_dir / "logs").mkdir()
         return review_dir
     raise SystemExit("trinity-codex: unable to create unique review directory")
 
@@ -1722,12 +1725,26 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
             env=build_provider_env(),
         )
         registry.add(provider, popen, started)
+        _rm.update_provider_state(
+            review_dir,
+            provider,
+            status="running",
+            pid=getattr(popen, "pid", None),
+            started_at=started,
+        )
         stdout, stderr = popen.communicate(timeout=timeout)
         raw_path.write_text(raw_output(stdout, stderr))
         finished = timestamp()
         progress(
             f"provider {provider} finished returncode={popen.returncode} "
             f"elapsed={elapsed_seconds(started_monotonic)}s"
+        )
+        _rm.update_provider_state(
+            review_dir,
+            provider,
+            status="finished",
+            returncode=popen.returncode,
+            finished_at=finished,
         )
         return {
             "provider": provider,
@@ -1742,12 +1759,20 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
             f"provider {provider} failed returncode=127 "
             f"elapsed={elapsed_seconds(started_monotonic)}s"
         )
+        finished = timestamp()
+        _rm.update_provider_state(
+            review_dir,
+            provider,
+            status="failed",
+            returncode=127,
+            finished_at=finished,
+        )
         return {
             "provider": provider,
             "returncode": 127,
             "raw": str(raw_path.relative_to(review_dir)),
             "started_at": started,
-            "finished_at": timestamp(),
+            "finished_at": finished,
         }
     except subprocess.TimeoutExpired as exc:
         cleanup_result = terminate_process_group(popen)
@@ -1766,12 +1791,20 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
             f"provider {provider} timed out returncode=124 "
             f"cleanup={cleanup_result} elapsed={elapsed_seconds(started_monotonic)}s"
         )
+        finished = timestamp()
+        _rm.update_provider_state(
+            review_dir,
+            provider,
+            status="timed_out",
+            returncode=124,
+            finished_at=finished,
+        )
         return {
             "provider": provider,
             "returncode": 124,
             "raw": str(raw_path.relative_to(review_dir)),
             "started_at": started,
-            "finished_at": timestamp(),
+            "finished_at": finished,
         }
     except Exception:
         if popen is not None and popen.poll() is None:
@@ -2242,6 +2275,31 @@ def cmd_review(args):
         prompt_path = review_dir / "prompt.md"
         progress("writing prompt")
         prompt_path.write_text(prompt)
+        # TRN-2018 M1: write metadata.json with all providers queued BEFORE
+        # run_providers. This gives `trinity status --latest` a live view
+        # while providers run, instead of waiting until completion.
+        _rm.init_metadata(
+            review_dir,
+            review_id=review_dir.name,
+            review_dir_str=str(review_dir),
+            providers=providers,
+            preset=preset_metadata,
+            scope=args.scope,
+            root=str(root),
+            input=review_input["metadata"],
+        )
+        if strict_review is not None:
+            # Preserve strict_review block alongside the live state by
+            # threading it into metadata after init.
+            data = _rm.read_metadata(review_dir)
+            data["strict_review"] = {
+                key: value
+                for key, value in strict_review.items()
+                if key != "template"
+            }
+            (review_dir / "metadata.json").write_text(
+                json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+            )
         results = run_providers(
             max_workers,
             providers,
@@ -2250,22 +2308,19 @@ def cmd_review(args):
             review_dir,
             root,
         )
-        metadata = {
-            "scope": args.scope,
-            "root": str(root),
-            "providers": providers,
-            "preset": preset_metadata,
-            "input": review_input["metadata"],
-            "results": results,
-        }
-        if strict_review is not None:
-            metadata["strict_review"] = {
-                key: value for key, value in strict_review.items() if key != "template"
-            }
         progress("writing metadata")
-        (review_dir / "metadata.json").write_text(
-            json.dumps(metadata, indent=2, ensure_ascii=False) + "\n"
-        )
+        _rm.finalize_metadata(review_dir, results)
+        # Re-apply strict_review if it was set (finalize rewrites the file).
+        if strict_review is not None:
+            data = _rm.read_metadata(review_dir)
+            data["strict_review"] = {
+                key: value
+                for key, value in strict_review.items()
+                if key != "template"
+            }
+            (review_dir / "metadata.json").write_text(
+                json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+            )
         progress("writing synthesis")
         summary, synthesis_path = write_synthesis(
             review_dir, args.scope, results, strict_review=strict_review

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1702,7 +1702,17 @@ def _review_schema_addendum(task_type, strict_review=None):
 
 
 def run_provider(provider, provider_config, prompt_path, review_dir, root, registry):
+    # TRN-2018 M1: stdout/stderr stream to logs/<p>.std{out,err}.log via
+    # line-buffered file handles so `trinity status` and external watchers
+    # can read partial output while the provider runs. raw/<p>.txt is
+    # composed from the (closed) log files after completion for backward
+    # compat with downstream consumers.
     raw_path = review_dir / "raw" / f"{provider}.txt"
+    # Defensive: production cmd_review path creates logs/ via make_review_dir,
+    # but unit tests that build review_dir manually may skip it.
+    (review_dir / "logs").mkdir(exist_ok=True)
+    stdout_path = review_dir / "logs" / f"{provider}.stdout.log"
+    stderr_path = review_dir / "logs" / f"{provider}.stderr.log"
     cmd = provider_command(provider, provider_config) + [
         build_prompt_handoff(prompt_path)
     ]
@@ -1714,59 +1724,109 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
     started_monotonic = time.monotonic()
     progress(f"starting provider {provider} timeout={timeout}s")
     popen = None
-    try:
-        popen = subprocess.Popen(
-            cmd,
-            cwd=str(root),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            start_new_session=True,
-            env=build_provider_env(),
-        )
-        registry.add(provider, popen, started)
-        _rm.update_provider_state(
-            review_dir,
-            provider,
-            status="running",
-            pid=getattr(popen, "pid", None),
-            started_at=started,
-        )
-        stdout, stderr = popen.communicate(timeout=timeout)
-        raw_path.write_text(raw_output(stdout, stderr))
-        finished = timestamp()
-        progress(
-            f"provider {provider} finished returncode={popen.returncode} "
-            f"elapsed={elapsed_seconds(started_monotonic)}s"
-        )
-        _rm.update_provider_state(
-            review_dir,
-            provider,
-            status="finished",
-            returncode=popen.returncode,
-            finished_at=finished,
-        )
+    outcome = None  # tuple describing terminal state; consumed below for raw compose
+    with (
+        open(stdout_path, "w", buffering=1, encoding="utf-8") as fout,
+        open(stderr_path, "w", buffering=1, encoding="utf-8") as ferr,
+    ):
+        try:
+            popen = subprocess.Popen(
+                cmd,
+                cwd=str(root),
+                stdout=fout,
+                stderr=ferr,
+                text=True,
+                start_new_session=True,
+                env=build_provider_env(),
+            )
+            registry.add(provider, popen, started)
+            _rm.update_provider_state(
+                review_dir,
+                provider,
+                status="running",
+                pid=getattr(popen, "pid", None),
+                started_at=started,
+                stdout_path=str(stdout_path.relative_to(review_dir)),
+                stderr_path=str(stderr_path.relative_to(review_dir)),
+            )
+            popen.wait(timeout=timeout)
+            finished = timestamp()
+            progress(
+                f"provider {provider} finished returncode={popen.returncode} "
+                f"elapsed={elapsed_seconds(started_monotonic)}s"
+            )
+            _rm.update_provider_state(
+                review_dir,
+                provider,
+                status="finished",
+                returncode=popen.returncode,
+                finished_at=finished,
+            )
+            outcome = ("finished", popen.returncode, finished)
+        except FileNotFoundError as exc:
+            finished = timestamp()
+            progress(
+                f"provider {provider} failed returncode=127 "
+                f"elapsed={elapsed_seconds(started_monotonic)}s"
+            )
+            _rm.update_provider_state(
+                review_dir,
+                provider,
+                status="failed",
+                returncode=127,
+                finished_at=finished,
+            )
+            outcome = ("filenotfound", str(exc), finished)
+        except subprocess.TimeoutExpired as exc:
+            cleanup_result = terminate_process_group(popen)
+            # Best effort: wait briefly so the child fully exits before we
+            # close its stdout/stderr file handles.
+            try:
+                popen.wait(timeout=1)
+            except (subprocess.TimeoutExpired, ValueError):
+                pass
+            finished = timestamp()
+            progress(
+                f"provider {provider} timed out returncode=124 "
+                f"cleanup={cleanup_result} elapsed={elapsed_seconds(started_monotonic)}s"
+            )
+            _rm.update_provider_state(
+                review_dir,
+                provider,
+                status="timed_out",
+                returncode=124,
+                finished_at=finished,
+            )
+            outcome = ("timeout", exc, timeout, finished)
+        except Exception:
+            if popen is not None and popen.poll() is None:
+                terminate_process_group(popen)
+            raise
+        finally:
+            try:
+                fout.flush()
+                ferr.flush()
+            except Exception:
+                pass
+            if popen is not None:
+                registry.remove(provider, popen)
+
+    # Log file handles are now closed; compose raw_path from disk content.
+    if outcome[0] == "finished":
+        _, rc, finished = outcome
+        stdout_text = stdout_path.read_text(errors="replace") if stdout_path.exists() else ""
+        stderr_text = stderr_path.read_text(errors="replace") if stderr_path.exists() else ""
+        raw_path.write_text(raw_output(stdout_text, stderr_text))
         return {
             "provider": provider,
-            "returncode": popen.returncode,
+            "returncode": rc,
             "raw": str(raw_path.relative_to(review_dir)),
             "started_at": started,
             "finished_at": finished,
         }
-    except FileNotFoundError as exc:
-        raw_path.write_text(f"ERROR: command not found: {exc}\n")
-        progress(
-            f"provider {provider} failed returncode=127 "
-            f"elapsed={elapsed_seconds(started_monotonic)}s"
-        )
-        finished = timestamp()
-        _rm.update_provider_state(
-            review_dir,
-            provider,
-            status="failed",
-            returncode=127,
-            finished_at=finished,
-        )
+    if outcome[0] == "filenotfound":
+        _, msg, finished = outcome
+        raw_path.write_text(f"ERROR: command not found: {msg}\n")
         return {
             "provider": provider,
             "returncode": 127,
@@ -1774,45 +1834,22 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
             "started_at": started,
             "finished_at": finished,
         }
-    except subprocess.TimeoutExpired as exc:
-        cleanup_result = terminate_process_group(popen)
-        stdout = None
-        stderr = None
-        try:
-            stdout, stderr = popen.communicate(timeout=1)
-        except (subprocess.TimeoutExpired, ValueError):
-            pass
-        partial = timeout_partial_output(exc, stdout, stderr)
-        output = f"ERROR: timeout after {timeout}s\n{exc}\n"
-        if partial:
-            output += "\n[partial output]\n" + partial
-        raw_path.write_text(output)
-        progress(
-            f"provider {provider} timed out returncode=124 "
-            f"cleanup={cleanup_result} elapsed={elapsed_seconds(started_monotonic)}s"
-        )
-        finished = timestamp()
-        _rm.update_provider_state(
-            review_dir,
-            provider,
-            status="timed_out",
-            returncode=124,
-            finished_at=finished,
-        )
-        return {
-            "provider": provider,
-            "returncode": 124,
-            "raw": str(raw_path.relative_to(review_dir)),
-            "started_at": started,
-            "finished_at": finished,
-        }
-    except Exception:
-        if popen is not None and popen.poll() is None:
-            terminate_process_group(popen)
-        raise
-    finally:
-        if popen is not None:
-            registry.remove(provider, popen)
+    # timeout
+    _, exc, timeout_val, finished = outcome
+    stdout_text = stdout_path.read_text(errors="replace") if stdout_path.exists() else ""
+    stderr_text = stderr_path.read_text(errors="replace") if stderr_path.exists() else ""
+    partial = timeout_partial_output(exc, stdout_text, stderr_text)
+    output = f"ERROR: timeout after {timeout_val}s\n{exc}\n"
+    if partial:
+        output += "\n[partial output]\n" + partial
+    raw_path.write_text(output)
+    return {
+        "provider": provider,
+        "returncode": 124,
+        "raw": str(raw_path.relative_to(review_dir)),
+        "started_at": started,
+        "finished_at": finished,
+    }
 
 
 def review_parallelism(config, providers):

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1817,6 +1817,11 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
                 registry.remove(provider, popen)
 
     # Log file handles are now closed; compose raw_path from disk content.
+    # TRN-2018 R3 fix (codex R2 P2): append the result entry to metadata
+    # immediately so status readers can discover completed providers'
+    # artifacts before the full review finishes (parallel-provider case).
+    # finalize_metadata later overwrites results with the canonical
+    # ordered list from run_providers, so duplicate appends are harmless.
     if outcome[0] == "finished":
         _, rc, finished = outcome
         stdout_text = (
@@ -1826,23 +1831,27 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
             stderr_path.read_text(errors="replace") if stderr_path.exists() else ""
         )
         raw_path.write_text(raw_output(stdout_text, stderr_text))
-        return {
+        result = {
             "provider": provider,
             "returncode": rc,
             "raw": str(raw_path.relative_to(review_dir)),
             "started_at": started,
             "finished_at": finished,
         }
+        _rm.append_result(review_dir, result)
+        return result
     if outcome[0] == "filenotfound":
         _, msg, finished = outcome
         raw_path.write_text(f"ERROR: command not found: {msg}\n")
-        return {
+        result = {
             "provider": provider,
             "returncode": 127,
             "raw": str(raw_path.relative_to(review_dir)),
             "started_at": started,
             "finished_at": finished,
         }
+        _rm.append_result(review_dir, result)
+        return result
     # timeout
     _, exc, timeout_val, finished = outcome
     stdout_text = (
@@ -1856,13 +1865,15 @@ def run_provider(provider, provider_config, prompt_path, review_dir, root, regis
     if partial:
         output += "\n[partial output]\n" + partial
     raw_path.write_text(output)
-    return {
+    result = {
         "provider": provider,
         "returncode": 124,
         "raw": str(raw_path.relative_to(review_dir)),
         "started_at": started,
         "finished_at": finished,
     }
+    _rm.append_result(review_dir, result)
+    return result
 
 
 def review_parallelism(config, providers):
@@ -2596,8 +2607,12 @@ def _print_review_summary(review_dir):
     results = metadata.get("results", [])
 
     # "started Xm ago" — earliest started_at across results, vs now.
+    # TRN-2018 R3 fix (codex R2 P2): when M1 metadata is mid-review (results
+    # still empty because run_providers hasn't finished), fall back to the
+    # top-level `started_at` written by init_metadata so the header doesn't
+    # render "started ?" in the exact state the live-status feature is for.
     started_isos = [r.get("started_at") for r in results if r.get("started_at")]
-    earliest = min(started_isos) if started_isos else None
+    earliest = min(started_isos) if started_isos else metadata.get("started_at")
     now_iso = dt.datetime.now().isoformat(timespec="seconds")
     ago = _format_ago(now_iso, earliest) if earliest else "?"
 

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -2636,8 +2636,14 @@ def _print_review_summary(review_dir):
             rc = state.get("returncode")
             if rc is not None:
                 bits.append(f"rc={rc}")
+            # TRN-2018 R4 fix (codex R3 P2): for currently-running providers,
+            # finished_at is absent; use `now` as the end time so the row
+            # shows elapsed-so-far. Terminal states use their finished_at.
+            end_iso = state.get("finished_at") or (
+                now_iso if status_str == "running" else None
+            )
             ls_elapsed = _format_duration(
-                _format_elapsed(state.get("started_at"), state.get("finished_at"))
+                _format_elapsed(state.get("started_at"), end_iso)
             )
             if ls_elapsed and ls_elapsed != "?":
                 bits.append(f"elapsed {ls_elapsed}")
@@ -2691,18 +2697,25 @@ def _print_review_summary(review_dir):
         # would mislabel an exception-after-metadata-write (e.g. inside
         # write_synthesis()) as a user interruption.
         overall = incomplete_status
+    elif metadata.get("status") == "running":
+        # TRN-2018 R4 fix (codex R3 P2): when M1's top-level status is
+        # `running`, a partial `results[]` (one provider finished while
+        # another is still queued/running) must NOT report `completed`.
+        # The live state is authoritative — defer to it until terminal.
+        overall = "running"
+    elif metadata.get("status") in ("failed", "timed_out", "finished"):
+        # M1 terminal: top-level status is authoritative (correctly accounts
+        # for failed/timed_out providers via finalize_metadata precedence).
+        overall = metadata["status"]
     elif not results:
-        # TRN-2018 M1: when init_metadata has written the M1 top-level status
-        # field, prefer it (e.g. "running" mid-review) over "unknown (no
-        # results)". Pre-M1 metadata lacks the top-level status key.
-        m1_status = metadata.get("status")
-        overall = m1_status if m1_status else "unknown (no results)"
+        # Pre-M1 with no results (or M1 without a top-level status set,
+        # which shouldn't happen but is defended).
+        overall = "unknown (no results)"
     elif any(r.get("returncode") != 0 for r in results):
-        # Any non-success rc (non-zero OR missing — None != 0) → partial.
-        # The visual marker for rc=None is ✗, so the overall status must
-        # not contradict that by reporting "completed".
+        # Pre-M1 path: any non-success rc → partial.
         overall = "partial"
     else:
+        # Pre-M1 path: all-zero results → completed.
         overall = "completed"
     print(f"  Status: {overall}")
     return 0

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -2350,6 +2350,16 @@ def cmd_review(args):
         # TRN-2018 M1: write metadata.json with all providers queued BEFORE
         # run_providers. This gives `trinity status --latest` a live view
         # while providers run, instead of waiting until completion.
+        # R5 fix (codex R5 P2): strict_review threaded into the initial
+        # atomic write — finalize_metadata mutates only finished_at /
+        # results / status / provider_states, so strict_review survives
+        # through the post-run update without a separate write_text that
+        # would race readers.
+        strict_review_block = (
+            {key: value for key, value in strict_review.items() if key != "template"}
+            if strict_review is not None
+            else None
+        )
         _rm.init_metadata(
             review_dir,
             review_id=review_dir.name,
@@ -2359,17 +2369,8 @@ def cmd_review(args):
             scope=args.scope,
             root=str(root),
             input=review_input["metadata"],
+            strict_review=strict_review_block,
         )
-        if strict_review is not None:
-            # Preserve strict_review block alongside the live state by
-            # threading it into metadata after init.
-            data = _rm.read_metadata(review_dir)
-            data["strict_review"] = {
-                key: value for key, value in strict_review.items() if key != "template"
-            }
-            (review_dir / "metadata.json").write_text(
-                json.dumps(data, indent=2, ensure_ascii=False) + "\n"
-            )
         results = run_providers(
             max_workers,
             providers,
@@ -2380,15 +2381,6 @@ def cmd_review(args):
         )
         progress("writing metadata")
         _rm.finalize_metadata(review_dir, results)
-        # Re-apply strict_review if it was set (finalize rewrites the file).
-        if strict_review is not None:
-            data = _rm.read_metadata(review_dir)
-            data["strict_review"] = {
-                key: value for key, value in strict_review.items() if key != "template"
-            }
-            (review_dir / "metadata.json").write_text(
-                json.dumps(data, indent=2, ensure_ascii=False) + "\n"
-            )
         progress("writing synthesis")
         summary, synthesis_path = write_synthesis(
             review_dir, args.scope, results, strict_review=strict_review

--- a/tests/fixtures/fake_provider_buffered.py
+++ b/tests/fixtures/fake_provider_buffered.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Emit newline-terminated stdout without explicit flush, then sleep."""
+
+import sys
+import time
+
+sys.stdout.write("buffered output before sleep\n")
+time.sleep(1)
+sys.stdout.write("buffered output after sleep\n")

--- a/tests/fixtures/fake_provider_fail.sh
+++ b/tests/fixtures/fake_provider_fail.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# TRN-2018 M1 test fixture: emits to stderr then exits with rc=2.
+# Used to verify provider_states.<p>.status == 'failed' (not 'finished')
+# when a provider exits cleanly with a non-zero returncode.
+echo "stdout before failure"
+echo "explanatory error message" >&2
+exit 2

--- a/tests/fixtures/fake_provider_hang.sh
+++ b/tests/fixtures/fake_provider_hang.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# TRN-2018 M1 test fixture: sleeps far longer than test timeout.
+# Used to exercise the timeout path (returncode 124 + TERM/KILL escalation).
+echo "starting hang"
+sleep 999
+exit 0

--- a/tests/fixtures/fake_provider_partial.sh
+++ b/tests/fixtures/fake_provider_partial.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# TRN-2018 M1 test fixture: emits partial stdout, then sleeps for ~1s.
+# Used to prove logs/<p>.stdout.log exists while provider is still running.
+echo "partial output line 1"
+sleep 1
+echo "partial output line 2"
+exit 0

--- a/tests/fixtures/fake_provider_quick.sh
+++ b/tests/fixtures/fake_provider_quick.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# TRN-2018 M1 test fixture: emits stdout and exits 0 immediately.
+echo "quick provider stdout"
+exit 0

--- a/tests/fixtures/fake_provider_stderr.sh
+++ b/tests/fixtures/fake_provider_stderr.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# TRN-2018 M1 test fixture: emits to both stdout and stderr.
+# Used to verify raw/<p>.txt format preservation (stdout, then
+# `\n[stderr]\n` and stderr, per existing raw_output() helper).
+echo "stdout line"
+echo "stderr line" >&2
+exit 0

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -1638,16 +1638,20 @@ def test_strict_cor_reviewer_at_9_2_passes():
     import json as _json
     from pathlib import Path as _Path
     import sys as _sys
+
     _ROOT = _Path(__file__).resolve().parent.parent
     if str(_ROOT / "scripts") not in _sys.path:
         _sys.path.insert(0, str(_ROOT / "scripts"))
     import codex as _codex_mod
-    payload = _json.dumps({
-        "decision": "PASS",
-        "weighted_score": 9.2,
-        "blocking": [],
-        "advisories": [],
-    })
+
+    payload = _json.dumps(
+        {
+            "decision": "PASS",
+            "weighted_score": 9.2,
+            "blocking": [],
+            "advisories": [],
+        }
+    )
     raw = f"```json\n{payload}\n```"
     result = _codex_mod.parse_structured_review(raw, pass_threshold=9.0)
     assert result is not None
@@ -1659,16 +1663,20 @@ def test_fast_review_panel_at_9_4_coerces_to_FIX():
     import json as _json
     from pathlib import Path as _Path
     import sys as _sys
+
     _ROOT = _Path(__file__).resolve().parent.parent
     if str(_ROOT / "scripts") not in _sys.path:
         _sys.path.insert(0, str(_ROOT / "scripts"))
     import codex as _codex_mod
-    payload = _json.dumps({
-        "decision": "PASS",
-        "weighted_score": 9.4,
-        "blocking": [],
-        "advisories": [],
-    })
+
+    payload = _json.dumps(
+        {
+            "decision": "PASS",
+            "weighted_score": 9.4,
+            "blocking": [],
+            "advisories": [],
+        }
+    )
     raw = f"```json\n{payload}\n```"
     result = _codex_mod.parse_structured_review(raw)
     assert result is not None
@@ -1680,27 +1688,33 @@ def test_parse_structured_review_default_threshold():
     import json as _json
     from pathlib import Path as _Path
     import sys as _sys
+
     _ROOT = _Path(__file__).resolve().parent.parent
     if str(_ROOT / "scripts") not in _sys.path:
         _sys.path.insert(0, str(_ROOT / "scripts"))
     import codex as _codex_mod
+
     # Score 9.5 should PASS (>= 9.5)
-    payload_pass = _json.dumps({
-        "decision": "PASS",
-        "weighted_score": 9.5,
-        "blocking": [],
-        "advisories": [],
-    })
+    payload_pass = _json.dumps(
+        {
+            "decision": "PASS",
+            "weighted_score": 9.5,
+            "blocking": [],
+            "advisories": [],
+        }
+    )
     raw_pass = f"```json\n{payload_pass}\n```"
     result_pass = _codex_mod.parse_structured_review(raw_pass)
     assert result_pass["effective_decision"] == "PASS"
     # Score 9.4 should FIX (< 9.5)
-    payload_fix = _json.dumps({
-        "decision": "PASS",
-        "weighted_score": 9.4,
-        "blocking": [],
-        "advisories": [],
-    })
+    payload_fix = _json.dumps(
+        {
+            "decision": "PASS",
+            "weighted_score": 9.4,
+            "blocking": [],
+            "advisories": [],
+        }
+    )
     raw_fix = f"```json\n{payload_fix}\n```"
     result_fix = _codex_mod.parse_structured_review(raw_fix)
     assert result_fix["effective_decision"] == "FIX"

--- a/tests/test_codex_review_dispatch.py
+++ b/tests/test_codex_review_dispatch.py
@@ -560,7 +560,12 @@ def test_review_sigint_during_metadata_write_marks_incomplete(
     assert (review_dir / "metadata.json").exists()
     init_meta = json.loads((review_dir / "metadata.json").read_text())
     assert init_meta["status"] == "running"
-    assert not (review_dir / "synthesis.md").exists()
+    # TRN-2018 R7: cmd_review reorders write_synthesis BEFORE
+    # finalize_metadata so a concurrent status poll never sees
+    # status=finished without synthesis.md. With finalize_metadata
+    # monkeypatched to raise here, synthesis.md was already written
+    # in the prior step. (Pre-R7 order had this assertion reversed.)
+    assert (review_dir / "synthesis.md").exists()
 
 
 def test_run_providers_does_not_start_queued_provider_after_failure(

--- a/tests/test_codex_review_dispatch.py
+++ b/tests/test_codex_review_dispatch.py
@@ -468,7 +468,14 @@ time.sleep(30)
     assert incomplete["providers_running_at_cleanup"] == ["deepseek"]
     assert "glm" not in incomplete["cleanup"]
     assert "deepseek" in incomplete["cleanup"]
-    assert not (review_dir / "metadata.json").exists()
+    # TRN-2018 M1: metadata.json is written at init (before run_providers),
+    # so an interrupted review now leaves both files. metadata.json contains
+    # the init-time state (status=running with provider_states); incomplete.json
+    # overlays the interrupted-status verdict (read by _print_review_summary).
+    assert (review_dir / "metadata.json").exists()
+    init_meta = json.loads((review_dir / "metadata.json").read_text())
+    assert init_meta["status"] == "running"
+    assert set(init_meta["provider_states"].keys()) == {"glm", "deepseek"}
 
 
 def test_review_sigint_before_dispatch_writes_incomplete_json(
@@ -513,20 +520,22 @@ def test_review_sigint_before_dispatch_writes_incomplete_json(
 def test_review_sigint_during_metadata_write_marks_incomplete(
     tmp_path, monkeypatch, capsys
 ):
+    """TRN-2018 M1: metadata writes go through _review_metadata._write_atomic
+    (os.replace), not Path.write_text. Interrupt during the post-run write
+    is now achieved by patching finalize_metadata. The init-time
+    metadata.json (written before run_providers starts) survives.
+    """
     repo = simple_repo(tmp_path)
     events = tmp_path / "events.jsonl"
     glm = tmp_path / "glm"
     write_sleep_provider(glm, events, sleep_seconds=0.1)
     config = tmp_path / "codex.json"
     write_config(config, {"glm": glm})
-    original_write_text = Path.write_text
 
-    def interrupt_metadata_write(path, *args, **kwargs):
-        if path.name == "metadata.json":
-            raise KeyboardInterrupt
-        return original_write_text(path, *args, **kwargs)
+    def interrupt_finalize(*args, **kwargs):
+        raise KeyboardInterrupt
 
-    monkeypatch.setattr(codex.Path, "write_text", interrupt_metadata_write)
+    monkeypatch.setattr(codex._rm, "finalize_metadata", interrupt_finalize)
     args = codex.build_parser().parse_args(
         [
             "review",
@@ -546,7 +555,11 @@ def test_review_sigint_during_metadata_write_marks_incomplete(
     assert incomplete["providers_started"] == ["glm"]
     assert incomplete["providers_running_at_cleanup"] == []
     assert incomplete["cleanup"] == {}
-    assert not (review_dir / "metadata.json").exists()
+    # M1: init_metadata wrote metadata.json before run_providers; finalize
+    # was the interrupted step. The file persists with init-time state.
+    assert (review_dir / "metadata.json").exists()
+    init_meta = json.loads((review_dir / "metadata.json").read_text())
+    assert init_meta["status"] == "running"
     assert not (review_dir / "synthesis.md").exists()
 
 

--- a/tests/test_provider_env.py
+++ b/tests/test_provider_env.py
@@ -227,9 +227,15 @@ def test_a9_run_provider_passes_env_to_popen():
         def __init__(self, *args, **kwargs):
             captured["env"] = kwargs.get("env")
             self.returncode = 0
+            self.pid = 12345
 
         def communicate(self, timeout=None):
             return ("ok\n", "")
+
+        def wait(self, timeout=None):
+            # TRN-2018 M1: run_provider uses Popen.wait() now (file-handle
+            # stdout/stderr); mock returns immediately with rc=0.
+            return 0
 
     class FakeRegistry:
         def add(self, *args, **kwargs):

--- a/tests/test_provider_logs.py
+++ b/tests/test_provider_logs.py
@@ -206,9 +206,9 @@ def test_run_provider_nonzero_rc_marks_state_failed(tmp_path):
     assert result["returncode"] == 2
     import json
 
-    state = json.loads((review_dir / "metadata.json").read_text())[
-        "provider_states"
-    ]["p"]
+    state = json.loads((review_dir / "metadata.json").read_text())["provider_states"][
+        "p"
+    ]
     assert state["status"] == "failed", (
         f"expected failed (rc=2 != 0); got {state['status']!r}"
     )

--- a/tests/test_provider_logs.py
+++ b/tests/test_provider_logs.py
@@ -186,6 +186,35 @@ def test_raw_txt_format_unchanged_with_stderr(tmp_path):
     )
 
 
+def test_run_provider_nonzero_rc_marks_state_failed(tmp_path):
+    """R2 fix for codex P2 finding 3249xxxx: when a provider exits cleanly
+    with rc != 0, run_provider must record provider_states.<p>.status as
+    'failed' (not 'finished'), so finalize_metadata correctly surfaces the
+    top-level status as 'failed' via the failed > timed_out > finished
+    precedence."""
+    review_dir = _init_review(tmp_path)
+    provider_config = {"cli": str(FIXTURES / "fake_provider_fail.sh"), "timeout": 10}
+    registry = codex_mod.ActiveProcessRegistry()
+    result = codex_mod.run_provider(
+        "p",
+        provider_config,
+        tmp_path / "prompt.md",
+        review_dir,
+        tmp_path,
+        registry,
+    )
+    assert result["returncode"] == 2
+    import json
+
+    state = json.loads((review_dir / "metadata.json").read_text())[
+        "provider_states"
+    ]["p"]
+    assert state["status"] == "failed", (
+        f"expected failed (rc=2 != 0); got {state['status']!r}"
+    )
+    assert state["returncode"] == 2
+
+
 def test_active_process_registry_remove_called_on_normal_exit(tmp_path):
     """After run_provider returns, the registry snapshot must NOT contain
     the provider — preserves codex.py:1782's finally-block contract."""

--- a/tests/test_provider_logs.py
+++ b/tests/test_provider_logs.py
@@ -1,0 +1,225 @@
+"""TRN-2018 M1: incremental provider logs via Popen file-handle refactor.
+
+Currently `run_provider` (scripts/codex.py:1701) uses
+`Popen(stdout=PIPE, stderr=PIPE) + communicate(timeout=...)`, so
+nothing is written to disk until communicate() returns. C.2 refactors
+this to `Popen(stdout=open(path, 'w', buffering=1), stderr=...)` so
+the logs/<p>.std{out,err}.log files appear and grow while the
+provider runs.
+
+These tests are RED before C.2 GREEN and prove:
+1. logs/<p>.stdout.log exists during provider execution
+2. timeout path preserves partial logs + returncode 124
+3. command-not-found path creates empty log files + returncode 127
+4. raw/<p>.txt format is unchanged (stdout-only and stdout+stderr cases)
+5. ActiveProcessRegistry.remove is called on normal exit (preserves
+   codex.py:1782 finally-block semantics)
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import codex as codex_mod  # noqa: E402
+import _review_metadata as rm  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _init_review(tmp_path: Path, providers=("p",)) -> Path:
+    """Set up a review_dir with raw/, logs/, and an init'd metadata.json
+    so update_provider_state calls land instead of silently no-opping."""
+    review_dir = tmp_path / "20260516-100000-test"
+    (review_dir / "raw").mkdir(parents=True)
+    (review_dir / "logs").mkdir()
+    (tmp_path / "prompt.md").write_text("p")
+    rm.init_metadata(
+        review_dir,
+        review_id=review_dir.name,
+        review_dir_str=str(review_dir),
+        providers=list(providers),
+        preset=None,
+        scope=".",
+        root=str(tmp_path),
+        input={"mode": "scope"},
+    )
+    return review_dir
+
+
+def test_run_provider_creates_logs_files_before_completion(tmp_path):
+    """The partial fixture emits one line, sleeps 1s, then emits another.
+    During the sleep, logs/p.stdout.log should already contain line 1.
+    Poll from the main thread while run_provider executes in a background
+    thread."""
+    review_dir = _init_review(tmp_path)
+    provider_config = {"cli": str(FIXTURES / "fake_provider_partial.sh"), "timeout": 10}
+    registry = codex_mod.ActiveProcessRegistry()
+    result_holder: dict = {}
+
+    def run():
+        result_holder["result"] = codex_mod.run_provider(
+            "p",
+            provider_config,
+            tmp_path / "prompt.md",
+            review_dir,
+            tmp_path,
+            registry,
+        )
+
+    t = threading.Thread(target=run)
+    t.start()
+
+    stdout_log = review_dir / "logs" / "p.stdout.log"
+    deadline = time.time() + 1.5
+    seen = False
+    while time.time() < deadline and t.is_alive():
+        if stdout_log.exists() and "partial output line 1" in stdout_log.read_text():
+            seen = True
+            break
+        time.sleep(0.05)
+
+    t.join(timeout=5)
+    assert not t.is_alive(), "run_provider thread didn't finish"
+    assert seen, (
+        "logs/p.stdout.log should contain partial output BEFORE provider exits"
+    )
+    assert result_holder["result"]["returncode"] == 0
+
+
+def test_run_provider_logs_persist_after_timeout(tmp_path):
+    """Hang fixture sleeps 999s; provider_config sets timeout=2s. Expected:
+    returncode 124, raw/p.txt contains the timeout banner, logs files
+    exist on disk (may be empty or contain 'starting hang' depending on
+    flush timing)."""
+    review_dir = _init_review(tmp_path)
+    provider_config = {"cli": str(FIXTURES / "fake_provider_hang.sh"), "timeout": 2}
+    registry = codex_mod.ActiveProcessRegistry()
+    result = codex_mod.run_provider(
+        "p",
+        provider_config,
+        tmp_path / "prompt.md",
+        review_dir,
+        tmp_path,
+        registry,
+    )
+    assert result["returncode"] == 124
+    raw = (review_dir / "raw" / "p.txt").read_text()
+    assert "ERROR: timeout after 2s" in raw
+    assert (review_dir / "logs" / "p.stdout.log").exists()
+    assert (review_dir / "logs" / "p.stderr.log").exists()
+
+
+def test_run_provider_logs_filenotfound_path(tmp_path):
+    """Command points at a nonexistent path. Expected: returncode 127,
+    raw/p.txt contains the command-not-found banner. Log files may
+    exist (empty) or not — Popen() raises before the file handles open
+    on some platforms, after on others. The contract is just "raw is
+    written and returncode is 127", per the existing semantics at
+    codex.py:1740-1751."""
+    review_dir = _init_review(tmp_path)
+    provider_config = {"cli": "/nonexistent/trinity-test-cmd", "timeout": 5}
+    registry = codex_mod.ActiveProcessRegistry()
+    result = codex_mod.run_provider(
+        "p",
+        provider_config,
+        tmp_path / "prompt.md",
+        review_dir,
+        tmp_path,
+        registry,
+    )
+    assert result["returncode"] == 127
+    raw = (review_dir / "raw" / "p.txt").read_text()
+    assert "ERROR: command not found" in raw
+
+
+def test_raw_txt_format_unchanged_stdout_only(tmp_path):
+    """Quick fixture emits stdout only. raw/p.txt must contain the stdout
+    bytes. The _STDERR_SENTINEL is always appended by raw_output() (see
+    codex.py:1417) even when stderr is empty — the contract is that the
+    sentinel is unique enough that no real provider output collides, and
+    _strip_stderr_region (TRN-3022 coupling) relies on it being present
+    as a boundary marker."""
+    review_dir = _init_review(tmp_path)
+    provider_config = {"cli": str(FIXTURES / "fake_provider_quick.sh"), "timeout": 10}
+    registry = codex_mod.ActiveProcessRegistry()
+    codex_mod.run_provider(
+        "p",
+        provider_config,
+        tmp_path / "prompt.md",
+        review_dir,
+        tmp_path,
+        registry,
+    )
+    raw = (review_dir / "raw" / "p.txt").read_text()
+    assert "quick provider stdout" in raw
+    assert codex_mod._STDERR_SENTINEL in raw
+    # stderr region after the sentinel is empty for stdout-only providers
+    assert raw.endswith(codex_mod._STDERR_SENTINEL)
+
+
+def test_raw_txt_format_unchanged_with_stderr(tmp_path):
+    """stderr fixture emits to both. raw/p.txt is
+    `<stdout>{_STDERR_SENTINEL}<stderr>` per codex.py:1417."""
+    review_dir = _init_review(tmp_path)
+    provider_config = {"cli": str(FIXTURES / "fake_provider_stderr.sh"), "timeout": 10}
+    registry = codex_mod.ActiveProcessRegistry()
+    codex_mod.run_provider(
+        "p",
+        provider_config,
+        tmp_path / "prompt.md",
+        review_dir,
+        tmp_path,
+        registry,
+    )
+    raw = (review_dir / "raw" / "p.txt").read_text()
+    assert "stdout line" in raw
+    assert codex_mod._STDERR_SENTINEL in raw
+    assert "stderr line" in raw
+    # Order: stdout, then sentinel, then stderr.
+    assert (
+        raw.index("stdout line")
+        < raw.index(codex_mod._STDERR_SENTINEL)
+        < raw.index("stderr line")
+    )
+
+
+def test_active_process_registry_remove_called_on_normal_exit(tmp_path):
+    """After run_provider returns, the registry snapshot must NOT contain
+    the provider — preserves codex.py:1782's finally-block contract."""
+    review_dir = _init_review(tmp_path)
+    provider_config = {"cli": str(FIXTURES / "fake_provider_quick.sh"), "timeout": 10}
+    registry = codex_mod.ActiveProcessRegistry()
+    codex_mod.run_provider(
+        "p",
+        provider_config,
+        tmp_path / "prompt.md",
+        review_dir,
+        tmp_path,
+        registry,
+    )
+    snap = registry.snapshot()
+    assert all(item["provider"] != "p" for item in snap)
+
+
+def test_active_process_registry_remove_called_on_timeout(tmp_path):
+    """Same as above but for the timeout path — registry must be cleaned
+    even when run_provider returns via the TimeoutExpired branch."""
+    review_dir = _init_review(tmp_path)
+    provider_config = {"cli": str(FIXTURES / "fake_provider_hang.sh"), "timeout": 2}
+    registry = codex_mod.ActiveProcessRegistry()
+    codex_mod.run_provider(
+        "p",
+        provider_config,
+        tmp_path / "prompt.md",
+        review_dir,
+        tmp_path,
+        registry,
+    )
+    snap = registry.snapshot()
+    assert all(item["provider"] != "p" for item in snap)

--- a/tests/test_provider_logs.py
+++ b/tests/test_provider_logs.py
@@ -3,9 +3,9 @@
 Currently `run_provider` (scripts/codex.py:1701) uses
 `Popen(stdout=PIPE, stderr=PIPE) + communicate(timeout=...)`, so
 nothing is written to disk until communicate() returns. C.2 refactors
-this to `Popen(stdout=open(path, 'w', buffering=1), stderr=...)` so
-the logs/<p>.std{out,err}.log files appear and grow while the
-provider runs.
+this to stream logs/<p>.std{out,err}.log while the provider runs. R8
+routes stdout through a PTY so child processes that line-buffer on
+isatty() do not block-buffer progress until exit.
 
 These tests are RED before C.2 GREEN and prove:
 1. logs/<p>.stdout.log exists during provider execution
@@ -86,6 +86,50 @@ def test_run_provider_creates_logs_files_before_completion(tmp_path):
     t.join(timeout=5)
     assert not t.is_alive(), "run_provider thread didn't finish"
     assert seen, "logs/p.stdout.log should contain partial output BEFORE provider exits"
+    assert result_holder["result"]["returncode"] == 0
+
+
+def test_run_provider_pty_flushes_child_line_buffered_stdout(tmp_path):
+    """Python block-buffers stdout to a regular file, but line-buffers when
+    stdout is a TTY. The PTY path should therefore make the first newline
+    visible before the fixture wakes from its 1s sleep, even though the fixture
+    never calls flush()."""
+    review_dir = _init_review(tmp_path)
+    provider_config = {
+        "cli": f"{sys.executable} {FIXTURES / 'fake_provider_buffered.py'}",
+        "timeout": 10,
+    }
+    registry = codex_mod.ActiveProcessRegistry()
+    result_holder: dict = {}
+
+    def run():
+        result_holder["result"] = codex_mod.run_provider(
+            "p",
+            provider_config,
+            tmp_path / "prompt.md",
+            review_dir,
+            tmp_path,
+            registry,
+        )
+
+    t = threading.Thread(target=run)
+    t.start()
+
+    stdout_log = review_dir / "logs" / "p.stdout.log"
+    deadline = time.time() + 1.5
+    seen = False
+    while time.time() < deadline and t.is_alive():
+        if (
+            stdout_log.exists()
+            and "buffered output before sleep" in stdout_log.read_text()
+        ):
+            seen = True
+            break
+        time.sleep(0.05)
+
+    t.join(timeout=5)
+    assert not t.is_alive(), "run_provider thread didn't finish"
+    assert seen, "PTY-backed stdout should flush the first buffered line live"
     assert result_holder["result"]["returncode"] == 0
 
 

--- a/tests/test_provider_logs.py
+++ b/tests/test_provider_logs.py
@@ -19,7 +19,6 @@ These tests are RED before C.2 GREEN and prove:
 from __future__ import annotations
 
 import sys
-import tempfile
 import threading
 import time
 from pathlib import Path
@@ -86,9 +85,7 @@ def test_run_provider_creates_logs_files_before_completion(tmp_path):
 
     t.join(timeout=5)
     assert not t.is_alive(), "run_provider thread didn't finish"
-    assert seen, (
-        "logs/p.stdout.log should contain partial output BEFORE provider exits"
-    )
+    assert seen, "logs/p.stdout.log should contain partial output BEFORE provider exits"
     assert result_holder["result"]["returncode"] == 0
 
 

--- a/tests/test_review_metadata.py
+++ b/tests/test_review_metadata.py
@@ -266,9 +266,9 @@ def test_backwardcompat_results_finalized_entries_match_legacy_shape(tmp_path):
 
 
 def test_read_metadata_retries_once_on_json_decode_error(tmp_path):
-    """Simulate a mid-write read: write partial JSON, then valid JSON 50ms
-    later from a background thread. read_metadata returns the valid parse
-    without raising. With 100ms retry budget, this should succeed."""
+    """Simulate a mid-write read: write partial JSON, then atomically
+    replace with valid JSON 50ms later from a background thread.
+    read_metadata's retry-after-100ms catches the valid content."""
     review_dir = tmp_path / "20260516-120000-x"
     review_dir.mkdir()
     metadata_path = review_dir / "metadata.json"
@@ -276,7 +276,11 @@ def test_read_metadata_retries_once_on_json_decode_error(tmp_path):
 
     def fix_after_delay():
         time.sleep(0.05)
-        metadata_path.write_text('{"status": "running"}')
+        # Atomic replace so the second read never sees a torn write
+        # mid-replace — see init_metadata's _write_atomic() pattern.
+        tmp = metadata_path.with_suffix(".json.fixtmp")
+        tmp.write_text('{"status": "running"}')
+        tmp.replace(metadata_path)
 
     fixer = threading.Thread(target=fix_after_delay)
     fixer.start()

--- a/tests/test_review_metadata.py
+++ b/tests/test_review_metadata.py
@@ -270,6 +270,86 @@ def test_backwardcompat_results_finalized_entries_match_legacy_shape(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# append_result (R3 fix for codex R2 P2)
+# ---------------------------------------------------------------------------
+
+
+def test_append_result_appends_to_empty_results(tmp_path):
+    review_dir = _init(tmp_path)
+    rm.append_result(
+        review_dir, {"provider": "glm", "returncode": 0, "raw": "raw/glm.txt"}
+    )
+    data = json.loads((review_dir / "metadata.json").read_text())
+    assert len(data["results"]) == 1
+    assert data["results"][0]["provider"] == "glm"
+
+
+def test_append_result_preserves_prior_entries(tmp_path):
+    review_dir = _init(tmp_path)
+    rm.append_result(review_dir, {"provider": "glm", "returncode": 0})
+    rm.append_result(review_dir, {"provider": "deepseek", "returncode": 2})
+    data = json.loads((review_dir / "metadata.json").read_text())
+    assert [r["provider"] for r in data["results"]] == ["glm", "deepseek"]
+
+
+def test_append_result_no_op_when_metadata_missing(tmp_path):
+    """Defensive: append_result silently no-ops when metadata.json absent.
+    Mirrors update_provider_state for unit-test ergonomics."""
+    review_dir = tmp_path / "bare"
+    review_dir.mkdir()
+    rm.append_result(review_dir, {"provider": "glm"})  # must not raise
+    assert not (review_dir / "metadata.json").exists()
+
+
+def test_finalize_overwrites_appended_results_with_canonical_order(tmp_path):
+    """append_result + finalize: finalize replaces results with the
+    canonical ordered list (matching `providers` order), so even if
+    append_result wrote in completion-order, the final state matches
+    the orchestrator's intent."""
+    review_dir = _init(tmp_path, providers=("glm", "deepseek"))
+    # Simulate provider completions in reverse order
+    rm.append_result(
+        review_dir,
+        {
+            "provider": "deepseek",
+            "returncode": 0,
+            "raw": "raw/deepseek.txt",
+            "started_at": "t",
+            "finished_at": "t",
+        },
+    )
+    rm.append_result(
+        review_dir,
+        {
+            "provider": "glm",
+            "returncode": 0,
+            "raw": "raw/glm.txt",
+            "started_at": "t",
+            "finished_at": "t",
+        },
+    )
+    canonical = [
+        {
+            "provider": "glm",
+            "returncode": 0,
+            "raw": "raw/glm.txt",
+            "started_at": "t",
+            "finished_at": "t",
+        },
+        {
+            "provider": "deepseek",
+            "returncode": 0,
+            "raw": "raw/deepseek.txt",
+            "started_at": "t",
+            "finished_at": "t",
+        },
+    ]
+    rm.finalize_metadata(review_dir, canonical)
+    data = json.loads((review_dir / "metadata.json").read_text())
+    assert [r["provider"] for r in data["results"]] == ["glm", "deepseek"]
+
+
+# ---------------------------------------------------------------------------
 # Read-side resilience (DS-P2#3)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_review_metadata.py
+++ b/tests/test_review_metadata.py
@@ -270,6 +270,56 @@ def test_backwardcompat_results_finalized_entries_match_legacy_shape(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# strict_review threading (R6 fix for codex R5 P2)
+# ---------------------------------------------------------------------------
+
+
+def test_init_metadata_with_strict_review_is_written_atomically(tmp_path):
+    """R6 fix (codex R5 P2): strict_review is threaded through init_metadata's
+    initial atomic write, not appended via a separate Path.write_text after.
+    A status reader during a strict review must not observe a torn JSON."""
+    review_dir = _init(
+        tmp_path,
+        strict_review={"sop": "COR-1602", "rubric": "COR-1609", "pass_threshold": 9.0},
+    )
+    data = json.loads((review_dir / "metadata.json").read_text())
+    assert data["strict_review"] == {
+        "sop": "COR-1602",
+        "rubric": "COR-1609",
+        "pass_threshold": 9.0,
+    }
+
+
+def test_finalize_metadata_preserves_strict_review(tmp_path):
+    """finalize_metadata reads + mutates only finished_at/results/status/
+    provider_states. Other top-level keys (including strict_review from
+    init) must survive."""
+    review_dir = _init(
+        tmp_path,
+        providers=("glm",),
+        strict_review={"sop": "COR-1602"},
+    )
+    rm.update_provider_state(
+        review_dir, "glm", status="finished", returncode=0, finished_at="t"
+    )
+    rm.finalize_metadata(
+        review_dir,
+        [
+            {
+                "provider": "glm",
+                "returncode": 0,
+                "raw": "raw/glm.txt",
+                "started_at": "t",
+                "finished_at": "t",
+            }
+        ],
+    )
+    data = json.loads((review_dir / "metadata.json").read_text())
+    assert data["strict_review"] == {"sop": "COR-1602"}
+    assert data["status"] == "finished"
+
+
+# ---------------------------------------------------------------------------
 # append_result (R3 fix for codex R2 P2)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_review_metadata.py
+++ b/tests/test_review_metadata.py
@@ -1,0 +1,298 @@
+"""TRN-2018 M1: live review metadata helpers.
+
+These tests target `scripts._review_metadata` — a new module introduced by
+this CHG. The module owns:
+
+- atomic metadata.json read/write with json-decode retry
+- per-review-dir threading.Lock for read-modify-write under
+  concurrent_futures.ThreadPoolExecutor (run_providers parallelism)
+- init_metadata / update_provider_state / finalize_metadata helpers
+
+Tests are written RED first. After scripts/_review_metadata.py exists
+with the spec'd helpers, they should all pass.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import _review_metadata as rm  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+def _init(tmp_path, providers=("glm", "deepseek"), **overrides):
+    review_dir = tmp_path / "20260516-120000-test"
+    review_dir.mkdir(parents=True)
+    kwargs = dict(
+        review_id=review_dir.name,
+        review_dir_str=str(review_dir),
+        providers=list(providers),
+        preset={"resolved": "fast-review"},
+        scope=".",
+        root=str(tmp_path),
+        input={"mode": "scope"},
+    )
+    kwargs.update(overrides)
+    rm.init_metadata(review_dir, **kwargs)
+    return review_dir
+
+
+def test_init_metadata_writes_file_before_provider_execution(tmp_path):
+    review_dir = _init(tmp_path)
+    assert (review_dir / "metadata.json").exists()
+
+
+def test_init_metadata_contains_review_id_review_dir_status_running(tmp_path):
+    review_dir = _init(tmp_path)
+    data = json.loads((review_dir / "metadata.json").read_text())
+    assert data["review_id"] == review_dir.name
+    assert data["review_dir"] == str(review_dir)
+    assert data["status"] == "running"
+
+
+def test_init_metadata_all_providers_queued(tmp_path):
+    review_dir = _init(tmp_path, providers=("glm", "deepseek", "codex"))
+    data = json.loads((review_dir / "metadata.json").read_text())
+    for p in ("glm", "deepseek", "codex"):
+        assert data["provider_states"][p]["status"] == "queued"
+
+
+def test_init_metadata_has_started_at_iso_finished_at_null(tmp_path):
+    review_dir = _init(tmp_path)
+    data = json.loads((review_dir / "metadata.json").read_text())
+    # ISO seconds format: 2026-05-16T12:00:00
+    assert isinstance(data["started_at"], str) and "T" in data["started_at"]
+    assert data["finished_at"] is None
+
+
+def test_init_metadata_results_is_empty_list(tmp_path):
+    review_dir = _init(tmp_path)
+    data = json.loads((review_dir / "metadata.json").read_text())
+    assert data["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# State transitions
+# ---------------------------------------------------------------------------
+
+
+def test_update_provider_state_queued_to_running_writes_pid_started_at(tmp_path):
+    review_dir = _init(tmp_path)
+    rm.update_provider_state(
+        review_dir, "glm", status="running", pid=12345, started_at="2026-05-16T12:00:01"
+    )
+    data = json.loads((review_dir / "metadata.json").read_text())
+    glm = data["provider_states"]["glm"]
+    assert glm["status"] == "running"
+    assert glm["pid"] == 12345
+    assert glm["started_at"] == "2026-05-16T12:00:01"
+
+
+def test_update_provider_state_running_to_finished_writes_returncode_finished_at(tmp_path):
+    review_dir = _init(tmp_path)
+    rm.update_provider_state(review_dir, "glm", status="running", pid=99)
+    rm.update_provider_state(
+        review_dir,
+        "glm",
+        status="finished",
+        returncode=0,
+        finished_at="2026-05-16T12:01:00",
+    )
+    data = json.loads((review_dir / "metadata.json").read_text())
+    glm = data["provider_states"]["glm"]
+    assert glm["status"] == "finished"
+    assert glm["returncode"] == 0
+    assert glm["finished_at"] == "2026-05-16T12:01:00"
+    # pid is preserved from the previous update
+    assert glm["pid"] == 99
+
+
+def test_update_provider_state_running_to_failed_preserves_partial_log_paths(tmp_path):
+    review_dir = _init(tmp_path)
+    rm.update_provider_state(
+        review_dir,
+        "glm",
+        status="running",
+        pid=99,
+        stdout_path="logs/glm.stdout.log",
+        stderr_path="logs/glm.stderr.log",
+    )
+    rm.update_provider_state(
+        review_dir, "glm", status="failed", returncode=2, finished_at="t"
+    )
+    data = json.loads((review_dir / "metadata.json").read_text())
+    glm = data["provider_states"]["glm"]
+    assert glm["status"] == "failed"
+    assert glm["stdout_path"] == "logs/glm.stdout.log"
+    assert glm["stderr_path"] == "logs/glm.stderr.log"
+
+
+def test_update_provider_state_running_to_timed_out_writes_returncode_124(tmp_path):
+    review_dir = _init(tmp_path)
+    rm.update_provider_state(review_dir, "glm", status="running", pid=99)
+    rm.update_provider_state(
+        review_dir, "glm", status="timed_out", returncode=124, finished_at="t"
+    )
+    data = json.loads((review_dir / "metadata.json").read_text())
+    glm = data["provider_states"]["glm"]
+    assert glm["status"] == "timed_out"
+    assert glm["returncode"] == 124
+
+
+# ---------------------------------------------------------------------------
+# Finalization
+# ---------------------------------------------------------------------------
+
+
+def _finalize_after_all(tmp_path, terminal_states):
+    review_dir = _init(tmp_path, providers=tuple(terminal_states.keys()))
+    results = []
+    for provider, terminal in terminal_states.items():
+        rc = {"finished": 0, "failed": 2, "timed_out": 124}[terminal]
+        rm.update_provider_state(
+            review_dir,
+            provider,
+            status=terminal,
+            returncode=rc,
+            finished_at=f"t-{provider}",
+        )
+        results.append(
+            {
+                "provider": provider,
+                "returncode": rc,
+                "raw": f"raw/{provider}.txt",
+                "started_at": "t",
+                "finished_at": f"t-{provider}",
+            }
+        )
+    rm.finalize_metadata(review_dir, results)
+    return review_dir
+
+
+def test_finalize_metadata_all_finished_top_status_finished(tmp_path):
+    review_dir = _finalize_after_all(tmp_path, {"glm": "finished", "deepseek": "finished"})
+    data = json.loads((review_dir / "metadata.json").read_text())
+    assert data["status"] == "finished"
+    assert data["finished_at"] is not None
+    assert len(data["results"]) == 2
+
+
+def test_finalize_metadata_any_failed_top_status_failed(tmp_path):
+    review_dir = _finalize_after_all(tmp_path, {"glm": "finished", "deepseek": "failed"})
+    data = json.loads((review_dir / "metadata.json").read_text())
+    assert data["status"] == "failed"
+
+
+def test_finalize_metadata_any_timed_out_top_status_timed_out(tmp_path):
+    review_dir = _finalize_after_all(
+        tmp_path, {"glm": "finished", "deepseek": "timed_out"}
+    )
+    data = json.loads((review_dir / "metadata.json").read_text())
+    # Precedence per plan: failed > timed_out > finished. No 'failed' here, so timed_out.
+    assert data["status"] == "timed_out"
+
+
+# ---------------------------------------------------------------------------
+# Atomic writes under contention
+# ---------------------------------------------------------------------------
+
+
+def test_update_provider_state_concurrent_writes_no_lost_update(tmp_path):
+    """Two threads update different providers concurrently. Both updates land."""
+    review_dir = _init(tmp_path, providers=("glm", "deepseek"))
+
+    def write_glm():
+        for i in range(20):
+            rm.update_provider_state(review_dir, "glm", status="running", pid=i)
+
+    def write_deepseek():
+        for i in range(20):
+            rm.update_provider_state(review_dir, "deepseek", status="running", pid=100 + i)
+
+    t1 = threading.Thread(target=write_glm)
+    t2 = threading.Thread(target=write_deepseek)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    data = json.loads((review_dir / "metadata.json").read_text())
+    # Both providers ended up in running state with their last pid visible.
+    # If RMW races silently, one provider's update_provider_state may have read
+    # stale data and overwritten the other's progress.
+    assert data["provider_states"]["glm"]["status"] == "running"
+    assert data["provider_states"]["deepseek"]["status"] == "running"
+    assert data["provider_states"]["glm"]["pid"] == 19
+    assert data["provider_states"]["deepseek"]["pid"] == 119
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility (CHG §Backward compatibility)
+# ---------------------------------------------------------------------------
+
+
+def test_backwardcompat_providers_remains_list(tmp_path):
+    review_dir = _init(tmp_path, providers=("glm", "deepseek"))
+    data = json.loads((review_dir / "metadata.json").read_text())
+    assert isinstance(data["providers"], list)
+    assert data["providers"] == ["glm", "deepseek"]
+
+
+def test_backwardcompat_results_finalized_entries_match_legacy_shape(tmp_path):
+    """After finalize, each results[i] has exactly the legacy keys per
+    scripts/codex.py:1732-1738 (run_provider's return dict)."""
+    review_dir = _finalize_after_all(tmp_path, {"glm": "finished", "deepseek": "finished"})
+    data = json.loads((review_dir / "metadata.json").read_text())
+    legacy_keys = {"provider", "returncode", "raw", "started_at", "finished_at"}
+    for entry in data["results"]:
+        assert legacy_keys.issubset(entry.keys())
+
+
+# ---------------------------------------------------------------------------
+# Read-side resilience (DS-P2#3)
+# ---------------------------------------------------------------------------
+
+
+def test_read_metadata_retries_once_on_json_decode_error(tmp_path):
+    """Simulate a mid-write read: write partial JSON, then valid JSON 50ms
+    later from a background thread. read_metadata returns the valid parse
+    without raising. With 100ms retry budget, this should succeed."""
+    review_dir = tmp_path / "20260516-120000-x"
+    review_dir.mkdir()
+    metadata_path = review_dir / "metadata.json"
+    metadata_path.write_text('{"status": "running"')  # truncated, invalid
+
+    def fix_after_delay():
+        time.sleep(0.05)
+        metadata_path.write_text('{"status": "running"}')
+
+    fixer = threading.Thread(target=fix_after_delay)
+    fixer.start()
+    try:
+        data = rm.read_metadata(review_dir)
+        assert data == {"status": "running"}
+    finally:
+        fixer.join()
+
+
+def test_read_metadata_raises_after_retry_exhausted(tmp_path):
+    """If the file stays invalid past the retry window, read_metadata raises
+    json.JSONDecodeError. The 100ms retry is for transient mid-writes, not
+    indefinite tolerance."""
+    review_dir = tmp_path / "20260516-120000-y"
+    review_dir.mkdir()
+    (review_dir / "metadata.json").write_text("not json at all")
+    with pytest.raises(json.JSONDecodeError):
+        rm.read_metadata(review_dir)

--- a/tests/test_review_metadata.py
+++ b/tests/test_review_metadata.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import json
 import sys
 import threading
-import time
 from pathlib import Path
 
 import pytest
@@ -100,7 +99,9 @@ def test_update_provider_state_queued_to_running_writes_pid_started_at(tmp_path)
     assert glm["started_at"] == "2026-05-16T12:00:01"
 
 
-def test_update_provider_state_running_to_finished_writes_returncode_finished_at(tmp_path):
+def test_update_provider_state_running_to_finished_writes_returncode_finished_at(
+    tmp_path,
+):
     review_dir = _init(tmp_path)
     rm.update_provider_state(review_dir, "glm", status="running", pid=99)
     rm.update_provider_state(
@@ -182,7 +183,9 @@ def _finalize_after_all(tmp_path, terminal_states):
 
 
 def test_finalize_metadata_all_finished_top_status_finished(tmp_path):
-    review_dir = _finalize_after_all(tmp_path, {"glm": "finished", "deepseek": "finished"})
+    review_dir = _finalize_after_all(
+        tmp_path, {"glm": "finished", "deepseek": "finished"}
+    )
     data = json.loads((review_dir / "metadata.json").read_text())
     assert data["status"] == "finished"
     assert data["finished_at"] is not None
@@ -190,7 +193,9 @@ def test_finalize_metadata_all_finished_top_status_finished(tmp_path):
 
 
 def test_finalize_metadata_any_failed_top_status_failed(tmp_path):
-    review_dir = _finalize_after_all(tmp_path, {"glm": "finished", "deepseek": "failed"})
+    review_dir = _finalize_after_all(
+        tmp_path, {"glm": "finished", "deepseek": "failed"}
+    )
     data = json.loads((review_dir / "metadata.json").read_text())
     assert data["status"] == "failed"
 
@@ -219,7 +224,9 @@ def test_update_provider_state_concurrent_writes_no_lost_update(tmp_path):
 
     def write_deepseek():
         for i in range(20):
-            rm.update_provider_state(review_dir, "deepseek", status="running", pid=100 + i)
+            rm.update_provider_state(
+                review_dir, "deepseek", status="running", pid=100 + i
+            )
 
     t1 = threading.Thread(target=write_glm)
     t2 = threading.Thread(target=write_deepseek)
@@ -253,7 +260,9 @@ def test_backwardcompat_providers_remains_list(tmp_path):
 def test_backwardcompat_results_finalized_entries_match_legacy_shape(tmp_path):
     """After finalize, each results[i] has exactly the legacy keys per
     scripts/codex.py:1732-1738 (run_provider's return dict)."""
-    review_dir = _finalize_after_all(tmp_path, {"glm": "finished", "deepseek": "finished"})
+    review_dir = _finalize_after_all(
+        tmp_path, {"glm": "finished", "deepseek": "finished"}
+    )
     data = json.loads((review_dir / "metadata.json").read_text())
     legacy_keys = {"provider", "returncode", "raw", "started_at", "finished_at"}
     for entry in data["results"]:
@@ -265,30 +274,29 @@ def test_backwardcompat_results_finalized_entries_match_legacy_shape(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_read_metadata_retries_once_on_json_decode_error(tmp_path):
-    """Simulate a mid-write read: write partial JSON, then atomically
-    replace with valid JSON 50ms later from a background thread.
-    read_metadata's retry-after-100ms catches the valid content."""
+def test_read_metadata_retries_once_on_json_decode_error(tmp_path, monkeypatch):
+    """Mock-based: read_text returns invalid JSON the first call, valid
+    JSON the second. Asserts read_metadata's retry kicks in. Avoids the
+    threading + sleep timing fragility of an end-to-end race simulation."""
     review_dir = tmp_path / "20260516-120000-x"
     review_dir.mkdir()
     metadata_path = review_dir / "metadata.json"
-    metadata_path.write_text('{"status": "running"')  # truncated, invalid
+    metadata_path.write_text('{"status": "running"}')  # valid on disk
 
-    def fix_after_delay():
-        time.sleep(0.05)
-        # Atomic replace so the second read never sees a torn write
-        # mid-replace — see init_metadata's _write_atomic() pattern.
-        tmp = metadata_path.with_suffix(".json.fixtmp")
-        tmp.write_text('{"status": "running"}')
-        tmp.replace(metadata_path)
+    original_read_text = Path.read_text
+    calls = {"n": 0}
 
-    fixer = threading.Thread(target=fix_after_delay)
-    fixer.start()
-    try:
-        data = rm.read_metadata(review_dir)
-        assert data == {"status": "running"}
-    finally:
-        fixer.join()
+    def fake_read_text(self, *args, **kwargs):
+        if self == metadata_path:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return '{"status": "running"'  # truncated, invalid
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    data = rm.read_metadata(review_dir)
+    assert data == {"status": "running"}
+    assert calls["n"] >= 2, "expected retry after JSONDecodeError"
 
 
 def test_read_metadata_raises_after_retry_exhausted(tmp_path):

--- a/tests/test_review_schema.py
+++ b/tests/test_review_schema.py
@@ -263,7 +263,9 @@ def test_a5_enriched_all_pass_full_snapshot(tmp_path):
         "This synthesis is deterministic. Inspect raw provider outputs for findings and conflicts.\n"
         "\n"
     )
-    assert content == expected, f"snapshot mismatch:\n---got---\n{content}\n---expected---\n{expected}"
+    assert content == expected, (
+        f"snapshot mismatch:\n---got---\n{content}\n---expected---\n{expected}"
+    )
 
 
 def test_a5_enriched_fix_status(tmp_path):

--- a/tests/test_status_latest.py
+++ b/tests/test_status_latest.py
@@ -684,6 +684,30 @@ def test_t20_status_renders_timed_out_provider_returncode_124(tmp_path):
     assert "rc=124" in out
 
 
+def test_t22_status_header_uses_metadata_started_at_when_results_empty(tmp_path):
+    """R3 fix (codex R2 P2): when M1 metadata exists with provider_states
+    but results=[], the header `started X ago` must derive from top-level
+    `started_at` instead of falling through to `?`. Previously read only
+    `results[].started_at`, which is empty mid-review."""
+    # Use a recent ISO timestamp so the elapsed math produces seconds-old
+    now = time.time()
+    started_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(now - 30))
+    md = _m1_metadata(
+        {
+            "glm": {"status": "running", "pid": 99, "started_at": started_iso},
+        }
+    )
+    md["started_at"] = started_iso
+    _make_review(tmp_path, metadata=md, write_synthesis=False)
+    result = _run_status(tmp_path)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # Header should NOT show "started ?" when top-level started_at is present
+    assert "started ?" not in out
+    # And should show some "ago" string (seconds, minutes, etc.)
+    assert "ago" in out
+
+
 def test_t21_status_pre_m1_metadata_falls_back_to_results_rendering(tmp_path):
     """Pre-M1 metadata (no provider_states key) still renders correctly via
     the legacy `Providers:` results section. T1-T15 already exercise this

--- a/tests/test_status_latest.py
+++ b/tests/test_status_latest.py
@@ -176,23 +176,28 @@ def test_t5_malformed_metadata_exits_nonzero(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_t6_empty_reviews_dir_exits_nonzero(tmp_path):
+def test_t6_empty_reviews_dir_exits_zero_with_no_reviews_found(tmp_path):
+    """TRN-2018 M1 behavior change (per CHG L154): empty reviews dir now
+    exits 0 with `no reviews found` on stdout (was: rc=1, stderr
+    "no reviews under <path>"). Flagged in CHANGELOG."""
     (tmp_path / ".trinity" / "reviews").mkdir(parents=True)
     result = _run_status(tmp_path)
-    assert result.returncode == 1
-    assert "no reviews under" in result.stderr
+    assert result.returncode == 0, result.stderr
+    assert "no reviews found" in result.stdout
 
 
 # ---------------------------------------------------------------------------
-# T7: missing .trinity/reviews/ entirely → exits rc=1 with "no reviews dir".
+# T7: missing .trinity/reviews/ entirely → TRN-2018 M1: exits rc=0 with
+# stdout "no reviews found" (was: rc=1, stderr "no reviews dir at <path>").
 # ---------------------------------------------------------------------------
 
 
-def test_t7_missing_reviews_dir_exits_nonzero(tmp_path):
-    # tmp_path has no .trinity/ subdirectory at all.
+def test_t7_missing_reviews_dir_exits_zero_with_no_reviews_found(tmp_path):
+    """TRN-2018 M1 behavior change (per CHG L154): missing reviews dir now
+    exits 0 with `no reviews found` on stdout."""
     result = _run_status(tmp_path)
-    assert result.returncode == 1
-    assert "no reviews dir" in result.stderr
+    assert result.returncode == 0, result.stderr
+    assert "no reviews found" in result.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -532,9 +537,7 @@ def test_t15_same_second_reviews_use_mtime_tiebreak(tmp_path):
         json.dumps(_basic_metadata({"deepseek": 0}))
     )
     (review_z / "synthesis.md").write_text("# z\n")
-    (review_a / "metadata.json").write_text(
-        json.dumps(_basic_metadata({"glm": 0}))
-    )
+    (review_a / "metadata.json").write_text(json.dumps(_basic_metadata({"glm": 0})))
     (review_a / "synthesis.md").write_text("# a\n")
 
     # Force `-a` to have a strictly newer mtime than `-z`.
@@ -549,3 +552,150 @@ def test_t15_same_second_reviews_use_mtime_tiebreak(tmp_path):
     # (later in lex order).
     assert "20260508-120000-a" in out
     assert "20260508-120000-z" not in out
+
+
+# ---------------------------------------------------------------------------
+# TRN-2018 M1: live provider_states rendering
+# ---------------------------------------------------------------------------
+
+
+def _m1_metadata(provider_states: dict, *, results=None, status="running") -> dict:
+    """Build an M1-shape metadata.json: top-level status + provider_states
+    block. results defaults to [] (mid-run state)."""
+    return {
+        "review_id": "20260516-120000-rules",
+        "review_dir": "/fake/.trinity/reviews/20260516-120000-rules",
+        "status": status,
+        "started_at": "2026-05-16T12:00:00",
+        "finished_at": None,
+        "scope": "rules/",
+        "root": "/fake",
+        "providers": list(provider_states.keys()),
+        "preset": {
+            "requested": "review",
+            "resolved": "review",
+            "source": "explicit",
+            "task_type": "review",
+            "skipped_optional_providers": [],
+        },
+        "input": {"mode": "working-tree", "scope": "rules/"},
+        "results": list(results or []),
+        "provider_states": provider_states,
+    }
+
+
+def test_t16_status_renders_queued_providers_when_only_init_metadata(tmp_path):
+    """init_metadata writes all providers queued before run_providers.
+    Status output during this window must show each provider as queued."""
+    md = _m1_metadata(
+        {
+            "glm": {"status": "queued"},
+            "deepseek": {"status": "queued"},
+        }
+    )
+    _make_review(tmp_path, metadata=md, write_synthesis=False)
+    result = _run_status(tmp_path)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "Live state:" in out
+    assert "glm" in out and "queued" in out
+    # Both providers listed
+    glm_idx = out.index("glm")
+    ds_idx = out.index("deepseek")
+    assert glm_idx >= 0 and ds_idx >= 0
+
+
+def test_t17_status_renders_running_provider_with_pid(tmp_path):
+    md = _m1_metadata(
+        {
+            "glm": {
+                "status": "running",
+                "pid": 12345,
+                "started_at": "2026-05-16T12:00:01",
+            },
+            "deepseek": {"status": "queued"},
+        }
+    )
+    _make_review(tmp_path, metadata=md, write_synthesis=False)
+    result = _run_status(tmp_path)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # glm's line should contain its state, pid, and provider name
+    assert "running" in out
+    assert "pid=12345" in out
+
+
+def test_t18_status_renders_finished_provider_with_returncode(tmp_path):
+    md = _m1_metadata(
+        {
+            "glm": {
+                "status": "finished",
+                "pid": 12345,
+                "started_at": "2026-05-16T12:00:01",
+                "finished_at": "2026-05-16T12:03:08",
+                "returncode": 0,
+            },
+        },
+        status="finished",
+    )
+    _make_review(tmp_path, metadata=md, write_synthesis=False)
+    result = _run_status(tmp_path)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "finished" in out
+    assert "rc=0" in out
+
+
+def test_t19_status_renders_failed_provider_returncode_nonzero(tmp_path):
+    md = _m1_metadata(
+        {
+            "glm": {
+                "status": "failed",
+                "returncode": 2,
+                "finished_at": "2026-05-16T12:00:05",
+            },
+        },
+        status="failed",
+    )
+    _make_review(tmp_path, metadata=md, write_synthesis=False)
+    result = _run_status(tmp_path)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "failed" in out
+    assert "rc=2" in out
+
+
+def test_t20_status_renders_timed_out_provider_returncode_124(tmp_path):
+    md = _m1_metadata(
+        {
+            "glm": {
+                "status": "timed_out",
+                "returncode": 124,
+                "finished_at": "2026-05-16T12:00:10",
+            },
+        },
+        status="timed_out",
+    )
+    _make_review(tmp_path, metadata=md, write_synthesis=False)
+    result = _run_status(tmp_path)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "timed_out" in out
+    assert "rc=124" in out
+
+
+def test_t21_status_pre_m1_metadata_falls_back_to_results_rendering(tmp_path):
+    """Pre-M1 metadata (no provider_states key) still renders correctly via
+    the legacy `Providers:` results section. T1-T15 already exercise this
+    code path; this test is the explicit cross-reference."""
+    md = _basic_metadata({"glm": 0, "deepseek": 0})
+    assert "provider_states" not in md
+    _make_review(tmp_path, metadata=md)
+    result = _run_status(tmp_path)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # Existing legacy section still renders results.
+    assert "Providers:" in out
+    assert "Status: completed" in out
+    # No live-state section when M1 metadata absent.
+    assert "Live state:" not in out

--- a/tests/test_status_latest.py
+++ b/tests/test_status_latest.py
@@ -708,6 +708,67 @@ def test_t22_status_header_uses_metadata_started_at_when_results_empty(tmp_path)
     assert "ago" in out
 
 
+def test_t23_status_partial_results_with_running_top_status_says_running(tmp_path):
+    """R4 fix (codex R3 P2 first finding): when M1's top-level status is
+    `running` and one provider has appended a successful result (rc=0)
+    while another is still running, the final `Status:` line must say
+    `running` — NOT `completed` derived from the all-zero partial results."""
+    md = _m1_metadata(
+        {
+            "glm": {
+                "status": "finished",
+                "pid": 1,
+                "started_at": "2026-05-16T12:00:01",
+                "finished_at": "2026-05-16T12:00:30",
+                "returncode": 0,
+            },
+            "deepseek": {
+                "status": "running",
+                "pid": 2,
+                "started_at": "2026-05-16T12:00:02",
+            },
+        },
+        status="running",  # top-level still running (one provider still going)
+        results=[
+            {
+                "provider": "glm",
+                "returncode": 0,
+                "raw": "raw/glm.txt",
+                "started_at": "2026-05-16T12:00:01",
+                "finished_at": "2026-05-16T12:00:30",
+            }
+        ],
+    )
+    _make_review(tmp_path, metadata=md, write_synthesis=False)
+    result = _run_status(tmp_path)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "Status: running" in out, out
+    assert "Status: completed" not in out
+
+
+def test_t24_status_running_provider_shows_elapsed_with_now_as_end(tmp_path):
+    """R4 fix (codex R3 P2 second finding): a running provider has no
+    finished_at; the elapsed-time column must use `now` as the end time
+    so the live row shows elapsed-so-far instead of being blank."""
+    # started_at set ~10s in the past so the rendered elapsed is non-trivial
+    started = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(time.time() - 10))
+    md = _m1_metadata(
+        {
+            "glm": {"status": "running", "pid": 99, "started_at": started},
+        }
+    )
+    md["started_at"] = started
+    _make_review(tmp_path, metadata=md, write_synthesis=False)
+    result = _run_status(tmp_path)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    # Live-state row for running provider should include `elapsed <duration>`
+    assert "Live state:" in out
+    assert "running" in out
+    assert "elapsed" in out, f"running provider row missing elapsed time: {out!r}"
+
+
 def test_t21_status_pre_m1_metadata_falls_back_to_results_rendering(tmp_path):
     """Pre-M1 metadata (no provider_states key) still renders correctly via
     the legacy `Providers:` results section. T1-T15 already exercise this


### PR DESCRIPTION
## Summary

Ships **Milestone 1** of CHG-2018 (Review Status Observability). Eliminates the "single opaque blocking process" view of `trinity review` by writing `metadata.json` at init time, updating it as each provider transitions through queued → running → finished/failed/timed_out, and streaming stdout/stderr to `logs/<provider>.std{out,err}.log` in real time. The existing `raw/<provider>.txt` artifact is preserved (composed from the logs post-completion).

M2 (events.jsonl, heartbeat polling, stalled detection), M3 (`--detach`, `--watch`, `trinity wait`), and M4 (`--fail-on-stall`, cleanup) are explicitly **deferred** to follow-on sessions.

## What changed

**New helpers** in `scripts/_review_metadata.py`:
- `init_metadata(...)` — writes initial `metadata.json` with all providers in `queued`, top-level `status=running`.
- `update_provider_state(review_dir, provider, **fields)` — read-modify-write under per-review-dir `threading.Lock`. Required because `run_providers` (codex.py:1802) uses `ThreadPoolExecutor`; without locking, concurrent state updates race and silently lose updates.
- `finalize_metadata(review_dir, results)` — sets `finished_at`, appends `results`, recomputes top-level `status` from `provider_states` (precedence: failed > timed_out > finished).
- `read_metadata(review_dir)` — JSON load with single 100ms retry to tolerate transient mid-write reads.

**Refactored** `scripts/codex.py:run_provider` (codex.py:1701-1782):
- `Popen(stdout=PIPE)+communicate(timeout=...)` → `Popen(stdout=open(path, 'w', buffering=1))` + `popen.wait(timeout=...)`.
- State-machine outcome tuple keeps the file-handle `with` block linear and lets `raw_path` get composed after handles close (so disk reads see all flushed content).
- All existing semantics preserved: TERM/KILL escalation via `terminate_process_group`, returncode 124 on timeout, returncode 127 on FileNotFoundError, ActiveProcessRegistry.add/remove (L1724/L1782).

**Refactored** `_print_review_summary` (codex.py:2461):
- Additive `Live state:` section above the legacy `Providers:` section when `provider_states` is present.
- Pre-M1 metadata lacks `provider_states`; rendering falls through to the unchanged legacy path so all 18 existing T1-T15 status tests continue passing as regression guards.

**Behavior change flagged**: `cmd_status` (codex.py:2568) — missing/empty `.trinity/reviews/` now exits **0** with `no reviews found` on **stdout** (was: exit 1 with stderr message). Per CHG-2018 §Status Command contract. T6/T7 tests updated accordingly.

## Test coverage

| File | Tests | Coverage |
|---|---|---|
| `tests/test_review_metadata.py` (new) | 17 | init / state transitions / finalize / atomic-writes-under-contention / backward-compat / read retry |
| `tests/test_provider_logs.py` (new) | 7 | incremental log visibility / timeout log persistence / FileNotFound path / raw format preservation / registry cleanup on both exit paths |
| `tests/test_status_latest.py` | 18 → 24 | 18 existing as regression guards + 6 new (T16-T21) for live state rendering |
| `tests/fixtures/fake_provider_*.sh` (new) | 4 fixtures | quick, partial (1-line + 1s + 1 line), hang (sleep 999), stderr |

Total: 401 passed (up from 371 pre-Phase C).

## Plan-review verdict

Phase C execution plan cleared trinity fast-review tier:
- **trinity-glm: PASS 9.58/10** (zero P1 blockers, 4 P2 advisories all in-flight)
- **trinity-deepseek: PASS 9.50/10** (exactly at strict gate)

Both reviewers cross-checked file:line citations against the actual `scripts/codex.py` and verified the CHG contract. The v1 plan was scored FIX 8.53 / 8.10 with 2 P1 blockers; v2 addressed every finding (mapping table in `/tmp/trn-2018-phase-c-plan-v2.md`).

## TRN-1008 phase notes

- **§4 plan-review**: PASS (see above; tracked in CHG Execution Log)
- **§5 dispatch**: orchestrator implementation (single-author refactor, not worker-dispatched)
- **§6 verify**: pytest tests/ → 401 passed; ruff check + format clean; af validate clean; install-codex smoke clean
- **§7 PR open**: this PR
- **§8 iterate**: codex-bot review to be triggered after PR open

## Behavior changes / migration notes

1. **Empty-case exit-0 change** (`cmd_status`): downstream callers that check `trinity status` exit code for empty-reviews-dir condition will now see 0 instead of 1. The stdout/stderr surface also flipped (was stderr "no reviews under/dir at <path>", now stdout "no reviews found"). Flagged in CHANGELOG. No known internal callers; external consumer should re-check.
2. **Interrupted reviews now leave both metadata.json and incomplete.json** (was: incomplete.json only). `_print_review_summary` continues to surface `incomplete.json`'s status as the top-level verdict, so user-visible status output is unchanged on interrupt.

## Test plan

- [x] `.venv/bin/pytest tests/` → 401 passed
- [x] `.venv/bin/ruff check + format --check` → clean
- [x] `af validate --root .` → 145 documents, 0 issues
- [x] `make install-codex` → installs cleanly; `trinity --version` → 3.2.0
- [x] Smoke: `trinity status` on empty `.trinity/` → exits 0 with `no reviews found`
- [x] Smoke: `trinity status` on synthetic M1 metadata → renders `Live state:` section with running pid + queued
- [ ] codex-bot review on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)