### PR TITLE
Add CODEOWNERS review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+# Repository default
+* @frankyxhl
+
+# GitHub configuration and automation
+/.github/ @frankyxhl
+/.github/workflows/ @frankyxhl
+
+# Runtime, installer, and provider surfaces
+/scripts/ @frankyxhl
+/providers/ @frankyxhl
+/bin/ @frankyxhl
+/install.sh @frankyxhl
+/install-manifest.json @frankyxhl
+/Makefile @frankyxhl
+
+# Policy, process, and regression coverage
+/rules/ @frankyxhl
+/tests/ @frankyxhl
+/CONTRIBUTING.md @frankyxhl
+/SECURITY.md @frankyxhl
+/LICENSE @frankyxhl
+
+# Packaging and dependency metadata
+/pyproject.toml @frankyxhl
+/uv.lock @frankyxhl
+/requirements-dev.txt @frankyxhl
+/VERSION @frankyxhl
+/CHANGELOG.md @frankyxhl
+/README.md @frankyxhl
+/SKILL.md @frankyxhl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- `.github/CODEOWNERS` now maps the repository default, GitHub automation,
+  runtime/provider surfaces, rules, tests, and release metadata to @frankyxhl.
+  Closes #159.
 - `CONTRIBUTING.md` now documents setup, tests, lint, coverage, branch naming,
   PR expectations, and release preparation, with a README entry point. Closes
   #158.

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ test:           ## Run pytest and shell regression tests
 	bash tests/test_codeql_workflow.sh
 	bash tests/test_gitleaks_config.sh
 	bash tests/test_dependency_audit_workflow.sh
+	bash tests/test_codeowners.sh
 	bash tests/test_license_metadata.sh
 	bash tests/test_security_policy.sh
 	bash tests/test_contributing_doc.sh

--- a/tests/test_codeowners.sh
+++ b/tests/test_codeowners.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+failures=0
+
+pass() {
+    printf 'PASS %s\n' "$1"
+}
+
+fail() {
+    printf 'FAIL %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+require_file_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Eq "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+if [[ -f .github/CODEOWNERS ]]; then
+    pass "CODEOWNERS exists under .github"
+else
+    fail "CODEOWNERS exists under .github"
+fi
+
+require_file_contains .github/CODEOWNERS '^\* @frankyxhl$' "default owner present"
+require_file_contains .github/CODEOWNERS '^/\.github/workflows/ @frankyxhl$' "workflow owner present"
+require_file_contains .github/CODEOWNERS '^/scripts/ @frankyxhl$' "scripts owner present"
+require_file_contains .github/CODEOWNERS '^/providers/ @frankyxhl$' "providers owner present"
+require_file_contains .github/CODEOWNERS '^/rules/ @frankyxhl$' "rules owner present"
+require_file_contains .github/CODEOWNERS '^/tests/ @frankyxhl$' "tests owner present"
+require_file_contains .github/CODEOWNERS '^/install\.sh @frankyxhl$' "installer owner present"
+require_file_contains .github/CODEOWNERS '^/Makefile @frankyxhl$' "Makefile owner present"
+require_file_contains .github/CODEOWNERS '^/pyproject\.toml @frankyxhl$' "pyproject owner present"
+
+if grep -Ev '^(#.*)?$|^[^[:space:]]+[[:space:]]+@frankyxhl$' .github/CODEOWNERS >/dev/null; then
+    fail "CODEOWNERS entries use path plus @frankyxhl owner"
+else
+    pass "CODEOWNERS entries use path plus @frankyxhl owner"
+fi
+
+if [[ "${failures}" -ne 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` with @frankyxhl as the repository default owner.
- Cover critical paths including `.github/workflows/`, `scripts/`, `providers/`, `rules/`, `tests/`, installer files, and release/dependency metadata.
- Add `tests/test_codeowners.sh`, wire it into `make test`, and update the changelog.

Closes #159.

## Validation
- `bash tests/test_codeowners.sh`
- `make test`
- `make lint`
- `make coverage`
- `make audit` -> No known vulnerabilities found
- `git diff --check`
- `trinity review --providers glm,minimax,deepseek --base origin/main --head HEAD --scope '#159 Add CODEOWNERS review routing'` -> 3/3 PASS, 0 FIX, 0 FAIL

## Notes
GitHub owner auto-request behavior can only be finally observed on a PR after `.github/CODEOWNERS` lands on the default branch. This PR adds the recognized `.github/CODEOWNERS` location and validates the critical path mappings statically.
