### PR TITLE
Schedule dependency audit workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    - cron: '23 5 * * 2'
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
   manual dispatch, with Trinity-specific rules for provider API keys and bearer
   tokens. Closes #154.
 - Dependency vulnerability auditing now runs `pip-audit` against the locked dev
-  requirements on pull requests, pushes to `main`, and manual dispatch. Closes
-  #155.
+  requirements on pull requests, pushes to `main`, a weekly schedule, and manual
+  dispatch. Closes #155.
 - TRN-2018 M1 — review status observability. `trinity status` now renders a
   live `Live state:` section when reading M1 metadata, showing each provider
   in `queued` / `running` / `finished` / `failed` / `timed_out` state with

--- a/tests/test_dependency_audit_workflow.sh
+++ b/tests/test_dependency_audit_workflow.sh
@@ -36,6 +36,8 @@ check "workflow name is Dependency Audit" grep -qE '^name: Dependency Audit$' "$
 check "push trigger present" grep -qE '^  push:$' "$WORKFLOW"
 check "push targets main" grep -qF 'branches: [main]' "$WORKFLOW"
 check "pull_request trigger present" grep -qE '^  pull_request:$' "$WORKFLOW"
+check "weekly schedule present" grep -qE '^  schedule:$' "$WORKFLOW"
+check "schedule uses weekly cron" grep -qF "cron: '23 5 * * 2'" "$WORKFLOW"
 check "manual dispatch present" grep -qE '^  workflow_dispatch:$' "$WORKFLOW"
 check "global contents read permission" grep -qE '^  contents: read$' "$WORKFLOW"
 check "concurrency group set" grep -qF 'group: dependency-audit-${{ github.event_name }}-${{ github.ref }}' "$WORKFLOW"


### PR DESCRIPTION
## Summary
- Add a weekly schedule trigger to `.github/workflows/dependency-audit.yml`.
- Extend `tests/test_dependency_audit_workflow.sh` to assert the schedule.
- Update the changelog entry for #155 to mention scheduled audits.

## Why
Codex review on #185 correctly noted that dependency advisories can appear after a clean merge even when the lockfile does not change. This follow-up makes the dependency audit run weekly in addition to PR, push, and manual runs.

Follow-up to #155 and #185.

## Validation
- `bash tests/test_dependency_audit_workflow.sh`
- `make audit` -> No known vulnerabilities found
- `make lint`
- `make test && make coverage && make audit && git diff --check`
- `trinity review --providers glm,minimax,deepseek --base origin/main --head HEAD --scope '#155 follow-up dependency audit weekly schedule'` -> 3/3 PASS, 0 FIX, 0 FAIL
