### PR TITLE
Keep Test checks green for docs-only PRs (Closes #149)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,32 +3,7 @@ name: Test
 on:
   push:
     branches: [main]
-    # Skip pure-docs pushes — see paths-ignore rationale below.
-    paths-ignore:
-      - 'rules/**'
-      - '*.md'
   pull_request:
-    # Skip CI on pure-docs PRs (status flips, README edits, CHANGELOG, TRN-PRP/PLN/CHG
-    # markdown). Mixed PRs that also touch Makefile/scripts/tests/.github still trigger.
-    # Trinity panel decision matrix (2026-05-07): unanimous Option A, weighted 8.75/8.37/6.62
-    # against B/B+A/C variants. Saves ~6 min macOS wall-clock on the ~70% of PRs that
-    # are pure-docs without losing the cross-platform parity gate on code PRs.
-    #
-    # Re-evaluate the glob if `rules/` ever gains executable content (hooks, scripts,
-    # `af validate` in CI) — currently all `.md`, so safe.
-    #
-    # FOOT-GUN: if branch protection on `main` is ever configured to require the
-    # `Test (ubuntu-latest)` / `Test (macos-latest)` checks, this `paths-ignore`
-    # makes pure-docs PRs UNMERGEABLE — the skipped checks stay `Pending` forever.
-    # As of 2026-05-07 no branch protection / required checks are configured on main
-    # (only `protect-release-tags` ruleset, which targets tags), so this works today.
-    # If you add required checks later, migrate to a job-level `if:` skip pattern so
-    # the matrix always runs and reports success. See GitHub's docs on "skipping
-    # workflow runs" + the community pattern for required checks on path-filtered
-    # workflows.
-    paths-ignore:
-      - 'rules/**'
-      - '*.md'
 
 permissions:
   contents: read
@@ -50,14 +25,66 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect test-relevant changes
+        id: changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          changed_files="${RUNNER_TEMP}/changed-files.txt"
+          zero_sha="0000000000000000000000000000000000000000"
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if ! git rev-parse --verify HEAD^1 >/dev/null 2>&1; then
+              echo "run_tests=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            git diff --name-only HEAD^1 HEAD > "$changed_files"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "$zero_sha" ]; then
+              echo "run_tests=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" > "$changed_files"
+          else
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          run_tests=false
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            case "$path" in
+              rules/*) ;;
+              */*) run_tests=true; break ;;
+              *.md) ;;
+              *) run_tests=true; break ;;
+            esac
+          done < "$changed_files"
+
+          echo "run_tests=$run_tests" >> "$GITHUB_OUTPUT"
+      - name: No test-relevant changes
+        if: steps.changes.outputs.run_tests != 'true'
+        run: echo "No test-relevant changes; expensive checks skipped."
       - uses: actions/setup-python@v5
+        if: steps.changes.outputs.run_tests == 'true'
         with:
           python-version: '3.11'
       - name: Install dev dependencies
+        if: steps.changes.outputs.run_tests == 'true'
         run: make setup
       - name: Lint
+        if: steps.changes.outputs.run_tests == 'true'
         run: make lint
       - name: Run tests
+        if: steps.changes.outputs.run_tests == 'true'
         run: make test
       - name: Run coverage
+        if: steps.changes.outputs.run_tests == 'true'
         run: make coverage

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -15,6 +15,7 @@
 # T10 One-click release path — tag_name optional, main-only guard, derive-from-VERSION logic
 # T11 Multi-model review fixes — concurrency key, 2-job verify/publish split, no env-injection in run
 # T13 PR CI lint gate — test.yml runs make lint on every OS matrix leg
+# T14 Required-check-safe docs skip — test.yml always reports matrix checks
 
 set -e
 
@@ -234,6 +235,20 @@ check "test workflow lint runs after setup before tests" bash -c '
 '
 check "Makefile lint runs ruff check" grep -qF '.venv/bin/ruff check scripts/ tests/' Makefile
 check "Makefile lint runs ruff format check" grep -qF '.venv/bin/ruff format --check scripts/ tests/' Makefile
+
+echo "-- T14: required-check-safe docs skip"
+check_neg "test workflow has no paths-ignore" grep -qF 'paths-ignore:' "$TEST_WORKFLOW"
+check "test workflow fetches history for diff detection" grep -qF 'fetch-depth: 0' "$TEST_WORKFLOW"
+check "test workflow detects test-relevant changes" grep -qF 'name: Detect test-relevant changes' "$TEST_WORKFLOW"
+check "test workflow has docs-only success step" grep -qF 'name: No test-relevant changes' "$TEST_WORKFLOW"
+check "test workflow docs-only step runs when expensive checks are off" grep -qF "if: steps.changes.outputs.run_tests != 'true'" "$TEST_WORKFLOW"
+check "test workflow gates every expensive step" bash -c '
+  gate_count=$(grep -cF "if: steps.changes.outputs.run_tests == '\''true'\''" .github/workflows/test.yml)
+  [ "$gate_count" -ge 5 ]
+'
+check "test workflow preserves rules docs skip" grep -qF 'rules/*) ;;' "$TEST_WORKFLOW"
+check "test workflow preserves root markdown skip" grep -qF '*.md) ;;' "$TEST_WORKFLOW"
+check "test workflow treats non-rules subdirs as test-relevant" grep -qF '*/*) run_tests=true; break ;;' "$TEST_WORKFLOW"
 
 echo "-- T11: multi-model review fixes (concurrency, 2-job split, env-mapping)"
 # Concurrency key prevents two release runs at once.


### PR DESCRIPTION
## Summary
- Remove workflow-level `paths-ignore` from `test.yml` so PR checks are always created.
- Add a matrix-local change detector that skips expensive setup/lint/test/coverage for `rules/**` and root `*.md` only.
- Add regression coverage so `paths-ignore` cannot return silently.

## Why
Required Test checks would stay pending forever on pure-docs PRs when workflow-level `paths-ignore` prevents the workflow from starting. This keeps the `ubuntu-latest` and `macos-latest` jobs green while preserving the existing docs-only cost savings.

## Surfaces
- `.github/workflows/test.yml`
- `tests/test_release_workflow.sh`

## Test plan
- `bash tests/test_release_workflow.sh`
- `make lint`
- `make test`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "yaml ok"'`\n\n## Files\n- `.github/workflows/test.yml`\n- `tests/test_release_workflow.sh`\n\nCloses #149.