### PR TITLE
Add Python 3.14 to PR test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   natively.
 
 ### Added
+- PR CI test matrix now also covers Python 3.14 on both Ubuntu and macOS,
+  matching the local development venv, while preserving the existing
+  `ubuntu-latest` / `macos-latest` aggregate required-check names. Closes #208.
 - PR CI now restores the uv dependency cache in each test matrix leg before
   `make setup`, keyed by `pyproject.toml` and `uv.lock`. Closes #162.
 - GitHub Actions workflow steps are now pinned to full commit SHAs with trailing

--- a/tests/test_test_workflow_matrix.sh
+++ b/tests/test_test_workflow_matrix.sh
@@ -36,7 +36,7 @@ fi
 
 require_file_contains "${WORKFLOW}" 'name: test / \$\{\{ matrix\.os \}\} / Python \$\{\{ matrix\.python-version \}\}' "matrix job name includes OS and Python version"
 require_file_contains "${WORKFLOW}" 'os: \[ubuntu-latest, macos-latest\]' "OS matrix keeps ubuntu and macos"
-require_file_contains "${WORKFLOW}" "python-version: \\['3\\.11', '3\\.12', '3\\.13'\\]" "Python matrix covers 3.11, 3.12, and 3.13"
+require_file_contains "${WORKFLOW}" "python-version: \\['3\\.11', '3\\.12', '3\\.13', '3\\.14'\\]" "Python matrix covers 3.11, 3.12, 3.13, and 3.14"
 require_file_contains "${WORKFLOW}" 'runs-on: \$\{\{ matrix\.os \}\}' "runner uses OS matrix"
 require_file_contains "${WORKFLOW}" 'uses: actions/setup-python@[0-9a-f]{40} # v6' "setup-python action is pinned to SHA"
 require_file_contains "${WORKFLOW}" 'python-version: \$\{\{ matrix\.python-version \}\}' "setup-python uses Python matrix"


### PR DESCRIPTION
## Summary

Adds Python 3.14 to the PR CI test matrix on both Ubuntu and macOS, closing the validation gap between the local development venv (already on 3.14) and CI (previously 3.11–3.13 only).

Closes #208

## Changes

- `.github/workflows/test.yml` — matrix `python-version` now `['3.11', '3.12', '3.13', '3.14']`; the `ubuntu-latest` / `macos-latest` aggregate required-check gate jobs are untouched, so existing branch-protection check names keep working
- `tests/test_test_workflow_matrix.sh` — matrix assertion updated to require 3.14
- `CHANGELOG.md` — entry under `[Unreleased]` / `Added`

## Validation

- `bash tests/test_test_workflow_matrix.sh` — 19/19 PASS
- `make test` — 416 pytest passed + all shell regression suites green
- `make lint` — ruff check + format clean

## Context

Issue #208 was originally dispatched to Assembly (`/assembly`), which failed at `git_push`: its GitHub App lacks the `workflows` permission and the remote rejected the branch. Implemented via the normal agent flow instead, per @frankyxhl's decision on the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
