### PR TITLE
Add CodeQL Python code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 - Dependabot version updates for the root uv lockfile and GitHub
   Actions workflows now run weekly from `.github/dependabot.yml`. Closes #152.
+- CodeQL code scanning now runs for Python on pull requests and pushes
+  targeting `main`, on a weekly schedule, and by manual dispatch. Closes #153.
 - TRN-2018 M1 — review status observability. `trinity status` now renders a
   live `Live state:` section when reading M1 metadata, showing each provider
   in `queued` / `running` / `finished` / `failed` / `timed_out` state with

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,12 @@ install-hooks:  ## Install git pre-commit hook to run generated-artifact checks 
 	@chmod +x .git/hooks/pre-commit
 	@echo "Installed pre-commit hook → .git/hooks/pre-commit"
 
-test:           ## Run all tests (TRN-1001 + TRN-2004 build tests + TRN-2006 release workflow tests)
+test:           ## Run pytest and shell regression tests
 	$(MAKE) verify-built
 	.venv/bin/pytest tests/ -v
 	bash tests/test_build_providers.sh
 	bash tests/test_dependabot_config.sh
+	bash tests/test_codeql_workflow.sh
 	bash tests/test_release_workflow.sh
 	bash tests/test_install_sh.sh
 	bash tests/test_make_bump.sh

--- a/tests/test_codeql_workflow.sh
+++ b/tests/test_codeql_workflow.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# tests/test_codeql_workflow.sh
+#
+# Tests for .github/workflows/codeql.yml per #153.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORKFLOW=".github/workflows/codeql.yml"
+
+PASS=0
+FAIL=0
+FAILS=()
+
+check() {
+  local name="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "  ok  %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILS+=("$name")
+    printf "  FAIL %s\n" "$name"
+  fi
+}
+
+echo "== #153: CodeQL workflow tests =="
+
+check "CodeQL workflow exists" test -f "$WORKFLOW"
+check "workflow name is CodeQL" grep -qE '^name: CodeQL$' "$WORKFLOW"
+check "push trigger present" grep -qE '^  push:$' "$WORKFLOW"
+check "push targets main" grep -qF 'branches: [main]' "$WORKFLOW"
+check "pull_request trigger present" grep -qE '^  pull_request:$' "$WORKFLOW"
+check "pull_request targets main" grep -qF 'branches: [main]' "$WORKFLOW"
+check "weekly schedule present" grep -qE '^  schedule:$' "$WORKFLOW"
+check "schedule uses weekly cron" grep -qF "cron: '17 4 * * 1'" "$WORKFLOW"
+check "manual dispatch present" grep -qE '^  workflow_dispatch:$' "$WORKFLOW"
+
+check "global contents read permission" grep -qE '^  contents: read$' "$WORKFLOW"
+check "global security-events write permission" grep -qE '^  security-events: write$' "$WORKFLOW"
+
+check "concurrency group set" grep -qF 'group: codeql-${{ github.event_name }}-${{ github.ref }}' "$WORKFLOW"
+check "concurrency cancels stale runs" grep -qF 'cancel-in-progress: true' "$WORKFLOW"
+check "analyze job present" grep -qE '^  analyze:$' "$WORKFLOW"
+check "analyze runs on ubuntu latest" grep -qF 'runs-on: ubuntu-latest' "$WORKFLOW"
+check "analyze has timeout" grep -qF 'timeout-minutes: 15' "$WORKFLOW"
+check "strategy fail-fast false" grep -qF 'fail-fast: false' "$WORKFLOW"
+check "python language configured" grep -qF 'language: python' "$WORKFLOW"
+check "python build-mode none" grep -qF 'build-mode: none' "$WORKFLOW"
+
+check "checkout uses pinned major" grep -qF 'uses: actions/checkout@v6' "$WORKFLOW"
+check "CodeQL init uses pinned major" grep -qF 'uses: github/codeql-action/init@v4' "$WORKFLOW"
+check "CodeQL analyze uses pinned major" grep -qF 'uses: github/codeql-action/analyze@v4' "$WORKFLOW"
+check "CodeQL init receives language" grep -qF 'languages: ${{ matrix.language }}' "$WORKFLOW"
+check "CodeQL init receives build mode" grep -qF 'build-mode: ${{ matrix.build-mode }}' "$WORKFLOW"
+check "CodeQL analyze category set" grep -qF 'category: "/language:${{ matrix.language }}"' "$WORKFLOW"
+
+echo
+echo "=== Result ==="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  printf "\nFailures:\n"
+  printf "  - %s\n" "${FAILS[@]}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `.github/workflows/codeql.yml` for Python CodeQL scanning on PRs to `main`, pushes to `main`, weekly scheduled scans, and manual dispatch.
- Use least-privilege CodeQL permissions, Python `build-mode: none`, concurrency cancellation, and a 15-minute job timeout.
- Add `tests/test_codeql_workflow.sh` and wire it into `make test` so the workflow shape stays covered.
- Rebased on top of #152 so the Dependabot and CodeQL shell regression tests both run from `make test`.

## Why
Trinity handles provider orchestration and token-adjacent code but had no code-scanning workflow. This adds baseline SAST coverage through GitHub CodeQL and refreshes the default-branch baseline on each merge to `main`.

## Validation
- `trinity doctor --providers glm,minimax,deepseek`
- `bash tests/test_codeql_workflow.sh && bash tests/test_dependabot_config.sh && git diff --check`
- `make lint && make test && make coverage && git diff --check`
- `trinity review --providers glm,minimax,deepseek --base origin/main --head HEAD --scope '#153 CodeQL Python scanning workflow after Codex baseline fix'` → 3/3 PASS, 0 FIX, 0 FAIL

## Note
The CodeQL workflow file must land on the default branch before scheduled scans and default-branch Security tab results can be observed. This PR verifies the workflow shape locally and in PR checks; after merge, `push` to `main` should refresh the baseline automatically.

Closes #153