### PR TITLE
Bump release artifact actions as a matched pair + ref-agnostic release test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
           echo "Extracted $(wc -l < release-notes.md) lines from CHANGELOG"
 
       - name: Upload release notes artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: release-notes-${{ steps.tag.outputs.tag }}
           path: release-notes.md
@@ -221,7 +221,7 @@ jobs:
           token: ${{ secrets.RELEASE_TAG_PAT }}
 
       - name: Download release notes artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: release-notes-${{ needs.verify.outputs.tag }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@
   rationale and surfaces.
 
 ### Changed
+- Release workflow artifact actions bumped as a matched pair:
+  `upload-artifact@v7` + `download-artifact@v8` (kept on the same v4+ backend
+  so the verify→publish release-notes handoff stays compatible). The
+  `test_release_workflow.sh` action-version assertions are now ref-agnostic
+  (present + pinned, any `@vN` or `@<sha>`) instead of hard-coding exact
+  versions, so Dependabot action bumps and #163 SHA-pinning no longer fail CI.
+  Supersedes #176 and #177.
 - Dev dependency setup now resolves from committed lock artifacts:
   `uv.lock` is the canonical lock, `requirements-dev.txt` is the pinned pip
   fallback, and `make setup` installs via `uv sync --locked --dev` when uv is

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -149,9 +149,13 @@ done
 echo "-- T5: no third-party publish actions"
 check_neg "no softprops/action-gh-release" grep -q 'softprops/action-gh-release' "$WORKFLOW"
 check     "uses gh release create"         grep -q 'gh release create' "$WORKFLOW"
-check     "checkout pinned to v6"          grep -q 'actions/checkout@v6' "$WORKFLOW"
-check     "upload-artifact pinned to v5"   grep -q 'actions/upload-artifact@v5' "$WORKFLOW"
-check     "setup-uv pinned to v6"          grep -q 'astral-sh/setup-uv@v6' "$WORKFLOW"
+# Assert each action is present and pinned to a ref (a version tag OR a commit
+# SHA), not a specific version string. Hard-pinning the exact @vN here made
+# every Dependabot action bump fail CI and would also break #163 (pin to SHA).
+check     "checkout present + pinned"          grep -qE 'actions/checkout@[^ ]+' "$WORKFLOW"
+check     "upload-artifact present + pinned"   grep -qE 'actions/upload-artifact@[^ ]+' "$WORKFLOW"
+check     "download-artifact present + pinned" grep -qE 'actions/download-artifact@[^ ]+' "$WORKFLOW"
+check     "setup-uv present + pinned"          grep -qE 'astral-sh/setup-uv@[^ ]+' "$WORKFLOW"
 
 echo "-- T6: semver regex acceptance"
 check "accepts v1.2.3"        valid_semver_tag "v1.2.3"


### PR DESCRIPTION
## Summary
- Bump `release.yml` artifact actions **together**: `upload-artifact@v5→v7` and `download-artifact@v5→v8`.
- Make `tests/test_release_workflow.sh` action-version assertions **ref-agnostic** (present + pinned to any `@vN` or `@<sha>`), and add a `download-artifact` pair assertion.

## Why
Dependabot opened these as two separate PRs (#176 download→v8, #177 upload→v7). Merging either alone **desyncs the upload/download pair** in `release.yml`, and PR CI never runs `release.yml` (it only fires on tag push), so a broken verify→publish release-notes handoff would surface only at release time. Bumping both to their latest majors keeps them on the same v4+ artifact backend.

`#177` also failed CI for a benign reason: `test_release_workflow.sh` hard-coded `actions/upload-artifact@v5`. That pattern makes **every** Dependabot action bump fail CI and would also break #163 (pin Actions to SHAs). The asserts now check the action is present and pinned to *some* ref, version-agnostic.

## Verification
- `bash tests/test_release_workflow.sh` → 138 passed, 0 failed (run locally on this branch)
- Artifact pair confirmed: `upload-artifact@v7`, `download-artifact@v8`
- End-to-end artifact handoff is exercised only by the Release workflow on the next tag push (not by PR CI).

Supersedes #176, #177.