### PR TITLE
Upgrade minimax provider to MiniMax M3 (droid BYOK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+- `minimax` provider upgraded from MiniMax 2.7 to MiniMax M3 (released
+  2026-06-01). M3 is not yet in droid's built-in catalog, so the CLI now uses
+  the BYOK reference `droid exec --auto medium --model custom:MiniMax-M3`
+  (requires a `MiniMax-M3` entry in `~/.factory/settings.json` `customModels`;
+  `--reasoning-effort` dropped — unsupported for `custom:` models). Reverses
+  the TRN-3035 built-in-id decision out of necessity until droid ships M3
+  natively.
+
 ### Added
 - PR CI now restores the uv dependency cache in each test matrix leg before
   `make setup`, keyed by `pyproject.toml` and `uv.lock`. Closes #162.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 - `minimax` provider upgraded from MiniMax 2.7 to MiniMax M3 (released
   2026-06-01). M3 is not yet in droid's built-in catalog, so the CLI now uses
   the BYOK reference `droid exec --auto medium --model custom:MiniMax-M3`
-  (requires a `MiniMax-M3` entry in `~/.factory/settings.json` `customModels`;
-  `--reasoning-effort` dropped — unsupported for `custom:` models). Reverses
+  (requires a `~/.factory/settings.json` `customModels` entry with an
+  **explicit** `"id": "custom:MiniMax-M3"` — without it droid auto-generates
+  an indexed id like `custom:MiniMax-M3-<n>` and the registry CLI string will
+  not resolve; `--reasoning-effort` dropped — unsupported for `custom:`
+  models). Reverses
   the TRN-3035 built-in-id decision out of necessity until droid ships M3
   natively.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Expected output: glm, minimax, codex, gemini, openrouter, deepseek, and claude-c
 | `~/.claude/skills/trinity/SKILL.md` | Trinity skill — loaded by Claude Code |
 | `~/.claude/skills/trinity/scripts/` | Python session/config/discover/install scripts |
 | `~/.claude/agents/trinity-glm.md` | GLM worker agent |
-| `~/.claude/agents/trinity-minimax.md` | MiniMax 2.7 worker agent |
+| `~/.claude/agents/trinity-minimax.md` | MiniMax M3 worker agent |
 | `~/.claude/agents/trinity-codex.md` | Codex worker agent |
 | `~/.claude/agents/trinity-gemini.md` | Gemini worker agent |
 | `~/.claude/agents/trinity-openrouter.md` | OpenRouter worker agent |
@@ -168,7 +168,7 @@ cp trinity/providers/gemini.md ~/.claude/agents/trinity-gemini.md
 # GLM
 cp trinity/providers/glm.md ~/.claude/agents/trinity-glm.md
 
-# MiniMax 2.7
+# MiniMax M3
 cp trinity/providers/minimax.md ~/.claude/agents/trinity-minimax.md
 
 # OpenRouter
@@ -195,7 +195,7 @@ Then create `~/.claude/trinity.json`:
     "codex":      { "cli": "codex exec --skip-git-repo-check -m gpt-5.5", "installed": true },
     "gemini":     { "cli": "gemini -p",                        "installed": true },
     "glm":        { "cli": "droid exec --auto medium --model glm-5.1 --reasoning-effort high", "installed": true },
-    "minimax":    { "cli": "droid exec --auto medium --model minimax-m2.7 --reasoning-effort high", "installed": true },
+    "minimax":    { "cli": "droid exec --auto medium --model custom:MiniMax-M3", "installed": true },
     "openrouter":  { "cli": "/Users/<you>/.claude/skills/trinity/bin/openrouter -p",  "installed": true },
     "deepseek":    { "cli": "/Users/<you>/.claude/skills/trinity/bin/deepseek -p",    "installed": true },
     "claude-code": { "cli": "/Users/<you>/.claude/skills/trinity/bin/claude-code -p", "installed": true }
@@ -612,7 +612,7 @@ Sessions persist in `.claude/trinity.json` (project-scoped). Clearing removes th
 
 ~/.claude/agents/
   trinity-glm.md                ← GLM worker agent
-  trinity-minimax.md            ← MiniMax 2.7 worker agent
+  trinity-minimax.md            ← MiniMax M3 worker agent
   trinity-codex.md              ← Codex worker agent
   trinity-gemini.md             ← Gemini worker agent
   trinity-deepseek.md           ← DeepSeek (Anthropic-compat wrapper)

--- a/SKILL.md
+++ b/SKILL.md
@@ -109,7 +109,7 @@ A provider is **usable** only when it has both a config entry AND an agent file.
 {
   "providers": {
     "glm":     { "cli": "droid exec --auto medium --model glm-5.1 --reasoning-effort high", "installed": true },
-    "minimax": { "cli": "droid exec --auto medium --model minimax-m2.7 --reasoning-effort high", "installed": true },
+    "minimax": { "cli": "droid exec --auto medium --model custom:MiniMax-M3", "installed": true },
     "codex":   { "cli": "codex exec --skip-git-repo-check -m gpt-5.5", "installed": true },
     "gemini":  { "cli": "gemini -p",                        "installed": true }
   },
@@ -311,7 +311,7 @@ Run provider discovery. Display two sections:
 | Provider | Status    | CLI                              |
 |----------|-----------|----------------------------------|
 | glm      | ✅ usable  | droid exec --auto medium --model glm-5.1 --reasoning-effort high |
-| minimax  | ✅ usable  | droid exec --auto medium --model minimax-m2.7 --reasoning-effort high |
+| minimax  | ✅ usable  | droid exec --auto medium --model custom:MiniMax-M3 |
 | codex    | ✅ usable  | codex exec --skip-git-repo-check -m gpt-5.5 |
 | gemini   | ⚠️ missing | (agent file not found)           |
 ```

--- a/providers/minimax.delta.md
+++ b/providers/minimax.delta.md
@@ -1,29 +1,29 @@
 ---
 name: trinity-minimax
 description: |
-  Worker agent for MiniMax 2.7 (via droid exec --auto medium --model minimax-m2.7 --reasoning-effort high).
+  Worker agent for MiniMax M3 (via droid exec --auto medium --model custom:MiniMax-M3).
   Handles session management automatically.
-  Spawned by Claude to delegate coding, analysis, or brainstorming tasks to MiniMax 2.7.
+  Spawned by Claude to delegate coding, analysis, or brainstorming tasks to MiniMax M3.
 
   Invoked via Agent tool with subagent_type="general-purpose".
   Claude passes: provider instance name, project dir, and task description.
 tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 
-You are a worker agent that executes tasks using MiniMax 2.7 via the `droid` CLI.
+You are a worker agent that executes tasks using MiniMax M3 via the `droid` CLI.
 
 ## Your Job
 
 1. Receive a task from Claude (the orchestrator)
 2. Manage the session (new or resume)
-3. Call MiniMax 2.7 via droid exec
+3. Call MiniMax M3 via droid exec
 4. Return a structured summary
 
 @include _base/common-session.md
 
 ### New session (no existing session)
 ```bash
-RESPONSE=$(droid exec --auto medium --model minimax-m2.7 --reasoning-effort high "<prompt>" 2>&1)
+RESPONSE=$(droid exec --auto medium --model custom:MiniMax-M3 "<prompt>" 2>&1)
 ```
 Then extract session ID from droid's session list:
 ```bash
@@ -37,7 +37,7 @@ print(sessions[0]['sessionId'] if sessions else 'UNKNOWN')
 
 ### Resume session (existing session found)
 ```bash
-RESPONSE=$(droid exec --auto medium --model minimax-m2.7 --reasoning-effort high -s "$SESSION_ID" "<prompt>" 2>&1)
+RESPONSE=$(droid exec --auto medium --model custom:MiniMax-M3 -s "$SESSION_ID" "<prompt>" 2>&1)
 ```
 
 If resume fails (non-zero exit or error), discard the old session and create a new one.
@@ -49,5 +49,5 @@ The instance key is passed by Claude in the prompt. Format:
 - Named: `minimax:auth`, `minimax:order`, etc.
 
 @include _base/common-tail.md
-- Always use `droid exec --auto medium --model minimax-m2.7 --reasoning-effort high` (non-interactive mode)
+- Always use `droid exec --auto medium --model custom:MiniMax-M3` (non-interactive mode). Note: `--reasoning-effort` is not supported for `custom:` models — do not add it.
 - If the task description mentions "complex", "large", or "multi-file", use the longer 600000ms timeout

--- a/providers/minimax.md
+++ b/providers/minimax.md
@@ -1,22 +1,22 @@
 ---
 name: trinity-minimax
 description: |
-  Worker agent for MiniMax 2.7 (via droid exec --auto medium --model minimax-m2.7 --reasoning-effort high).
+  Worker agent for MiniMax M3 (via droid exec --auto medium --model custom:MiniMax-M3).
   Handles session management automatically.
-  Spawned by Claude to delegate coding, analysis, or brainstorming tasks to MiniMax 2.7.
+  Spawned by Claude to delegate coding, analysis, or brainstorming tasks to MiniMax M3.
 
   Invoked via Agent tool with subagent_type="general-purpose".
   Claude passes: provider instance name, project dir, and task description.
 tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 
-You are a worker agent that executes tasks using MiniMax 2.7 via the `droid` CLI.
+You are a worker agent that executes tasks using MiniMax M3 via the `droid` CLI.
 
 ## Your Job
 
 1. Receive a task from Claude (the orchestrator)
 2. Manage the session (new or resume)
-3. Call MiniMax 2.7 via droid exec
+3. Call MiniMax M3 via droid exec
 4. Return a structured summary
 
 ## Session Management
@@ -37,7 +37,7 @@ python3 ~/.claude/skills/trinity/scripts/session.py write "$PROJECT_DIR" "$INSTA
 
 ### New session (no existing session)
 ```bash
-RESPONSE=$(droid exec --auto medium --model minimax-m2.7 --reasoning-effort high "<prompt>" 2>&1)
+RESPONSE=$(droid exec --auto medium --model custom:MiniMax-M3 "<prompt>" 2>&1)
 ```
 Then extract session ID from droid's session list:
 ```bash
@@ -51,7 +51,7 @@ print(sessions[0]['sessionId'] if sessions else 'UNKNOWN')
 
 ### Resume session (existing session found)
 ```bash
-RESPONSE=$(droid exec --auto medium --model minimax-m2.7 --reasoning-effort high -s "$SESSION_ID" "<prompt>" 2>&1)
+RESPONSE=$(droid exec --auto medium --model custom:MiniMax-M3 -s "$SESSION_ID" "<prompt>" 2>&1)
 ```
 
 If resume fails (non-zero exit or error), discard the old session and create a new one.
@@ -106,5 +106,5 @@ Providers that do not emit the block continue to work — synthesis falls back t
 - If the provider needs file contents, read the file yourself and include it in the prompt
 - If the provider produces code, verify it looks reasonable before returning
 - Keep your summary focused — Claude doesn't need the full conversation log
-- Always use `droid exec --auto medium --model minimax-m2.7 --reasoning-effort high` (non-interactive mode)
+- Always use `droid exec --auto medium --model custom:MiniMax-M3` (non-interactive mode). Note: `--reasoning-effort` is not supported for `custom:` models — do not add it.
 - If the task description mentions "complex", "large", or "multi-file", use the longer 600000ms timeout

--- a/providers/registry.json
+++ b/providers/registry.json
@@ -8,7 +8,7 @@
       "timeout": 360
     },
     "minimax": {
-      "cli": "droid exec --auto medium --model minimax-m2.7 --reasoning-effort high",
+      "cli": "droid exec --auto medium --model custom:MiniMax-M3",
       "supports_resume": true,
       "resume_arg": "-s",
       "timeout": 360

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -11,6 +11,7 @@ Usage:
 
 import json
 import os
+import re
 import sys
 import tempfile
 
@@ -172,6 +173,54 @@ def _validate_registry(data):
                 )
 
 
+# droid BYOK model references embedded in a provider cli string, e.g.
+# "droid exec --auto medium --model custom:MiniMax-M3".
+_CUSTOM_MODEL_RE = re.compile(r"(custom:[^\s\"']+)")
+
+
+def _declared_custom_model_ids(factory_settings_path):
+    """Return the set of explicit custom-model ids declared in
+    ~/.factory/settings.json customModels. Missing/unreadable file -> empty set."""
+    try:
+        with open(factory_settings_path, encoding="utf-8") as f:
+            settings = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return set()
+    ids = set()
+    models = settings.get("customModels")
+    if isinstance(models, list):
+        for m in models:
+            if isinstance(m, dict) and isinstance(m.get("id"), str):
+                ids.add(m["id"])
+    return ids
+
+
+def warn_missing_custom_models(provider_name, cli, factory_settings_path=None):
+    """Warn (stderr) when a cli references a droid `custom:` model id that has
+    no matching explicit `\"id\"` in ~/.factory/settings.json customModels.
+
+    Warning-only by design: install.sh has never smoke-tested provider CLIs,
+    and droid may be configured after install. This surfaces the BYOK
+    prerequisite at install time instead of first dispatch (PR #196 review).
+    """
+    refs = _CUSTOM_MODEL_RE.findall(cli)
+    if not refs:
+        return
+    path = factory_settings_path or os.path.join(
+        os.path.expanduser("~"), ".factory", "settings.json"
+    )
+    declared = _declared_custom_model_ids(path)
+    for ref in refs:
+        if ref not in declared:
+            print(
+                f"trinity-install: warning: provider '{provider_name}' references "
+                f"droid custom model '{ref}', but {path} has no customModels entry "
+                f'with an explicit "id": "{ref}" — dispatch will fail until that '
+                f"entry is added.",
+                file=sys.stderr,
+            )
+
+
 def cmd_register_from_registry(registry_path, global_config):
     """Read providers/registry.json and call cmd_register() per provider.
 
@@ -194,6 +243,7 @@ def cmd_register_from_registry(registry_path, global_config):
     for provider_name, entry in data["providers"].items():
         cli = entry["cli"].replace("{HOME}", home)
         cmd_register(provider_name, cli, global_config)
+        warn_missing_custom_models(provider_name, cli)
 
 
 def cmd_unregister(provider, global_config):

--- a/tests/test_build_providers.sh
+++ b/tests/test_build_providers.sh
@@ -155,7 +155,7 @@ done
 check "codex CLI signature"      grep -q 'codex exec' providers/codex.md
 check "gemini CLI signature"     grep -q 'gemini --model' providers/gemini.md
 check "glm CLI signature"        grep -q 'droid exec --auto medium --model glm-5.1 --reasoning-effort high' providers/glm.md
-check "minimax CLI signature"    grep -q 'droid exec --auto medium --model minimax-m2.7 --reasoning-effort high' providers/minimax.md
+check "minimax CLI signature"    grep -q 'droid exec --auto medium --model custom:MiniMax-M3' providers/minimax.md
 check "openrouter run function"  grep -q 'run_openrouter()' providers/openrouter.md
 check "deepseek run function"    grep -q 'run_deepseek()' providers/deepseek.md
 check "claude-code run function" grep -q 'run_claude_code()' providers/claude-code.md

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -346,6 +346,55 @@ def test_register_from_registry_populates_global_config(tmp_path):
         }, f"register-from-registry failed for {provider}"
 
 
+def test_register_from_registry_warns_on_undeclared_custom_model(tmp_path, capsys):
+    """A provider cli referencing a droid `custom:` model id must emit an
+    install-time stderr warning when ~/.factory/settings.json lacks a
+    customModels entry with that explicit id (PR #196 review gate)."""
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({"customModels": []}))
+    install_py.warn_missing_custom_models(
+        "minimax",
+        "droid exec --auto medium --model custom:MiniMax-M3",
+        str(settings),
+    )
+    err = capsys.readouterr().err
+    assert "custom:MiniMax-M3" in err
+    assert "minimax" in err
+
+
+def test_register_from_registry_no_warning_when_custom_model_declared(tmp_path, capsys):
+    """No warning when the explicit id is declared in customModels."""
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({"customModels": [{"id": "custom:MiniMax-M3"}]}))
+    install_py.warn_missing_custom_models(
+        "minimax",
+        "droid exec --auto medium --model custom:MiniMax-M3",
+        str(settings),
+    )
+    assert capsys.readouterr().err == ""
+
+
+def test_register_from_registry_no_warning_for_builtin_models(tmp_path, capsys):
+    """CLI strings without a `custom:` reference never warn — even when the
+    factory settings file is absent."""
+    install_py.warn_missing_custom_models(
+        "glm",
+        "droid exec --auto medium --model glm-5.1 --reasoning-effort high",
+        str(tmp_path / "missing.json"),
+    )
+    assert capsys.readouterr().err == ""
+
+
+def test_register_from_registry_warns_when_settings_file_missing(tmp_path, capsys):
+    """Missing ~/.factory/settings.json counts as undeclared (fresh machine)."""
+    install_py.warn_missing_custom_models(
+        "minimax",
+        "droid exec --auto medium --model custom:MiniMax-M3",
+        str(tmp_path / "missing.json"),
+    )
+    assert "custom:MiniMax-M3" in capsys.readouterr().err
+
+
 def test_register_from_registry_drops_metadata_fields(tmp_path):
     """Verify that supports_resume/resume_arg/timeout do NOT propagate to
     ~/.claude/trinity.json (they are codex-side metadata only — TRN-3020


### PR DESCRIPTION
## What

Switch the `minimax` provider from MiniMax 2.7 (droid built-in `minimax-m2.7`) to **MiniMax M3** (released 2026-06-01) via droid BYOK reference `custom:MiniMax-M3`.

## Why

M3 brings frontier coding (SWE-Bench Pro 59.0%), 1M context, and native multimodality, but is **not yet in droid's built-in catalog** — only reachable through a `customModels` entry in `~/.factory/settings.json`. This reverses the TRN-3035 built-in-id decision ("avoid coupling to per-machine settings") out of necessity, until droid ships M3 natively — at which point the CLI string can flip back to a built-in id in one line.

## Changes

| Surface | Change |
|---------|--------|
| `providers/registry.json` | CLI → `droid exec --auto medium --model custom:MiniMax-M3` |
| `providers/minimax.delta.md` + rebuilt `providers/minimax.md` | model/brand strings; note that `--reasoning-effort` is unsupported for `custom:` models (dropped) |
| `SKILL.md`, `README.md` | config examples + tables |
| `tests/test_build_providers.sh` | CLI signature assertion updated |
| `CHANGELOG.md` | Unreleased → Changed entry |

## Prerequisite (per-machine)

`~/.factory/settings.json` needs a `customModels` entry with `"model": "MiniMax-M3"`, `"id": "custom:MiniMax-M3"`, base URL `https://api.minimaxi.com/anthropic` (CN) or `https://api.minimax.io/anthropic` (intl), and a MiniMax API key. Already configured on the orchestrator machine.

## Verification

- `bash tests/test_build_providers.sh` → 127/127 pass
- `make test` → full suite green
- Live end-to-end against MiniMax M3: new session ✅, `droid search` session-id extraction ✅, `-s` resume recalled context ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)