### PR TITLE
Upload coverage artifacts from PR CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,16 @@ jobs:
       - name: Run coverage
         if: steps.changes.outputs.run_tests == 'true'
         run: make coverage
+      - name: Upload coverage report
+        if: always() && steps.changes.outputs.run_tests == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: |
+            coverage.xml
+            htmlcov/
+          if-no-files-found: warn
+          retention-days: 14
 
   ubuntu-latest:
     name: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- PR CI now uploads per-matrix-leg coverage artifacts containing `coverage.xml`
+  and the `htmlcov/` HTML report, while keeping the existing 80% coverage gate.
+  Closes #161.
 - PR CI now runs the test workflow across a Python version matrix covering
   3.11, 3.12, and 3.13 on both Ubuntu and macOS, while preserving the existing
   `ubuntu-latest` and `macos-latest` required-check names as aggregate gates.

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ test:           ## Run pytest and shell regression tests
 	bash tests/test_dependabot_config.sh
 	bash tests/test_codeql_workflow.sh
 	bash tests/test_test_workflow_matrix.sh
+	bash tests/test_coverage_visibility.sh
 	bash tests/test_gitleaks_config.sh
 	bash tests/test_dependency_audit_workflow.sh
 	bash tests/test_codeowners.sh
@@ -53,6 +54,8 @@ coverage:       ## Measure line coverage with subprocess tracking (TRN-2023, fai
 	.venv/bin/coverage erase
 	COVERAGE_PROCESS_START=$(CURDIR)/.coveragerc .venv/bin/coverage run -m pytest tests/ -q
 	.venv/bin/coverage combine
+	.venv/bin/coverage xml -o coverage.xml
+	.venv/bin/coverage html -d htmlcov
 	.venv/bin/coverage report --include='scripts/*' --fail-under=80
 
 audit:          ## Check locked dev dependencies with pip-audit

--- a/tests/test_coverage_visibility.sh
+++ b/tests/test_coverage_visibility.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+WORKFLOW=".github/workflows/test.yml"
+failures=0
+
+pass() {
+    printf 'PASS %s\n' "$1"
+}
+
+fail() {
+    printf 'FAIL %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+require_file_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Eq "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+require_file_contains Makefile 'coverage xml -o coverage\.xml' "coverage target emits XML report"
+require_file_contains Makefile 'coverage html -d htmlcov' "coverage target emits HTML report"
+require_file_contains Makefile 'coverage report --include='\''scripts/\*'\'' --fail-under=80' "coverage target preserves fail-under gate"
+
+xml_line=$(grep -nF 'coverage xml -o coverage.xml' Makefile | head -1 | cut -d: -f1)
+html_line=$(grep -nF 'coverage html -d htmlcov' Makefile | head -1 | cut -d: -f1)
+report_line=$(grep -nF "coverage report --include='scripts/*' --fail-under=80" Makefile | head -1 | cut -d: -f1)
+
+if [[ "${xml_line}" -lt "${report_line}" && "${html_line}" -lt "${report_line}" ]]; then
+    pass "coverage artifacts are generated before fail-under report"
+else
+    fail "coverage artifacts are generated before fail-under report"
+fi
+
+require_file_contains "${WORKFLOW}" 'name: Upload coverage report' "test workflow uploads coverage report"
+require_file_contains "${WORKFLOW}" 'if: always\(\) && steps\.changes\.outputs\.run_tests == '\''true'\''' "coverage upload runs even after coverage failure"
+require_file_contains "${WORKFLOW}" 'uses: actions/upload-artifact@v7' "coverage upload uses pinned artifact action"
+require_file_contains "${WORKFLOW}" 'name: coverage-\$\{\{ matrix\.os \}\}-py\$\{\{ matrix\.python-version \}\}' "coverage artifact name is unique per matrix leg"
+require_file_contains "${WORKFLOW}" 'coverage\.xml' "coverage upload includes XML report"
+require_file_contains "${WORKFLOW}" 'htmlcov/' "coverage upload includes HTML report"
+require_file_contains "${WORKFLOW}" 'if-no-files-found: warn' "coverage upload does not hide coverage command failures"
+require_file_contains "${WORKFLOW}" 'retention-days: 14' "coverage artifact retention is bounded"
+
+coverage_line=$(grep -nF 'run: make coverage' "${WORKFLOW}" | head -1 | cut -d: -f1)
+upload_line=$(grep -nF 'name: Upload coverage report' "${WORKFLOW}" | head -1 | cut -d: -f1)
+
+if [[ "${coverage_line}" -lt "${upload_line}" ]]; then
+    pass "coverage upload runs after coverage command"
+else
+    fail "coverage upload runs after coverage command"
+fi
+
+if [[ "${failures}" -ne 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Generate `coverage.xml` and `htmlcov/` from `make coverage` before the existing `--fail-under=80` report gate.
- Upload per-matrix-leg coverage artifacts from the Test workflow so PR coverage can be inspected without reading raw logs.
- Add a static regression test for coverage artifact generation and upload wiring.

Closes #161.

## Validation
- `bash tests/test_coverage_visibility.sh`
- `bash tests/test_test_workflow_matrix.sh`
- `make test`
- `make lint`
- `make coverage` -> TOTAL 85%, HTML report written to `htmlcov/index.html`, XML report written to `coverage.xml`
- `make audit` -> No known vulnerabilities found
- `git diff --check`
- `trinity review --providers glm,minimax,deepseek --base origin/main --head HEAD --scope '#161 Make coverage visible per PR'` -> 3/3 PASS, 0 FIX, 0 FAIL
