### PR TITLE
[CANARY] Verify docs-only PR gets green Test checks

### DIFF
--- a/CANARY-150-DOCS.md
+++ b/CANARY-150-DOCS.md
@@ -1,0 +1,3 @@
+# Branch Protection Canary
+
+Temporary docs-only change for verifying required Test checks in issue #150.


### PR DESCRIPTION
Canary for frankyxhl/trinity#150.

Expected result:
- `ubuntu-latest` and `macos-latest` checks are created.
- The job-level docs skip runs the lightweight no-op path.
- Both required checks report success instead of pending/skipped.

This PR is temporary and must not be merged.