### PR TITLE
Add contributing guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- `CONTRIBUTING.md` now documents setup, tests, lint, coverage, branch naming,
+  PR expectations, and release preparation, with a README entry point. Closes
+  #158.
 - MIT license metadata is now explicit through a root `LICENSE` file and
   `pyproject.toml` declaration. Closes #156.
 - `SECURITY.md` now documents supported security scope, response expectations,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing
+
+Thanks for improving Trinity. This guide documents the local workflow that is
+already encoded in the repository Makefile and CI.
+
+## Development Setup
+
+Use Python 3.11 or newer. The repository is a uv-managed virtual project, with
+a pip requirements fallback for environments without uv.
+
+```bash
+make setup
+```
+
+When dependencies intentionally change, refresh both lock artifacts:
+
+```bash
+make lock
+```
+
+Commit `pyproject.toml`, `uv.lock`, and `requirements-dev.txt` together when a
+dependency update affects them.
+
+## Build Artifacts
+
+Some checked-in files are generated from source templates. Before testing or
+opening a PR, confirm generated artifacts are current:
+
+```bash
+make build
+make verify-built
+```
+
+`make test` runs `make verify-built` first, but running the explicit target is
+useful when changing provider templates, install manifests, or Codex skill
+files.
+
+## Tests, Lint, And Coverage
+
+Run the standard local validation before pushing:
+
+```bash
+make test
+make lint
+make coverage
+make audit
+git diff --check
+```
+
+What these targets cover:
+
+- `make test` runs pytest plus shell regression tests for workflows, installers,
+  generated artifacts, metadata, release behavior, and governance documents.
+- `make lint` runs Ruff check and format verification for `scripts/` and
+  `tests/`.
+- `make coverage` measures subprocess-aware coverage for `scripts/` and enforces
+  the repository threshold.
+- `make audit` runs `pip-audit` against the locked dev requirements.
+- `git diff --check` rejects whitespace errors before they reach review.
+
+Use focused tests first while iterating, then run the full set before PR handoff.
+
+## Branch Naming
+
+Use a short topic branch. For issue work, prefer:
+
+```text
+codex/<issue-number>-short-description
+```
+
+Examples:
+
+```text
+codex/158-add-contributing-md
+codex/160-python-version-matrix
+```
+
+The automation also recognizes `claude/` branches. Keep branches scoped to one
+issue or one coherent fix.
+
+## Pull Requests
+
+Open PRs against `main`. A PR should include:
+
+- A concise summary of user-visible or maintainer-visible changes.
+- The issue it closes, when applicable.
+- Validation commands and their results.
+- Notes for anything that cannot be fully verified until after merge, such as
+  GitHub sidebar or Security tab recognition.
+
+For review-fix updates on an existing PR, the repository provides:
+
+```bash
+make pr-update PR=<number> MESSAGE="Address review feedback"
+```
+
+`make pr-update` validates, amends or commits the change depending on `MODE`,
+pushes to the current upstream branch, and posts a PR comment with evidence. Use
+`DRY_RUN=1` to inspect the planned actions before writing.
+
+## Release Flow
+
+Do not publish releases manually from a feature branch. Release preparation is a
+local metadata step:
+
+```bash
+make release-prep
+```
+
+That target verifies generated artifacts, runs tests and lint, stages release
+metadata, creates the release commit, and creates the local tag. CI publishes
+from the tag after it is pushed according to the release workflow.
+
+## Documentation Changes
+
+Documentation-only changes should still update `CHANGELOG.md` when they affect
+maintainer workflows, repository governance, installation, release, or security
+behavior. Keep README changes concise and link to focused documents when the
+details belong elsewhere.

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ test:           ## Run pytest and shell regression tests
 	bash tests/test_dependency_audit_workflow.sh
 	bash tests/test_license_metadata.sh
 	bash tests/test_security_policy.sh
+	bash tests/test_contributing_doc.sh
 	bash tests/test_release_workflow.sh
 	bash tests/test_install_sh.sh
 	bash tests/test_make_bump.sh

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The name comes from 三位一体 — not a fixed count, but a philosophy: all AI
   - [Step 2: Install providers](#step-2-install-providers)
   - [Step 3: Configure global defaults (optional)](#step-3-configure-global-defaults-optional)
 - [Codex Compatibility](#codex-compatibility)
+- [Contributing](#contributing)
 - [Command Reference](#command-reference)
 - [Usage Guide](#usage-guide)
   - [Single dispatch](#single-dispatch)
@@ -95,6 +96,11 @@ Expected output: glm, minimax, codex, gemini, openrouter, deepseek, and claude-c
 - **Install command** — `/trinity install codex` sets up the CLI, agent file, config, and smoke test in one step
 - **Plan mode** — draw a sequence diagram, confirm, then auto-dispatch in dependency order
 - **Codex adapter** — a terminal `trinity review` that runs the same multi-provider review without Claude Code
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, test and lint commands,
+branch naming, PR expectations, and the release preparation flow.
 
 ---
 

--- a/tests/test_contributing_doc.sh
+++ b/tests/test_contributing_doc.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+failures=0
+
+pass() {
+    printf 'PASS %s\n' "$1"
+}
+
+fail() {
+    printf 'FAIL %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+require_file_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Eq "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+if [[ -f CONTRIBUTING.md ]]; then
+    pass "CONTRIBUTING.md exists at repo root"
+else
+    fail "CONTRIBUTING.md exists at repo root"
+fi
+
+require_file_contains README.md '\[CONTRIBUTING\.md\]\(CONTRIBUTING\.md\)' "README links to contributing guide"
+require_file_contains CONTRIBUTING.md '^## Development Setup$' "setup section present"
+require_file_contains CONTRIBUTING.md '`make setup`|make setup' "setup command documented"
+require_file_contains CONTRIBUTING.md '`make test`|make test' "test command documented"
+require_file_contains CONTRIBUTING.md '`make lint`|make lint' "lint command documented"
+require_file_contains CONTRIBUTING.md '`make coverage`|make coverage' "coverage command documented"
+require_file_contains CONTRIBUTING.md '`make audit`|make audit' "audit command documented"
+require_file_contains CONTRIBUTING.md '^## Branch Naming$' "branch naming section present"
+require_file_contains CONTRIBUTING.md 'codex/<issue-number>-short-description' "issue branch pattern documented"
+require_file_contains CONTRIBUTING.md '^## Pull Requests$' "PR expectations section present"
+require_file_contains CONTRIBUTING.md 'make pr-update PR=<number>' "PR update helper documented"
+require_file_contains CONTRIBUTING.md '^## Release Flow$' "release flow section present"
+require_file_contains CONTRIBUTING.md 'make release-prep' "release-prep documented"
+
+if [[ "${failures}" -ne 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` covering setup, generated artifacts, tests, lint, coverage, audit, branch naming, PR expectations, and release preparation.
- Link the contributing guide from `README.md`.
- Add `tests/test_contributing_doc.sh`, wire it into `make test`, and update the changelog.

Closes #158.

## Validation
- `bash tests/test_contributing_doc.sh`
- `make test`
- `make lint`
- `make coverage`
- `make audit` -> No known vulnerabilities found
- `git diff --check`
- `trinity review --providers glm,minimax,deepseek --base origin/main --head HEAD --scope '#158 Add CONTRIBUTING.md contributor workflow documentation'` -> 3/3 PASS, 0 FIX, 0 FAIL
