### PR TITLE
Add Dependabot config for uv and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- Dependabot version updates for the root uv lockfile and GitHub
+  Actions workflows now run weekly from `.github/dependabot.yml`. Closes #152.
 - TRN-2018 M1 — review status observability. `trinity status` now renders a
   live `Live state:` section when reading M1 metadata, showing each provider
   in `queued` / `running` / `finished` / `failed` / `timed_out` state with

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test:           ## Run all tests (TRN-1001 + TRN-2004 build tests + TRN-2006 rel
 	$(MAKE) verify-built
 	.venv/bin/pytest tests/ -v
 	bash tests/test_build_providers.sh
+	bash tests/test_dependabot_config.sh
 	bash tests/test_release_workflow.sh
 	bash tests/test_install_sh.sh
 	bash tests/test_make_bump.sh

--- a/tests/test_dependabot_config.sh
+++ b/tests/test_dependabot_config.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# tests/test_dependabot_config.sh
+#
+# Tests for .github/dependabot.yml per #152.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+CONFIG=".github/dependabot.yml"
+
+PASS=0
+FAIL=0
+FAILS=()
+
+check() {
+  local name="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "  ok  %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILS+=("$name")
+    printf "  FAIL %s\n" "$name"
+  fi
+}
+
+echo "== #152: Dependabot config tests =="
+
+check "dependabot config exists" test -f "$CONFIG"
+check "dependabot config uses version 2" grep -qE '^version: 2$' "$CONFIG"
+check "dependabot config has updates list" grep -qE '^updates:$' "$CONFIG"
+
+check "uv ecosystem configured" grep -qF 'package-ecosystem: "uv"' "$CONFIG"
+check "github-actions ecosystem configured" grep -qF 'package-ecosystem: "github-actions"' "$CONFIG"
+
+check "uv uses root directory" bash -c '
+  awk "/package-ecosystem: \"uv\"/{f=1; next} f && /package-ecosystem:/{exit} f && /directory: \"\\/\"/{found=1} END{exit !found}" .github/dependabot.yml
+'
+check "github-actions uses root directory" bash -c '
+  awk "/package-ecosystem: \"github-actions\"/{f=1; next} f && /package-ecosystem:/{exit} f && /directory: \"\\/\"/{found=1} END{exit !found}" .github/dependabot.yml
+'
+
+check "uv schedule is weekly" bash -c '
+  awk "/package-ecosystem: \"uv\"/{f=1; next} f && /package-ecosystem:/{exit} f && /interval: \"weekly\"/{found=1} END{exit !found}" .github/dependabot.yml
+'
+check "github-actions schedule is weekly" bash -c '
+  awk "/package-ecosystem: \"github-actions\"/{f=1; next} f && /package-ecosystem:/{exit} f && /interval: \"weekly\"/{found=1} END{exit !found}" .github/dependabot.yml
+'
+
+echo
+echo "=== Result ==="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  printf "\nFailures:\n"
+  printf "  - %s\n" "${FAILS[@]}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly `uv` updates for the root `uv.lock` / `pyproject.toml` dependency surface.
- Add weekly `github-actions` update checks for workflow action versions.
- Add a focused shell test wired into `make test` so the Dependabot config shape stays covered.

## Why
Trinity now installs dev dependencies through `uv sync --locked --dev`, with `uv.lock` as the canonical lock and `requirements-dev.txt` as the generated pip fallback. GitHub and uv both document `package-ecosystem: "uv"` for Dependabot updates to `uv.lock`, so the Python entry uses `uv` rather than `pip`.

## Test Plan
- `bash tests/test_dependabot_config.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot yaml ok"'`
- `make setup`
- `make lint`
- `make test`
- `make coverage`
- `git diff --check`

Closes #152
