### PR TITLE
Add MIT license metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- MIT license metadata is now explicit through a root `LICENSE` file and
+  `pyproject.toml` declaration. Closes #156.
 - Dependabot version updates for the root uv lockfile and GitHub
   Actions workflows now run weekly from `.github/dependabot.yml`. Closes #152.
 - CodeQL code scanning now runs for Python on pull requests and pushes

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Frank Xu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ test:           ## Run pytest and shell regression tests
 	bash tests/test_codeql_workflow.sh
 	bash tests/test_gitleaks_config.sh
 	bash tests/test_dependency_audit_workflow.sh
+	bash tests/test_license_metadata.sh
 	bash tests/test_release_workflow.sh
 	bash tests/test_install_sh.sh
 	bash tests/test_make_bump.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "trinity-dev"
 version = "0.0.0"
 requires-python = ">=3.11"
+license = "MIT"
 dependencies = []
 
 [dependency-groups]

--- a/tests/test_license_metadata.sh
+++ b/tests/test_license_metadata.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+failures=0
+
+pass() {
+    printf 'PASS %s\n' "$1"
+}
+
+fail() {
+    printf 'FAIL %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+require_file_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Eq "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+if [[ -f LICENSE ]]; then
+    pass "LICENSE exists at repo root"
+else
+    fail "LICENSE exists at repo root"
+fi
+
+require_file_contains LICENSE '^MIT License$' "LICENSE uses MIT template heading"
+require_file_contains LICENSE '^Copyright \(c\) 2026 Frank Xu$' "LICENSE has owner copyright"
+require_file_contains LICENSE 'Permission is hereby granted, free of charge' "LICENSE has MIT grant text"
+require_file_contains pyproject.toml '^license = "MIT"$' "pyproject declares MIT license"
+
+if [[ "${failures}" -ne 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add a root `LICENSE` file using the MIT license selected by the owner.
- Declare `license = "MIT"` in `pyproject.toml`.
- Add a shell regression test for the license file and metadata, and wire it into `make test`.
- Update the changelog.

Closes #156.

## Validation
- `bash tests/test_license_metadata.sh`
- `make test`
- `make lint`
- `make coverage`
- `uv lock --check`
- `git diff --check`
- `trinity review --providers glm,minimax,deepseek --base origin/main --head HEAD --scope '#156 Add MIT license metadata'` -> 3/3 PASS, 0 FIX, 0 FAIL

## Notes
GitHub license sidebar recognition can only be finally observed after the root `LICENSE` lands on the default branch, but the file uses the standard MIT template heading and grant text.
