### PR TITLE
Add security policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- `SECURITY.md` now documents supported security scope, response expectations,
+  and private vulnerability reporting channels. Closes #157.
 - Dependabot version updates for the root uv lockfile and GitHub
   Actions workflows now run weekly from `.github/dependabot.yml`. Closes #152.
 - CodeQL code scanning now runs for Python on pull requests and pushes

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ test:           ## Run pytest and shell regression tests
 	bash tests/test_codeql_workflow.sh
 	bash tests/test_gitleaks_config.sh
 	bash tests/test_dependency_audit_workflow.sh
+	bash tests/test_security_policy.sh
 	bash tests/test_release_workflow.sh
 	bash tests/test_install_sh.sh
 	bash tests/test_make_bump.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Supported Versions
+
+Trinity supports security fixes for the latest released version and the current
+`main` branch. Older releases are not routinely patched unless the maintainer
+announces an exception for a specific vulnerability.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release | Yes |
+| `main` | Yes |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately. Do not open a public issue
+for credential leaks, token handling bugs, command injection, release pipeline
+weaknesses, or other security-sensitive findings.
+
+Preferred channel:
+
+1. Use GitHub's private vulnerability reporting flow for this repository, if it
+   is available under the repository Security tab.
+2. If private vulnerability reporting is unavailable, email
+   `franky.xhl@gmail.com` with the subject prefix `[trinity-security]`.
+
+Include enough detail to reproduce or assess the issue:
+
+- Affected version, commit, or installation method.
+- The vulnerable command, workflow, provider, or file path.
+- Reproduction steps or a proof of concept.
+- Expected impact, such as credential exposure, command execution, or privilege
+  escalation.
+- Whether the issue is already public or being coordinated elsewhere.
+
+## Response Expectations
+
+The maintainer aims to acknowledge security reports within 3 business days.
+After acknowledgement, the maintainer will triage severity, ask for any missing
+details, and coordinate a fix or disclosure timeline when the report is valid.
+
+Please allow a reasonable remediation window before public disclosure. If the
+report is not considered a vulnerability, the maintainer will explain the reason
+or redirect it to a public issue when appropriate.
+
+## Security Scope
+
+In scope:
+
+- Credential and token loading, redaction, and environment isolation.
+- Provider wrappers and command execution paths.
+- Installer, release, and GitHub Actions workflows.
+- Review artifacts or logs that could expose secrets.
+
+Out of scope:
+
+- Vulnerabilities in third-party providers, CLIs, or model services unless
+  Trinity's integration materially creates or worsens the risk.
+- Social engineering, spam, denial-of-service load testing, or attacks against
+  accounts and infrastructure not owned by this project.

--- a/tests/test_security_policy.sh
+++ b/tests/test_security_policy.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+failures=0
+
+pass() {
+    printf 'PASS %s\n' "$1"
+}
+
+fail() {
+    printf 'FAIL %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+require_file_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Eq "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+if [[ -f SECURITY.md ]]; then
+    pass "SECURITY.md exists at repo root"
+else
+    fail "SECURITY.md exists at repo root"
+fi
+
+require_file_contains SECURITY.md '^## Supported Versions$' "supported versions section present"
+require_file_contains SECURITY.md 'Latest release' "latest release support documented"
+require_file_contains SECURITY.md '^## Reporting a Vulnerability$' "reporting section present"
+require_file_contains SECURITY.md 'private vulnerability reporting' "private GitHub reporting channel documented"
+require_file_contains SECURITY.md 'franky\.xhl@gmail\.com' "fallback private email channel documented"
+require_file_contains SECURITY.md '^## Response Expectations$' "response expectations section present"
+require_file_contains SECURITY.md '3 business days' "acknowledgement target documented"
+require_file_contains SECURITY.md '^## Security Scope$' "scope section present"
+require_file_contains SECURITY.md 'Credential and token loading' "credential scope documented"
+
+if [[ "${failures}" -ne 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add root `SECURITY.md` with supported versions, private reporting channels, response expectations, and security scope.
- Add `tests/test_security_policy.sh` to guard the policy shape.
- Wire the new test into `make test` and update the changelog.

Closes #157.

## Validation
- `bash tests/test_security_policy.sh`
- `make test`
- `make lint`
- `make coverage`
- `git diff --check`
- `trinity review --providers glm,minimax,deepseek --base origin/main --head HEAD --scope '#157 Add SECURITY.md vulnerability reporting policy'` -> 3/3 PASS, 0 FIX, 0 FAIL

## Notes
GitHub Security tab surfacing can only be finally observed after `SECURITY.md` lands on the default branch, but root-level `SECURITY.md` is the repository policy location GitHub recognizes.
