### PR TITLE
Cache dependencies in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,14 @@ jobs:
         if: steps.changes.outputs.run_tests == 'true'
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Setup uv
+        if: steps.changes.outputs.run_tests == 'true'
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
       - name: Install dev dependencies
         if: steps.changes.outputs.run_tests == 'true'
         run: make setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- PR CI now restores the uv dependency cache in each test matrix leg before
+  `make setup`, keyed by `pyproject.toml` and `uv.lock`. Closes #162.
 - GitHub Actions workflow steps are now pinned to full commit SHAs with trailing
   version comments, while Dependabot remains configured to update actions.
   Closes #163.

--- a/tests/test_test_workflow_matrix.sh
+++ b/tests/test_test_workflow_matrix.sh
@@ -40,6 +40,11 @@ require_file_contains "${WORKFLOW}" "python-version: \\['3\\.11', '3\\.12', '3\\
 require_file_contains "${WORKFLOW}" 'runs-on: \$\{\{ matrix\.os \}\}' "runner uses OS matrix"
 require_file_contains "${WORKFLOW}" 'uses: actions/setup-python@[0-9a-f]{40} # v6' "setup-python action is pinned to SHA"
 require_file_contains "${WORKFLOW}" 'python-version: \$\{\{ matrix\.python-version \}\}' "setup-python uses Python matrix"
+require_file_contains "${WORKFLOW}" 'uses: astral-sh/setup-uv@[0-9a-f]{40} # v7' "setup-uv action is pinned to SHA"
+require_file_contains "${WORKFLOW}" 'enable-cache: true' "setup-uv cache is enabled"
+require_file_contains "${WORKFLOW}" 'cache-dependency-glob:' "setup-uv cache dependency glob configured"
+require_file_contains "${WORKFLOW}" 'pyproject\.toml' "setup-uv cache keys pyproject"
+require_file_contains "${WORKFLOW}" 'uv\.lock' "setup-uv cache keys lockfile"
 require_file_contains "${WORKFLOW}" '^  ubuntu-latest:$' "legacy ubuntu required-check gate present"
 require_file_contains "${WORKFLOW}" '^    name: ubuntu-latest$' "legacy ubuntu required-check name preserved"
 require_file_contains "${WORKFLOW}" '^  macos-latest:$' "legacy macos required-check gate present"
@@ -48,15 +53,16 @@ require_file_contains "${WORKFLOW}" 'needs: test' "required-check gates depend o
 require_file_contains "${WORKFLOW}" '\$\{\{ needs\.test\.result \}\}' "required-check gates inspect matrix result"
 
 setup_line=$(grep -nE 'uses: actions/setup-python@[0-9a-f]{40} # v6' "${WORKFLOW}" | head -1 | cut -d: -f1)
+uv_line=$(grep -nE 'uses: astral-sh/setup-uv@[0-9a-f]{40} # v7' "${WORKFLOW}" | head -1 | cut -d: -f1)
 install_line=$(grep -nF 'run: make setup' "${WORKFLOW}" | head -1 | cut -d: -f1)
 lint_line=$(grep -nF 'run: make lint' "${WORKFLOW}" | head -1 | cut -d: -f1)
 test_line=$(grep -nF 'run: make test' "${WORKFLOW}" | head -1 | cut -d: -f1)
 coverage_line=$(grep -nF 'run: make coverage' "${WORKFLOW}" | head -1 | cut -d: -f1)
 
-if [[ "${setup_line}" -lt "${install_line}" && "${install_line}" -lt "${lint_line}" && "${lint_line}" -lt "${test_line}" && "${test_line}" -lt "${coverage_line}" ]]; then
-    pass "matrix leg order remains setup, install, lint, test, coverage"
+if [[ "${setup_line}" -lt "${uv_line}" && "${uv_line}" -lt "${install_line}" && "${install_line}" -lt "${lint_line}" && "${lint_line}" -lt "${test_line}" && "${test_line}" -lt "${coverage_line}" ]]; then
+    pass "matrix leg order remains setup-python, setup-uv, install, lint, test, coverage"
 else
-    fail "matrix leg order remains setup, install, lint, test, coverage"
+    fail "matrix leg order remains setup-python, setup-uv, install, lint, test, coverage"
 fi
 
 if [[ "${failures}" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Add pinned `astral-sh/setup-uv` to each `test.yml` matrix leg before `make setup`.
- Enable uv dependency caching keyed by `pyproject.toml` and `uv.lock`, matching the release workflow cache pattern.
- Extend the test workflow regression to lock the setup-uv cache configuration and step ordering.

Closes #162.

## Validation
- `bash tests/test_test_workflow_matrix.sh`
- `bash tests/test_github_action_pins.sh`
- `bash tests/test_release_workflow.sh`
- `make test`
- `make lint`
- `make coverage` -> TOTAL 86%
- `make audit` -> No known vulnerabilities found
- `git diff --check`
- `trinity review --providers glm,minimax,deepseek --base origin/main --head HEAD --scope '#162 Add dependency caching to test.yml'` -> 3/3 PASS, 0 FIX, 0 FAIL
- PR CI on head `7fd72a2`: all checks passed
- Cache observability: Test workflow run `26703374015` shows `Cache hit for:` in all 6 matrix legs, including Ubuntu 3.11/3.12/3.13 and macOS 3.11/3.12/3.13

## Note
- I attempted a manual workflow rerun for a second-run check, but GitHub rejected it because this token lacks repo admin rights. The rebased PR CI run still satisfies the observability criterion because setup-uv restored warm caches and logged explicit cache hits for every matrix leg.
