### PR TITLE
[CANARY] Verify required checks block failing tests

### DIFF
--- a/tests/test_branch_protection_canary.py
+++ b/tests/test_branch_protection_canary.py
@@ -1,0 +1,2 @@
+def test_branch_protection_canary_fails():
+    assert False


### PR DESCRIPTION
Canary for frankyxhl/trinity#150.

Expected result:
- `ubuntu-latest` and `macos-latest` run because this touches `tests/`.
- `make test` fails intentionally.
- Branch protection blocks merge because required checks fail.

This PR is temporary and must not be merged.