### PR TITLE
Add Gitleaks secret scanning workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,31 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Scan for committed secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,27 @@
+title = "Trinity Gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "trinity-provider-api-key-assignment"
+description = "Provider API key or token assignment in Trinity source"
+regex = '''(?i)\b(?:DEEPSEEK|OPENROUTER|OPENAI|ANTHROPIC|GOOGLE|GEMINI|GLM|MINIMAX|TRINITY|VOYAGER|MCP)[A-Z0-9_]*(?:API_KEY|AUTH_TOKEN|TOKEN|SECRET|BEARER)[A-Z0-9_]*\b\s*[:=]\s*["']?([A-Za-z0-9][A-Za-z0-9._~+/\-=]{23,})["']?'''
+secretGroup = 1
+keywords = [
+  "API_KEY",
+  "AUTH_TOKEN",
+  "TOKEN",
+  "SECRET",
+  "BEARER",
+]
+
+[[rules]]
+id = "trinity-bearer-header"
+description = "Bearer token embedded in source"
+regex = '''(?i)\bAuthorization\s*:\s*Bearer\s+([A-Za-z0-9][A-Za-z0-9._~+/\-=]{23,})'''
+secretGroup = 1
+keywords = [
+  "Authorization",
+  "Bearer",
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   Actions workflows now run weekly from `.github/dependabot.yml`. Closes #152.
 - CodeQL code scanning now runs for Python on pull requests and pushes
   targeting `main`, on a weekly schedule, and by manual dispatch. Closes #153.
+- Secret scanning now runs Gitleaks on pull requests, pushes to `main`, and
+  manual dispatch, with Trinity-specific rules for provider API keys and bearer
+  tokens. Closes #154.
 - TRN-2018 M1 — review status observability. `trinity status` now renders a
   live `Live state:` section when reading M1 metadata, showing each provider
   in `queued` / `running` / `finished` / `failed` / `timed_out` state with

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test:           ## Run pytest and shell regression tests
 	bash tests/test_build_providers.sh
 	bash tests/test_dependabot_config.sh
 	bash tests/test_codeql_workflow.sh
+	bash tests/test_gitleaks_config.sh
 	bash tests/test_release_workflow.sh
 	bash tests/test_install_sh.sh
 	bash tests/test_make_bump.sh

--- a/tests/test_gitleaks_config.sh
+++ b/tests/test_gitleaks_config.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# tests/test_gitleaks_config.sh
+#
+# Tests for .github/workflows/gitleaks.yml and .gitleaks.toml per #154.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORKFLOW=".github/workflows/gitleaks.yml"
+CONFIG=".gitleaks.toml"
+
+PASS=0
+FAIL=0
+FAILS=()
+
+check() {
+  local name="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    PASS=$((PASS+1))
+    printf "  ok  %s\n" "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILS+=("$name")
+    printf "  FAIL %s\n" "$name"
+  fi
+}
+
+echo "== #154: Gitleaks secret scanning tests =="
+
+check "Gitleaks workflow exists" test -f "$WORKFLOW"
+check "workflow name is Secret Scan" grep -qE '^name: Secret Scan$' "$WORKFLOW"
+check "push trigger present" grep -qE '^  push:$' "$WORKFLOW"
+check "push targets main" grep -qF 'branches: [main]' "$WORKFLOW"
+check "pull_request trigger present" grep -qE '^  pull_request:$' "$WORKFLOW"
+check "manual dispatch present" grep -qE '^  workflow_dispatch:$' "$WORKFLOW"
+check "global contents read permission" grep -qE '^  contents: read$' "$WORKFLOW"
+check "concurrency group set" grep -qF 'group: secret-scan-${{ github.event_name }}-${{ github.ref }}' "$WORKFLOW"
+check "concurrency cancels stale runs" grep -qF 'cancel-in-progress: true' "$WORKFLOW"
+check "gitleaks job present" grep -qE '^  gitleaks:$' "$WORKFLOW"
+check "gitleaks runs on ubuntu latest" grep -qF 'runs-on: ubuntu-latest' "$WORKFLOW"
+check "gitleaks has timeout" grep -qF 'timeout-minutes: 10' "$WORKFLOW"
+check "checkout uses pinned major" grep -qF 'uses: actions/checkout@v6' "$WORKFLOW"
+check "checkout fetches full history" grep -qF 'fetch-depth: 0' "$WORKFLOW"
+check "official gitleaks action used" grep -qF 'uses: gitleaks/gitleaks-action@v2' "$WORKFLOW"
+check "GITHUB_TOKEN is provided" grep -qF 'GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}' "$WORKFLOW"
+check "custom config is wired" grep -qF 'GITLEAKS_CONFIG: .gitleaks.toml' "$WORKFLOW"
+
+check "Gitleaks config exists" test -f "$CONFIG"
+check "config extends default rules" grep -qF 'useDefault = true' "$CONFIG"
+check "provider API-key rule exists" grep -qF 'id = "trinity-provider-api-key-assignment"' "$CONFIG"
+check "bearer header rule exists" grep -qF 'id = "trinity-bearer-header"' "$CONFIG"
+check "provider rule uses secretGroup" bash -c "grep -A5 'trinity-provider-api-key-assignment' '$CONFIG' | grep -qF 'secretGroup = 1'"
+check "bearer rule uses secretGroup" bash -c "grep -A5 'trinity-bearer-header' '$CONFIG' | grep -qF 'secretGroup = 1'"
+
+check "planted fake secrets match configured rules" python3 - <<'PY'
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+config = tomllib.loads(Path(".gitleaks.toml").read_text())
+rules = {rule["id"]: rule for rule in config["rules"]}
+
+provider = re.compile(rules["trinity-provider-api-key-assignment"]["regex"])
+bearer = re.compile(rules["trinity-bearer-header"]["regex"])
+
+planted_provider = 'DEEPSEEK_API_KEY = "' + "sk-test-" + "0123456789abcdef012345" + '"'
+planted_bearer = "Authorization: Bearer " + "trn_" + "0123456789abcdef0123456789"
+
+safe_placeholders = [
+    'export DEEPSEEK_API_KEY=sk-...',
+    'DEEPSEEK_API_KEY = "from-env"',
+    'Authorization: Bearer <token>',
+]
+
+if not provider.search(planted_provider):
+    sys.exit("provider fake key was not matched")
+if not bearer.search(planted_bearer):
+    sys.exit("bearer fake token was not matched")
+if any(provider.search(line) or bearer.search(line) for line in safe_placeholders):
+    sys.exit("placeholder text should not match")
+PY
+
+echo
+echo "=== Result ==="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  printf "\nFailures:\n"
+  printf "  - %s\n" "${FAILS[@]}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `.github/workflows/gitleaks.yml` to run Gitleaks on pull requests, pushes to `main`, and manual dispatch.
- Add `.gitleaks.toml` that extends Gitleaks default rules and adds Trinity-specific provider API-key and bearer-token rules.
- Add `tests/test_gitleaks_config.sh` and wire it into `make test`, including a planted fake secret check built at runtime so the repository contents stay clean.

## Why
Trinity handles API keys and token-adjacent provider configuration. #154 asks for automated secret scanning so accidental credential commits are caught in CI.

## Validation
- `bash tests/test_gitleaks_config.sh`
- Gitleaks v8.30.1 temporary CLI: planted fake token scan returns leaks found
- Gitleaks v8.30.1 temporary CLI: current repo scan returns no leaks found
- `make lint && make test && make coverage && git diff --check`
- `trinity review --providers glm,minimax,deepseek --base origin/main --head HEAD --scope '#154 Gitleaks secret scanning workflow'` → 3/3 PASS, 0 FIX, 0 FAIL

Closes #154