### PR TITLE
Add Python version matrix to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,12 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.os }}
+    name: test / ${{ matrix.os }} / Python ${{ matrix.python-version }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        python-version: ['3.11', '3.12', '3.13']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -75,7 +76,7 @@ jobs:
       - uses: actions/setup-python@v6
         if: steps.changes.outputs.run_tests == 'true'
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
       - name: Install dev dependencies
         if: steps.changes.outputs.run_tests == 'true'
         run: make setup
@@ -88,3 +89,29 @@ jobs:
       - name: Run coverage
         if: steps.changes.outputs.run_tests == 'true'
         run: make coverage
+
+  ubuntu-latest:
+    name: ubuntu-latest
+    needs: test
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix result
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "test matrix result: ${{ needs.test.result }}"
+            exit 1
+          fi
+
+  macos-latest:
+    name: macos-latest
+    needs: test
+    runs-on: macos-latest
+    if: always()
+    steps:
+      - name: Check matrix result
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "test matrix result: ${{ needs.test.result }}"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Added
+- PR CI now runs the test workflow across a Python version matrix covering
+  3.11, 3.12, and 3.13 on both Ubuntu and macOS, while preserving the existing
+  `ubuntu-latest` and `macos-latest` required-check names as aggregate gates.
+  Closes #160.
 - `.github/CODEOWNERS` now maps the repository default, GitHub automation,
   runtime/provider surfaces, rules, tests, and release metadata to @frankyxhl.
   Closes #159.

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test:           ## Run pytest and shell regression tests
 	bash tests/test_build_providers.sh
 	bash tests/test_dependabot_config.sh
 	bash tests/test_codeql_workflow.sh
+	bash tests/test_test_workflow_matrix.sh
 	bash tests/test_gitleaks_config.sh
 	bash tests/test_dependency_audit_workflow.sh
 	bash tests/test_codeowners.sh

--- a/tests/test_test_workflow_matrix.sh
+++ b/tests/test_test_workflow_matrix.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+WORKFLOW=".github/workflows/test.yml"
+failures=0
+
+pass() {
+    printf 'PASS %s\n' "$1"
+}
+
+fail() {
+    printf 'FAIL %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+require_file_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Eq "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+if [[ -f "${WORKFLOW}" ]]; then
+    pass "test workflow exists"
+else
+    fail "test workflow exists"
+fi
+
+require_file_contains "${WORKFLOW}" 'name: test / \$\{\{ matrix\.os \}\} / Python \$\{\{ matrix\.python-version \}\}' "matrix job name includes OS and Python version"
+require_file_contains "${WORKFLOW}" 'os: \[ubuntu-latest, macos-latest\]' "OS matrix keeps ubuntu and macos"
+require_file_contains "${WORKFLOW}" "python-version: \\['3\\.11', '3\\.12', '3\\.13'\\]" "Python matrix covers 3.11, 3.12, and 3.13"
+require_file_contains "${WORKFLOW}" 'runs-on: \$\{\{ matrix\.os \}\}' "runner uses OS matrix"
+require_file_contains "${WORKFLOW}" 'uses: actions/setup-python@v6' "setup-python action is pinned to major"
+require_file_contains "${WORKFLOW}" 'python-version: \$\{\{ matrix\.python-version \}\}' "setup-python uses Python matrix"
+require_file_contains "${WORKFLOW}" '^  ubuntu-latest:$' "legacy ubuntu required-check gate present"
+require_file_contains "${WORKFLOW}" '^    name: ubuntu-latest$' "legacy ubuntu required-check name preserved"
+require_file_contains "${WORKFLOW}" '^  macos-latest:$' "legacy macos required-check gate present"
+require_file_contains "${WORKFLOW}" '^    name: macos-latest$' "legacy macos required-check name preserved"
+require_file_contains "${WORKFLOW}" 'needs: test' "required-check gates depend on matrix job"
+require_file_contains "${WORKFLOW}" '\$\{\{ needs\.test\.result \}\}' "required-check gates inspect matrix result"
+
+setup_line=$(grep -nF 'uses: actions/setup-python@v6' "${WORKFLOW}" | head -1 | cut -d: -f1)
+install_line=$(grep -nF 'run: make setup' "${WORKFLOW}" | head -1 | cut -d: -f1)
+lint_line=$(grep -nF 'run: make lint' "${WORKFLOW}" | head -1 | cut -d: -f1)
+test_line=$(grep -nF 'run: make test' "${WORKFLOW}" | head -1 | cut -d: -f1)
+coverage_line=$(grep -nF 'run: make coverage' "${WORKFLOW}" | head -1 | cut -d: -f1)
+
+if [[ "${setup_line}" -lt "${install_line}" && "${install_line}" -lt "${lint_line}" && "${lint_line}" -lt "${test_line}" && "${test_line}" -lt "${coverage_line}" ]]; then
+    pass "matrix leg order remains setup, install, lint, test, coverage"
+else
+    fail "matrix leg order remains setup, install, lint, test, coverage"
+fi
+
+if [[ "${failures}" -ne 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add Python 3.11, 3.12, and 3.13 to the test workflow matrix across `ubuntu-latest` and `macos-latest`.
- Preserve the existing required-check names `ubuntu-latest` and `macos-latest` with aggregate gate jobs that depend on the full matrix.
- Add `tests/test_test_workflow_matrix.sh`, wire it into `make test`, and update the changelog.

Closes #160.

## Validation
- `bash tests/test_test_workflow_matrix.sh`
- `make test`
- `make lint`
- `make coverage`
- `make audit` -> No known vulnerabilities found
- `git diff --check`
- `trinity review --providers glm,minimax,deepseek --base origin/main --head HEAD --scope '#160 Add Python version matrix to test workflow'` -> 3/3 PASS, 0 FIX, 0 FAIL
