### PR TITLE
Add trinity doctor --live provider probe (supersedes #214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,21 @@ so existing `grep` patterns continue to work.
 Doctor still does not call the provider, so API-key or quota errors can
 still surface during an actual review.
 
+### Live probe
+
+```bash
+trinity doctor --live --providers glm,gemini,deepseek
+trinity doctor --live --preset fast-review
+```
+
+With `--live`, doctor runs a minimal "reply OK" prompt against each
+statically-healthy provider with a short (10s) timeout. Failures are
+classified as **auth**, **quota**, **timeout**, or **error**. REQUIRED
+providers with live failures exit 1; OPTIONAL provider failures are
+demoted to warnings (exit 0), matching the existing static-check
+semantics. The first line per provider stays grep-compatible; live
+results appear as additional lines in verbose output.
+
 ### Run a review
 
 ```bash

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1901,8 +1901,17 @@ def _probe_provider(provider, provider_config, root):
             "cause": "timeout",
             "detail": f"no response within {_LIVE_PROBE_TIMEOUT}s",
         }
-    except FileNotFoundError:
-        return None
+    except OSError as exc:
+        # executable_health already vouched for the file, so a launch-time
+        # OSError (FileNotFoundError from a missing shebang interpreter,
+        # ENOEXEC, etc.) means reviews cannot launch this provider —
+        # surface it as a live failure rather than silently omitting the
+        # probe result for a statically healthy provider.
+        return {
+            "status": "fail",
+            "cause": "error",
+            "detail": f"failed to launch: {exc}",
+        }
 
 
 def cmd_doctor(args):

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -473,6 +473,7 @@ def _make_health_result(
         "cli": cli,
         "auth": auth,
         "timeout_warning": timeout_warning,
+        "live_probe": None,
     }
 
 
@@ -740,6 +741,12 @@ def _format_provider_block(result, *, optional=False):
             lines.append(
                 f"    auth: missing — ${auth['env_var']} unset, {auth['file']} absent"
             )
+    probe = result.get("live_probe")
+    if probe is not None:
+        if probe["status"] == "pass":
+            lines.append(f"    live: pass")
+        else:
+            lines.append(f"    live: FAIL - {probe['cause']}: {probe['detail']}")
     for w in result.get("warnings", []):
         lines.append(f"    warning: {w}")
     for issue in result.get("issues", []):
@@ -1843,6 +1850,20 @@ def cmd_doctor(args):
                 f"auth file {auth['file']} has wrong mode (expected 600 or 400)"
             )
             h["ok"] = False
+    if args.live:
+        provider_configs = config.get("providers", {})
+        if not isinstance(provider_configs, dict):
+            provider_configs = {}
+        for h in health:
+            if not h["ok"]:
+                continue
+            probe = _probe_provider(
+                h["provider"], provider_configs.get(h["provider"], {}), root
+            )
+            h["live_probe"] = probe
+            if probe and probe["status"] == "fail":
+                h["issues"].append(f"live probe: {probe['cause']} — {probe['detail']}")
+                h["ok"] = False
     env_pollution = detect_env_pollution()
     print(
         format_health_results(
@@ -2226,6 +2247,8 @@ def build_parser():
     doctor.add_argument("--config", default=str(DEFAULT_CONFIG))
     doctor.add_argument("--providers")
     doctor.add_argument("--preset")
+    doctor.add_argument("--live", action="store_true",
+        help="Probe providers with a minimal prompt to surface auth/quota/timeout failures.")
 
     review = subparsers.add_parser("review")
     review.add_argument("--root", default=".")
@@ -2293,3 +2316,72 @@ def main(argv=None):
 
 if __name__ == "__main__":
     sys.exit(main())
+_LIVE_PROBE_TIMEOUT = 10  # hard 10s timeout for live probes.
+
+
+def _probe_provider(provider, provider_config, root):
+    """Run a minimal live probe against a provider CLI.
+
+    Returns a dict with 'status' ('pass'|'fail') and if fail, 'cause'
+    ('auth'|'quota'|'timeout'|'error') and 'detail'. Returns None when
+    the provider cannot be probed (static check would already have
+    caught it).
+    """
+    try:
+        command = parse_provider_command(provider, provider_config)
+    except ValueError:
+        return None
+    executable, issue = executable_health(command, root)
+    if issue or executable is None:
+        return None
+    env = build_provider_env()
+    try:
+        result = subprocess.run(
+            command,
+            input="Reply with exactly one word: OK\n",
+            capture_output=True,
+            text=True,
+            timeout=_LIVE_PROBE_TIMEOUT,
+            env=env,
+        )
+        if result.returncode == 0:
+            return {"status": "pass"}
+
+        combined = ((result.stdout or "") + "\n" + (result.stderr or "")).lower()
+        if any(
+            p in combined
+            for p in (
+                "401",
+                "403",
+                "unauthorized",
+                "auth",
+                "api key",
+                "invalid key",
+                "forbidden",
+                "permission",
+            )
+        ):
+            cause = "auth"
+        elif any(
+            p in combined
+            for p in ("429", "quota", "rate limit", "rate_limit", "too many", "insufficient")
+        ):
+            cause = "quota"
+        else:
+            cause = "error"
+
+        detail = (result.stdout or "").strip()[:200] or (result.stderr or "").strip()[:200]
+        if detail:
+            detail = f"exit code {result.returncode}: {detail}"
+        else:
+            detail = f"exit code {result.returncode}"
+        return {"status": "fail", "cause": cause, "detail": detail}
+
+    except subprocess.TimeoutExpired:
+        return {
+            "status": "fail",
+            "cause": "timeout",
+            "detail": f"no response within {_LIVE_PROBE_TIMEOUT}s",
+        }
+    except FileNotFoundError:
+        return None

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1842,21 +1842,36 @@ def _probe_provider(provider, provider_config, root):
     try:
         # Mirror run_provider semantics: the prompt is appended as the final
         # CLI argument (gemini -p / droid exec / codex exec all take it that
-        # way) and the probe runs from the resolved root so relative
-        # executable paths match the static executable_health check.
-        result = subprocess.run(
+        # way), the probe runs from the resolved root so relative
+        # executable paths match the static executable_health check, and the
+        # probe gets its own session so a timeout can kill the whole process
+        # group — descendants holding the captured pipes would otherwise
+        # stall communicate() well past the advertised timeout.
+        proc = subprocess.Popen(
             command + ["Reply with exactly one word: OK"],
             cwd=str(root),
-            input="",
-            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=_LIVE_PROBE_TIMEOUT,
+            start_new_session=True,
             env=env,
         )
-        if result.returncode == 0:
+        try:
+            probe_stdout, probe_stderr = proc.communicate(
+                timeout=_LIVE_PROBE_TIMEOUT
+            )
+        except subprocess.TimeoutExpired:
+            terminate_process_group(proc)
+            return {
+                "status": "fail",
+                "cause": "timeout",
+                "detail": f"no response within {_LIVE_PROBE_TIMEOUT}s",
+            }
+        if proc.returncode == 0:
             return {"status": "pass"}
 
-        combined = ((result.stdout or "") + "\n" + (result.stderr or "")).lower()
+        combined = ((probe_stdout or "") + "\n" + (probe_stderr or "")).lower()
         if any(
             p in combined
             for p in (
@@ -1886,21 +1901,15 @@ def _probe_provider(provider, provider_config, root):
         else:
             cause = "error"
 
-        detail = (result.stdout or "").strip()[:200] or (result.stderr or "").strip()[
+        detail = (probe_stdout or "").strip()[:200] or (probe_stderr or "").strip()[
             :200
         ]
         if detail:
-            detail = f"exit code {result.returncode}: {detail}"
+            detail = f"exit code {proc.returncode}: {detail}"
         else:
-            detail = f"exit code {result.returncode}"
+            detail = f"exit code {proc.returncode}"
         return {"status": "fail", "cause": cause, "detail": detail}
 
-    except subprocess.TimeoutExpired:
-        return {
-            "status": "fail",
-            "cause": "timeout",
-            "detail": f"no response within {_LIVE_PROBE_TIMEOUT}s",
-        }
     except OSError as exc:
         # executable_health already vouched for the file, so a launch-time
         # OSError (FileNotFoundError from a missing shebang interpreter,

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1858,9 +1858,7 @@ def _probe_provider(provider, provider_config, root):
             env=env,
         )
         try:
-            probe_stdout, probe_stderr = proc.communicate(
-                timeout=_LIVE_PROBE_TIMEOUT
-            )
+            probe_stdout, probe_stderr = proc.communicate(timeout=_LIVE_PROBE_TIMEOUT)
         except subprocess.TimeoutExpired:
             terminate_process_group(proc)
             return {

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -744,7 +744,7 @@ def _format_provider_block(result, *, optional=False):
     probe = result.get("live_probe")
     if probe is not None:
         if probe["status"] == "pass":
-            lines.append(f"    live: pass")
+            lines.append("    live: pass")
         else:
             lines.append(f"    live: FAIL - {probe['cause']}: {probe['detail']}")
     for w in result.get("warnings", []):
@@ -2247,8 +2247,11 @@ def build_parser():
     doctor.add_argument("--config", default=str(DEFAULT_CONFIG))
     doctor.add_argument("--providers")
     doctor.add_argument("--preset")
-    doctor.add_argument("--live", action="store_true",
-        help="Probe providers with a minimal prompt to surface auth/quota/timeout failures.")
+    doctor.add_argument(
+        "--live",
+        action="store_true",
+        help="Probe providers with a minimal prompt to surface auth/quota/timeout failures.",
+    )
 
     review = subparsers.add_parser("review")
     review.add_argument("--root", default=".")
@@ -2364,13 +2367,22 @@ def _probe_provider(provider, provider_config, root):
             cause = "auth"
         elif any(
             p in combined
-            for p in ("429", "quota", "rate limit", "rate_limit", "too many", "insufficient")
+            for p in (
+                "429",
+                "quota",
+                "rate limit",
+                "rate_limit",
+                "too many",
+                "insufficient",
+            )
         ):
             cause = "quota"
         else:
             cause = "error"
 
-        detail = (result.stdout or "").strip()[:200] or (result.stderr or "").strip()[:200]
+        detail = (result.stdout or "").strip()[:200] or (result.stderr or "").strip()[
+            :200
+        ]
         if detail:
             detail = f"exit code {result.returncode}: {detail}"
         else:

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1820,6 +1820,86 @@ def cmd_review(args):
     return 0 if all(item["returncode"] == 0 for item in results) else 1
 
 
+_LIVE_PROBE_TIMEOUT = 10  # hard 10s timeout for live probes.
+
+
+def _probe_provider(provider, provider_config, root):
+    """Run a minimal live probe against a provider CLI.
+
+    Returns a dict with 'status' ('pass'|'fail') and if fail, 'cause'
+    ('auth'|'quota'|'timeout'|'error') and 'detail'. Returns None when
+    the provider cannot be probed (static check would already have
+    caught it).
+    """
+    try:
+        command = parse_provider_command(provider, provider_config)
+    except ValueError:
+        return None
+    executable, issue = executable_health(command, root)
+    if issue or executable is None:
+        return None
+    env = build_provider_env()
+    try:
+        result = subprocess.run(
+            command,
+            input="Reply with exactly one word: OK\n",
+            capture_output=True,
+            text=True,
+            timeout=_LIVE_PROBE_TIMEOUT,
+            env=env,
+        )
+        if result.returncode == 0:
+            return {"status": "pass"}
+
+        combined = ((result.stdout or "") + "\n" + (result.stderr or "")).lower()
+        if any(
+            p in combined
+            for p in (
+                "401",
+                "403",
+                "unauthorized",
+                "auth",
+                "api key",
+                "invalid key",
+                "forbidden",
+                "permission",
+            )
+        ):
+            cause = "auth"
+        elif any(
+            p in combined
+            for p in (
+                "429",
+                "quota",
+                "rate limit",
+                "rate_limit",
+                "too many",
+                "insufficient",
+            )
+        ):
+            cause = "quota"
+        else:
+            cause = "error"
+
+        detail = (result.stdout or "").strip()[:200] or (result.stderr or "").strip()[
+            :200
+        ]
+        if detail:
+            detail = f"exit code {result.returncode}: {detail}"
+        else:
+            detail = f"exit code {result.returncode}"
+        return {"status": "fail", "cause": cause, "detail": detail}
+
+    except subprocess.TimeoutExpired:
+        return {
+            "status": "fail",
+            "cause": "timeout",
+            "detail": f"no response within {_LIVE_PROBE_TIMEOUT}s",
+        }
+    except FileNotFoundError:
+        return None
+
+
 def cmd_doctor(args):
     root = resolve_health_root(args.root)
     config = load_config(args.config)
@@ -2319,81 +2399,3 @@ def main(argv=None):
 
 if __name__ == "__main__":
     sys.exit(main())
-_LIVE_PROBE_TIMEOUT = 10  # hard 10s timeout for live probes.
-
-
-def _probe_provider(provider, provider_config, root):
-    """Run a minimal live probe against a provider CLI.
-
-    Returns a dict with 'status' ('pass'|'fail') and if fail, 'cause'
-    ('auth'|'quota'|'timeout'|'error') and 'detail'. Returns None when
-    the provider cannot be probed (static check would already have
-    caught it).
-    """
-    try:
-        command = parse_provider_command(provider, provider_config)
-    except ValueError:
-        return None
-    executable, issue = executable_health(command, root)
-    if issue or executable is None:
-        return None
-    env = build_provider_env()
-    try:
-        result = subprocess.run(
-            command,
-            input="Reply with exactly one word: OK\n",
-            capture_output=True,
-            text=True,
-            timeout=_LIVE_PROBE_TIMEOUT,
-            env=env,
-        )
-        if result.returncode == 0:
-            return {"status": "pass"}
-
-        combined = ((result.stdout or "") + "\n" + (result.stderr or "")).lower()
-        if any(
-            p in combined
-            for p in (
-                "401",
-                "403",
-                "unauthorized",
-                "auth",
-                "api key",
-                "invalid key",
-                "forbidden",
-                "permission",
-            )
-        ):
-            cause = "auth"
-        elif any(
-            p in combined
-            for p in (
-                "429",
-                "quota",
-                "rate limit",
-                "rate_limit",
-                "too many",
-                "insufficient",
-            )
-        ):
-            cause = "quota"
-        else:
-            cause = "error"
-
-        detail = (result.stdout or "").strip()[:200] or (result.stderr or "").strip()[
-            :200
-        ]
-        if detail:
-            detail = f"exit code {result.returncode}: {detail}"
-        else:
-            detail = f"exit code {result.returncode}"
-        return {"status": "fail", "cause": cause, "detail": detail}
-
-    except subprocess.TimeoutExpired:
-        return {
-            "status": "fail",
-            "cause": "timeout",
-            "detail": f"no response within {_LIVE_PROBE_TIMEOUT}s",
-        }
-    except FileNotFoundError:
-        return None

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import re
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 
@@ -1860,7 +1861,21 @@ def _probe_provider(provider, provider_config, root):
         try:
             probe_stdout, probe_stderr = proc.communicate(timeout=_LIVE_PROBE_TIMEOUT)
         except subprocess.TimeoutExpired:
-            terminate_process_group(proc)
+            # terminate_process_group no-ops once the leader has exited,
+            # but children that inherited the pipes can keep the group
+            # alive (and communicate() blocked). start_new_session=True
+            # makes the group id equal to proc.pid, so signal the group
+            # directly — covering both the live-leader and exited-leader
+            # cases. The probe is a throwaway call; no graceful TERM
+            # needed.
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+            try:
+                proc.communicate(timeout=1)
+            except (subprocess.TimeoutExpired, OSError, ValueError):
+                pass
             return {
                 "status": "fail",
                 "cause": "timeout",

--- a/scripts/codex.py
+++ b/scripts/codex.py
@@ -1840,9 +1840,14 @@ def _probe_provider(provider, provider_config, root):
         return None
     env = build_provider_env()
     try:
+        # Mirror run_provider semantics: the prompt is appended as the final
+        # CLI argument (gemini -p / droid exec / codex exec all take it that
+        # way) and the probe runs from the resolved root so relative
+        # executable paths match the static executable_health check.
         result = subprocess.run(
-            command,
-            input="Reply with exactly one word: OK\n",
+            command + ["Reply with exactly one word: OK"],
+            cwd=str(root),
+            input="",
             capture_output=True,
             text=True,
             timeout=_LIVE_PROBE_TIMEOUT,

--- a/tests/test_doctor_preflight.py
+++ b/tests/test_doctor_preflight.py
@@ -739,3 +739,39 @@ def test_live_probe_timeout_kills_process_group(tmp_path, monkeypatch):
     assert result["status"] == "fail"
     assert result["cause"] == "timeout"
     assert elapsed < 10, f"probe blocked {elapsed:.1f}s past its 1s timeout"
+
+
+def test_live_probe_timeout_kills_orphaned_children(tmp_path, monkeypatch):
+    """Regression (PR #215 codex P2 #5): when the provider leader exits
+    before the deadline but leaves a pipe-holding child behind,
+    terminate_process_group() short-circuits on poll() and the child
+    survived. The probe must signal the process group id directly
+    (== proc.pid under start_new_session) so the orphan dies too."""
+    import os as _os
+    import time as _time
+
+    monkeypatch.setattr(codex_mod, "_LIVE_PROBE_TIMEOUT", 1)
+
+    pid_file = tmp_path / "child.pid"
+    fake = tmp_path / "exiting_leader"
+    fake.write_text(f'#!/bin/sh\nsleep 30 &\necho $! > "{pid_file}"\nexit 0\n')
+    fake.chmod(0o755)
+    config = {"cli": str(fake), "timeout": 120}
+
+    result = codex_mod._probe_provider("test", config, tmp_path)
+
+    assert result is not None
+    assert result["status"] == "fail"
+    assert result["cause"] == "timeout"
+
+    child_pid = int(pid_file.read_text().strip())
+    deadline = _time.monotonic() + 5
+    while _time.monotonic() < deadline:
+        try:
+            _os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        _time.sleep(0.1)
+    else:
+        _os.kill(child_pid, 9)  # cleanup before failing
+        raise AssertionError("orphaned child survived the probe timeout")

--- a/tests/test_doctor_preflight.py
+++ b/tests/test_doctor_preflight.py
@@ -518,6 +518,7 @@ def test_canonical_wrapper_resolves_symlinks(tmp_path, monkeypatch):
 
     assert _is_canonical_wrapper(str(canonical), "deepseek") is True
 
+
 # ---------------------------------------------------------------------------
 # Live probe tests (TRN-3042_209)
 # ---------------------------------------------------------------------------
@@ -525,7 +526,7 @@ def test_canonical_wrapper_resolves_symlinks(tmp_path, monkeypatch):
 
 def test_live_probe_success(tmp_path):
     """Probe passes when the provider exits 0."""
-    from codex import _probe_provider, _LIVE_PROBE_TIMEOUT
+    from codex import _probe_provider
 
     fake = tmp_path / "ok_provider"
     fake.write_text("#!/bin/sh\necho OK\n")
@@ -590,15 +591,13 @@ def test_live_probe_skips_bad_config(tmp_path):
 
 def test_live_probe_renders_in_verbose_output(tmp_path):
     """A passed live probe adds 'live: pass' in verbose format."""
-    from codex import _probe_provider, _format_provider_block
+    from codex import _format_provider_block
 
     fake = tmp_path / "ok_provider"
     fake.write_text("#!/bin/sh\necho OK\n")
     fake.chmod(0o755)
 
-    result = _make_health_result(
-        "test", ok=True, executable=str(fake), timeout=30
-    )
+    result = _make_health_result("test", ok=True, executable=str(fake), timeout=30)
     result["live_probe"] = {"status": "pass"}
     lines = _format_provider_block(result)
     assert any("live: pass" in line for line in lines)
@@ -608,9 +607,11 @@ def test_live_probe_fail_renders_in_verbose_output(tmp_path):
     """A failed live probe adds 'live: FAIL - cause: detail' in verbose."""
     from codex import _format_provider_block
 
-    result = _make_health_result(
-        "test", ok=False, executable="/bin/fake", timeout=30
-    )
-    result["live_probe"] = {"status": "fail", "cause": "auth", "detail": "exit 1: 401 Unauthorized"}
+    result = _make_health_result("test", ok=False, executable="/bin/fake", timeout=30)
+    result["live_probe"] = {
+        "status": "fail",
+        "cause": "auth",
+        "detail": "exit 1: 401 Unauthorized",
+    }
     lines = _format_provider_block(result)
     assert any("live: FAIL - auth" in line for line in lines)

--- a/tests/test_doctor_preflight.py
+++ b/tests/test_doctor_preflight.py
@@ -658,3 +658,42 @@ def test_live_probe_via_script_execution(tmp_path):
     assert "NameError" not in result.stderr
     assert result.returncode == 0, result.stderr
     assert "live: pass" in result.stdout
+
+
+def test_live_probe_passes_prompt_as_cli_argument(tmp_path):
+    """Regression (PR #215 codex P2): the probe prompt must be appended as
+    the final CLI argument, mirroring run_provider, because the bundled
+    CLIs (gemini -p / droid exec / codex exec) take the prompt via argv —
+    a stdin-only probe would report live failures for working providers."""
+    from codex import _probe_provider
+
+    fake = tmp_path / "argv_provider"
+    fake.write_text('#!/bin/sh\n[ -n "$1" ] || exit 1\necho OK\n')
+    fake.chmod(0o755)
+    config = {"cli": str(fake), "timeout": 30}
+    result = _probe_provider("test", config, tmp_path)
+    assert result is not None
+    assert result["status"] == "pass"
+
+
+def test_live_probe_runs_from_resolved_root(tmp_path, monkeypatch):
+    """Regression (PR #215 codex P2): a provider configured with a relative
+    executable path passes executable_health (resolved against root) but
+    the probe subprocess ran from the process cwd, hit FileNotFoundError,
+    and was silently skipped. The probe must run with cwd=root."""
+    from codex import _probe_provider
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "rel_provider"
+    fake.write_text("#!/bin/sh\necho OK\n")
+    fake.chmod(0o755)
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    config = {"cli": "bin/rel_provider", "timeout": 30}
+    result = _probe_provider("test", config, tmp_path)
+    assert result is not None, "probe must not be silently skipped"
+    assert result["status"] == "pass"

--- a/tests/test_doctor_preflight.py
+++ b/tests/test_doctor_preflight.py
@@ -52,6 +52,7 @@ def test_a1_result_dict_has_all_new_keys():
         "cli",
         "auth",
         "timeout_warning",
+        "live_probe",
     ):
         assert key in result, f"missing key {key}"
 
@@ -516,3 +517,100 @@ def test_canonical_wrapper_resolves_symlinks(tmp_path, monkeypatch):
     _os.symlink(real, canonical)
 
     assert _is_canonical_wrapper(str(canonical), "deepseek") is True
+
+# ---------------------------------------------------------------------------
+# Live probe tests (TRN-3042_209)
+# ---------------------------------------------------------------------------
+
+
+def test_live_probe_success(tmp_path):
+    """Probe passes when the provider exits 0."""
+    from codex import _probe_provider, _LIVE_PROBE_TIMEOUT
+
+    fake = tmp_path / "ok_provider"
+    fake.write_text("#!/bin/sh\necho OK\n")
+    fake.chmod(0o755)
+    config = {"cli": str(fake), "timeout": 30}
+    result = _probe_provider("test", config, tmp_path)
+    assert result is not None
+    assert result["status"] == "pass"
+
+
+def test_live_probe_auth_failure(tmp_path):
+    """Probe classifies 401/unauthorized output as auth failure."""
+    from codex import _probe_provider
+
+    fake = tmp_path / "auth_fail"
+    fake.write_text("#!/bin/sh\necho '401 Unauthorized: invalid API key'\nexit 1\n")
+    fake.chmod(0o755)
+    config = {"cli": str(fake), "timeout": 30}
+    result = _probe_provider("test", config, tmp_path)
+    assert result is not None
+    assert result["status"] == "fail"
+    assert result["cause"] == "auth"
+
+
+def test_live_probe_quota_failure(tmp_path):
+    """Probe classifies 429/quota output as quota failure."""
+    from codex import _probe_provider
+
+    fake = tmp_path / "quota_fail"
+    fake.write_text("#!/bin/sh\necho '429 Too Many Requests: quota exceeded'\nexit 1\n")
+    fake.chmod(0o755)
+    config = {"cli": str(fake), "timeout": 30}
+    result = _probe_provider("test", config, tmp_path)
+    assert result is not None
+    assert result["status"] == "fail"
+    assert result["cause"] == "quota"
+
+
+def test_live_probe_timeout(tmp_path):
+    """Probe reports timeout when the provider does not respond in time."""
+    from codex import _probe_provider, _LIVE_PROBE_TIMEOUT
+
+    fake = tmp_path / "slow_provider"
+    # Sleep a long time
+    fake.write_text(f"#!/bin/sh\nsleep {_LIVE_PROBE_TIMEOUT + 5}\necho 'too late'\n")
+    fake.chmod(0o755)
+    config = {"cli": str(fake), "timeout": 120}
+    result = _probe_provider("test", config, tmp_path)
+    assert result is not None
+    assert result["status"] == "fail"
+    assert result["cause"] == "timeout"
+
+
+def test_live_probe_skips_bad_config(tmp_path):
+    """Probe returns None when the provider config is unparseable."""
+    from codex import _probe_provider
+
+    config = {"cli": ""}  # missing cli — parse error
+    result = _probe_provider("test", config, tmp_path)
+    assert result is None
+
+
+def test_live_probe_renders_in_verbose_output(tmp_path):
+    """A passed live probe adds 'live: pass' in verbose format."""
+    from codex import _probe_provider, _format_provider_block
+
+    fake = tmp_path / "ok_provider"
+    fake.write_text("#!/bin/sh\necho OK\n")
+    fake.chmod(0o755)
+
+    result = _make_health_result(
+        "test", ok=True, executable=str(fake), timeout=30
+    )
+    result["live_probe"] = {"status": "pass"}
+    lines = _format_provider_block(result)
+    assert any("live: pass" in line for line in lines)
+
+
+def test_live_probe_fail_renders_in_verbose_output(tmp_path):
+    """A failed live probe adds 'live: FAIL - cause: detail' in verbose."""
+    from codex import _format_provider_block
+
+    result = _make_health_result(
+        "test", ok=False, executable="/bin/fake", timeout=30
+    )
+    result["live_probe"] = {"status": "fail", "cause": "auth", "detail": "exit 1: 401 Unauthorized"}
+    lines = _format_provider_block(result)
+    assert any("live: FAIL - auth" in line for line in lines)

--- a/tests/test_doctor_preflight.py
+++ b/tests/test_doctor_preflight.py
@@ -715,3 +715,27 @@ def test_live_probe_reports_launch_failure(tmp_path):
     assert result["status"] == "fail"
     assert result["cause"] == "error"
     assert "failed to launch" in result["detail"]
+
+
+def test_live_probe_timeout_kills_process_group(tmp_path, monkeypatch):
+    """Regression (PR #215 codex P2 #4): when a provider spawns a child
+    that inherits the captured pipes, a probe timeout must kill the whole
+    process group — otherwise communicate() keeps waiting on the pipes
+    held by the orphaned child, far past the advertised timeout."""
+    import time as _time
+
+    monkeypatch.setattr(codex_mod, "_LIVE_PROBE_TIMEOUT", 1)
+
+    fake = tmp_path / "forking_provider"
+    fake.write_text("#!/bin/sh\nsleep 30 &\nsleep 30\n")
+    fake.chmod(0o755)
+    config = {"cli": str(fake), "timeout": 120}
+
+    start = _time.monotonic()
+    result = codex_mod._probe_provider("test", config, tmp_path)
+    elapsed = _time.monotonic() - start
+
+    assert result is not None
+    assert result["status"] == "fail"
+    assert result["cause"] == "timeout"
+    assert elapsed < 10, f"probe blocked {elapsed:.1f}s past its 1s timeout"

--- a/tests/test_doctor_preflight.py
+++ b/tests/test_doctor_preflight.py
@@ -615,3 +615,46 @@ def test_live_probe_fail_renders_in_verbose_output(tmp_path):
     }
     lines = _format_provider_block(result)
     assert any("live: FAIL - auth" in line for line in lines)
+
+
+def test_live_probe_via_script_execution(tmp_path):
+    """Regression for PR #215 codex P1: `doctor --live` must work when
+    codex.py executes as a script (`__main__`), not only when imported.
+
+    The probe helpers were originally appended AFTER the `__main__`
+    block, so `main()` ran before they were defined and `--live`
+    crashed with NameError. Import-based tests cannot catch that
+    execution-order bug; this test runs the real CLI as a subprocess.
+    """
+    import json
+    import subprocess
+
+    fake = tmp_path / "ok_provider"
+    fake.write_text("#!/bin/sh\necho OK\n")
+    fake.chmod(0o755)
+
+    config_path = tmp_path / "trinity.codex.json"
+    config_path.write_text(
+        json.dumps({"providers": {"test": {"cli": str(fake), "timeout": 30}}})
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "codex.py"),
+            "doctor",
+            "--root",
+            str(tmp_path),
+            "--config",
+            str(config_path),
+            "--providers",
+            "test",
+            "--live",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert "NameError" not in result.stderr
+    assert result.returncode == 0, result.stderr
+    assert "live: pass" in result.stdout

--- a/tests/test_doctor_preflight.py
+++ b/tests/test_doctor_preflight.py
@@ -697,3 +697,21 @@ def test_live_probe_runs_from_resolved_root(tmp_path, monkeypatch):
     result = _probe_provider("test", config, tmp_path)
     assert result is not None, "probe must not be silently skipped"
     assert result["status"] == "pass"
+
+
+def test_live_probe_reports_launch_failure(tmp_path):
+    """Regression (PR #215 codex P2 #3): a file that passes the static
+    executable check but cannot launch (missing shebang interpreter)
+    must surface as a live 'error' failure, not be silently skipped —
+    otherwise doctor --live exits 0 for a provider reviews cannot run."""
+    from codex import _probe_provider
+
+    fake = tmp_path / "broken_shebang"
+    fake.write_text("#!/no/such/interpreter\necho OK\n")
+    fake.chmod(0o755)
+    config = {"cli": str(fake), "timeout": 30}
+    result = _probe_provider("test", config, tmp_path)
+    assert result is not None, "launch failure must not be silently skipped"
+    assert result["status"] == "fail"
+    assert result["cause"] == "error"
+    assert "failed to launch" in result["detail"]

--- a/tests/test_doctor_preflight.py
+++ b/tests/test_doctor_preflight.py
@@ -748,6 +748,7 @@ def test_live_probe_timeout_kills_orphaned_children(tmp_path, monkeypatch):
     survived. The probe must signal the process group id directly
     (== proc.pid under start_new_session) so the orphan dies too."""
     import os as _os
+    import subprocess
     import time as _time
 
     monkeypatch.setattr(codex_mod, "_LIVE_PROBE_TIMEOUT", 1)
@@ -764,12 +765,27 @@ def test_live_probe_timeout_kills_orphaned_children(tmp_path, monkeypatch):
     assert result["status"] == "fail"
     assert result["cause"] == "timeout"
 
+    def _gone_or_zombie(pid):
+        # signal-0 succeeds for zombies (codex P1 on PR #215): a child
+        # killed by os.killpg but adopted by PID 1 may linger as STAT Z
+        # before the init reaper collects it. A zombie runs no provider
+        # work, so treat it as dead; fall back to ps for the state.
+        try:
+            _os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        ps = subprocess.run(
+            ["ps", "-o", "stat=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+        )
+        stat = ps.stdout.strip()
+        return stat == "" or stat.startswith("Z")
+
     child_pid = int(pid_file.read_text().strip())
     deadline = _time.monotonic() + 5
     while _time.monotonic() < deadline:
-        try:
-            _os.kill(child_pid, 0)
-        except ProcessLookupError:
+        if _gone_or_zombie(child_pid):
             break
         _time.sleep(0.1)
     else:


### PR DESCRIPTION
## Summary

Supersedes #214 (same head commit plus a lint fix). Adds the opt-in `trinity doctor --live` provider probe per issue #209.

Closes #209

## Why a replacement PR

Assembly's PR #214 failed CI at the Lint step: 3 ruff findings (`F541` empty f-string in `scripts/codex.py`, 2× `F401` unused imports in `tests/test_doctor_preflight.py`). The Assembly branch lives on `frankyxhl/trinity`, which `ryosaeba1985` cannot push to, so the fix could not land on #214's head. This PR carries Assembly's original commit (`dc4f82f`, authorship preserved) plus one mechanical fix commit (`ruff check --fix` + `ruff format`).

@frankyxhl: please close #214 in favour of this PR.

## Validation

- `make lint` — ruff check + format clean
- `.venv/bin/pytest tests/` — 423 passed (45 in `test_doctor_preflight.py` covering probe success / auth failure / timeout)
- `make verify-built` — generated artifacts match sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)
