### PR TITLE
Add SKILL.md dispatch regression prompt set (supersedes #216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
   natively.
 
 ### Added
+- `samples/regression-prompts.md`: manual regression prompt set for Claude
+  Code SKILL.md dispatch paths (single dispatch, named-instance resume,
+  `provider*N`, preset expansion, reserved words, heartbeat, session
+  output-file resolution), with a TRN-1007 §5 readiness-gate item requiring a
+  run when SKILL.md, `providers/_base/`, or `scripts/session(_path).py`
+  change. Closes #211.
 - PR CI test matrix now also covers Python 3.14 on both Ubuntu and macOS,
   matching the local development venv, while preserving the existing
   `ubuntu-latest` / `macos-latest` aggregate required-check names. Closes #208.

--- a/rules/TRN-1007-SOP-PR-Readiness.md
+++ b/rules/TRN-1007-SOP-PR-Readiness.md
@@ -113,7 +113,7 @@ For new code surfaces, verify each step in the CHG body OR a PR-body checklist. 
 
 - **Install / UI / runtime-spawn changes documented in the PR body** — include the actual command run and expected output, not just "verified locally"
 - **Reproducer for any user-facing behavior change** — small command snippet showing pre/post
-- **SKILL.md regression prompts** — run `samples/regression-prompts.md` manually when the PR touches SKILL.md dispatch syntax, parse order, reserved words, preset definitions, heartbeat shape, or error handling. Pass each prompt's pass criteria before opening the PR.
+- **SKILL.md regression prompts** — run `samples/regression-prompts.md` manually when the PR touches SKILL.md dispatch syntax, parse order, reserved words, preset definitions, heartbeat shape, or error handling — or the other dispatcher surfaces the prompt set names: `providers/_base/` (provider discovery / agent resolution) and `scripts/session.py` / `scripts/session_path.py` (session keys, output capture, heartbeat mechanics). Pass each prompt's pass criteria before opening the PR.
 
 ### §6. Identity (per CLD `CLAUDE.md` global rule)
 

--- a/rules/TRN-1007-SOP-PR-Readiness.md
+++ b/rules/TRN-1007-SOP-PR-Readiness.md
@@ -113,6 +113,7 @@ For new code surfaces, verify each step in the CHG body OR a PR-body checklist. 
 
 - **Install / UI / runtime-spawn changes documented in the PR body** — include the actual command run and expected output, not just "verified locally"
 - **Reproducer for any user-facing behavior change** — small command snippet showing pre/post
+- **SKILL.md regression prompts** — run `samples/regression-prompts.md` manually when the PR touches SKILL.md dispatch syntax, parse order, reserved words, preset definitions, heartbeat shape, or error handling. Pass each prompt's pass criteria before opening the PR.
 
 ### §6. Identity (per CLD `CLAUDE.md` global rule)
 

--- a/samples/regression-prompts.md
+++ b/samples/regression-prompts.md
@@ -1,0 +1,284 @@
+# Trinity — Claude Code Skill Dispatch Regression Prompts
+
+This file is the **manual regression prompt set** for Claude Code's SKILL.md dispatch
+paths — the `/trinity ...` command routing, preset expansion, provider resolution,
+session management, and reserved-word handling.
+
+TRN-1800 (Evolution Philosophy, §Behavior Baseline) establishes the concept of a
+fixed regression sample for behaviour-bearing surfaces. This file is that baseline
+for the Claude Code skill dispatch surface, complementing the automated-pytest
+coverage that already exists for the Codex adapter (`trinity review`).
+
+---
+
+## When to run
+
+Run these prompts manually whenever a PR touches:
+- `SKILL.md` — dispatch syntax, parse order, execution rules, reserved words,
+  preset definitions, heartbeat/shape, or error handling
+- `providers/_base/` — provider discovery or agent resolution logic consumed
+  by the SKILL.md dispatch instructions
+- `scripts/session.py` or `scripts/session_path.py` — session key resolution,
+  output file capture, or heartbeat mechanics referenced from SKILL.md
+
+Each prompt below says what to type in a Claude Code session and what to look
+for in the response. A prompt "passes" when the observed output matches the
+pass criteria for every item listed.
+
+Before the first run, ensure:
+- `make install` has been run from a clean `main` checkout so scripts are current
+- At least one provider is installed (`/trinity install glm` or equivalent)
+- The project directory has a `.claude/trinity.json` with at least one session
+  entry for resume tests (run a dispatch first, e.g. `/trinity glm "hello"`)
+
+---
+
+## 1. Single dispatch
+
+**Prompt:**
+
+```
+/trinity glm "实现用户认证模块"
+```
+
+**Expected route:**
+Parse `glm` as bare provider name → no instance → key `"glm"` → provider discovery
+validates `glm` is usable (config entry + agent file present) → spawn `Agent(
+subagent_type="general-purpose", name="glm", …)` with prompt prefixed by
+`~/.claude/agents/trinity-glm.md` → record session entry under `sessions.glm`.
+
+**Pass criteria:**
+
+- [ ] Launch summary shows one entry, e.g. `GLM → 实现用户认证模块 (background)`
+- [ ] The task text `实现用户认证模块` appears verbatim in the prompt template
+- [ ] `.claude/trinity.json` gains a `sessions.glm` entry with `start_time`,
+      `output_file`, `task_type: "general"`, `stopped: false`
+- [ ] If `task` contains `review`/`tdd`/`prp` keywords → `task_type` reflects that
+
+---
+
+## 2. Named-instance resume
+
+**Prompt:**
+
+```
+/trinity glm:auth "继续实现认证模块"
+```
+
+**Expected route:**
+Parse `glm:auth` → base=`glm`, instance=`auth` → key `"glm:auth"` → provider
+discovery validates `glm` is usable → spawn `Agent(name="glm:auth", …)` with
+prompt prefixed by `~/.claude/agents/trinity-glm.md` and referencing key
+`"glm:auth"` → if `sessions.glm:auth` already exists, the subagent process
+resumes from prior state.
+
+**Pass criteria:**
+
+- [ ] Launch summary shows `GLM:auth → 继续实现认证模块 (background)`
+- [ ] The `:auth` instance suffix is preserved in the agent name and session key
+- [ ] `.claude/trinity.json` `sessions.glm:auth` is created (or updated if resuming)
+- [ ] Consecutive dispatches to `glm:auth` produce the same session key (resume,
+      not a new session each time)
+
+---
+
+## 3. `provider*N` parallel
+
+**Prompt:**
+
+```
+/trinity glm*2 "分别实现 auth 和 order 模块"
+```
+
+**Expected route:**
+Parse `glm*2` → base=`glm`, count=`2` → spawn 2 agents with auto-generated
+instance keys `glm:<uuid4-hex6>` → each gets its own independent session entry.
+Both run the same task text.
+
+**Pass criteria:**
+
+- [ ] Launch summary shows two entries, e.g.:
+      ```
+      GLM:a1b2c3 → 分别实现 auth 和 order 模块 (background)
+      GLM:d4e5f6 → 分别实现 auth 和 order 模块 (background)
+      ```
+- [ ] `.claude/trinity.json` has two distinct session keys (`glm:a1b2c3`,
+      `glm:d4e5f6`) with separate `session_id`, `output_file`, `start_time`
+- [ ] Both agents receive the same task text
+- [ ] Each agent independently tracks its own heartbeat/progress
+
+---
+
+## 4. Preset expansion — review
+
+**Prompt:**
+
+```
+/trinity review "review auth 代码"
+```
+
+**Expected route:**
+Parse `review` → matched as preset name → expand to required providers
+(`glm`, `gemini`, `deepseek`) + optional providers (`codex`, `claude-code`) →
+for each usable provider, dispatch the same task `"review auth 代码"` → optional
+providers that are missing (config/agent file absent) show a warning and are
+skipped.
+
+**Pass criteria:**
+
+- [ ] Launch summary shows dispatch to every **required** provider that is usable,
+      e.g. `GLM → review auth 代码 (background)`, `DeepSeek → review auth 代码 (background)`
+- [ ] If `gemini` has no agent file → output shows `⚠️ gemini (optional): missing agent file`
+      and continues (does not abort)
+- [ ] If `codex`/`claude-code` are present → they appear in the dispatch list
+- [ ] Each dispatched entry gets the **same task text**
+- [ ] `.claude/trinity.json` records a `task_type: "review"` for each dispatched agent
+
+---
+
+## 5. Preset alias — fr (fast-review)
+
+**Prompt:**
+
+```
+/trinity fr "quick review of auth code"
+```
+
+**Expected route:**
+Parse `fr` → alias resolution → `fast-review` preset → required providers
+(`glm`, `deepseek`) → dispatch the same task to each usable provider.
+No optional providers in fast-review.
+
+**Pass criteria:**
+
+- [ ] Launch summary shows dispatch to `GLM` and `DeepSeek` with task
+      `quick review of auth code`
+- [ ] No optional-provider warnings (fast-review has no optional list)
+- [ ] Same task text sent to both providers
+
+---
+
+## 6. Reserved-word rejection — status
+
+**Prompt:**
+
+```
+/trinity status
+```
+
+**Expected route:**
+Parse `status` → matched as built-in subcommand first (dispatch order rule 1) →
+run status mode: provider discovery, display registered providers, configured
+presets, and active sessions. The quoted string (if present) is ignored.
+
+**Pass criteria:**
+
+- [ ] Output shows **provider status section** with at least one registered provider
+      (e.g. `glm  ✅ usable`)
+- [ ] Output shows **preset table** (`review`, `fast-review`, `deep-review`)
+- [ ] Output shows **active sessions** (or "No active sessions")
+- [ ] No agent is spawned — this is a read-only status check
+- [ ] A trailing argument like `/trinity status "do something"` still runs status
+      mode and ignores the extraneous text
+
+---
+
+## 7. Reserved-word rejection — clear (with confirmed side effect)
+
+**Prompt:**
+
+```
+/trinity clear glm:auth
+```
+
+**Expected route:**
+Parse `clear` → built-in subcommand → synchronous clear operation on
+`.claude/trinity.json` sessions → remove `glm:auth` session key → confirm.
+
+**Pass criteria:**
+
+- [ ] Output confirms deletion, e.g. `Cleared session glm:auth`
+- [ ] `.claude/trinity.json` `sessions.glm:auth` no longer exists
+- [ ] `/trinity clear all` clears all sessions and confirms
+
+---
+
+## 8. Heartbeat output shape
+
+**Prompt (run after a dispatch is in progress):**
+
+```
+/trinity heartbeat
+```
+
+(Or `/trinity heartbeat glm:auth` for a single-instance check.)
+
+**Expected route:**
+On-demand heartbeat → for each agent with `output_file` set and
+`stopped: false`, read the output JSONL file, parse last activity, compare line
+counts, display liveness status. Update `last_line_count` and `last_heartbeat`
+in `.claude/trinity.json`.
+
+**Pass criteria:**
+
+- [ ] Output uses the expected columnar format, e.g.:
+      ```
+      GLM:auth    🔄 alive    +23 lines   [4m 12s]   Bash: pytest -v
+      ```
+- [ ] Each line shows: provider:instance, emoji status, line delta, elapsed time,
+      and last activity summary
+- [ ] Status emoji is one of: `🔄 alive`, `⚠️ possibly stalled`, `🟡 starting`,
+      `❌ failed to start`, `✅ done`
+- [ ] `.claude/trinity.json` `last_line_count` and `last_heartbeat` are updated
+      for each checked agent
+- [ ] A single-instance heartbeat (`/trinity heartbeat glm:auth`) only checks
+      that one entry
+
+---
+
+## 9. Multi-provider parallel dispatch
+
+**Prompt:**
+
+```
+/trinity glm "实现认证模块" codex "review 认证代码"
+```
+
+**Expected route:**
+Parse two `(provider, task)` pairs → `glm` dispatched with task
+`"实现认证模块"`, `codex` dispatched with task `"review 认证代码"` →
+both run as background agents concurrently.
+
+**Pass criteria:**
+
+- [ ] Launch summary shows both entries, e.g.:
+      ```
+      Dispatched:
+      - GLM → 实现认证模块 (background)
+      - Codex → review 认证代码 (background)
+      ```
+- [ ] Each provider independently records a `sessions` entry with the correct
+      task text and `task_type`
+- [ ] `codex` entry has `task_type: "review"` (keyword match); `glm` entry has
+      `task_type: "general"` (or `tdd`/`prp` depending on exact task text)
+
+---
+
+## 10. Unknown provider rejection
+
+**Prompt:**
+
+```
+/trinity nonexistent "do something"
+```
+
+**Expected route:**
+Parse `nonexistent` → not a built-in subcommand, not a preset/alias, not a known
+provider → provider discovery runs → `nonexistent` not found → error reported.
+
+**Pass criteria:**
+
+- [ ] Output reports an error: "Unknown provider: nonexistent" (or similar wording)
+- [ ] Error lists available providers the user can install instead
+- [ ] No agent is spawned
+- [ ] No session entry is created

--- a/samples/regression-prompts.md
+++ b/samples/regression-prompts.md
@@ -288,3 +288,35 @@ provider → provider discovery runs → `nonexistent` not found → error repor
 - [ ] Error lists available providers the user can install instead
 - [ ] No agent is spawned
 - [ ] No session entry is created
+
+---
+
+## 11. Session output-file resolution (session.py / session_path.py surface)
+
+**Prompt:**
+
+```
+/trinity glm "print hello and exit"
+```
+
+then, after the launch summary appears:
+
+```
+/trinity heartbeat glm
+```
+
+**Expected route:**
+Dispatch records `sessions.glm.output_file` via the session-path resolution
+helpers (`scripts/session.py` / `scripts/session_path.py`) → heartbeat resolves
+that same path, reads the transcript, and reports liveness with a line count.
+
+**Pass criteria:**
+
+- [ ] `.claude/trinity.json` `sessions.glm.output_file` is an **absolute path to a
+      file that exists on disk** at the time of the heartbeat (not a placeholder,
+      not a dangling path)
+- [ ] `/trinity heartbeat glm` reads that file successfully — it reports a state
+      (`alive`/`stalled`/`done`) plus a `+N lines` delta, with no "file not found"
+      or path-resolution error
+- [ ] After the agent finishes, a second heartbeat reflects the terminal state
+      instead of erroring on the resolved path

--- a/samples/regression-prompts.md
+++ b/samples/regression-prompts.md
@@ -320,3 +320,35 @@ that same path, reads the transcript, and reports liveness with a line count.
       or path-resolution error
 - [ ] After the agent finishes, a second heartbeat reflects the terminal state
       instead of erroring on the resolved path
+
+---
+
+## 12. Transcript resolution via `trinity session-path` (session_path.py surface)
+
+The `output_file` check above covers `scripts/session.py`; the
+`scripts/session_path.py` resolver is a different mechanism — it maps
+`sessions.<key>.session_id` to the provider's transcript file and is wired
+through the `trinity session-path` CLI subcommand, not through dispatch or
+heartbeat. Exercise it directly.
+
+**Prompt:** after at least one `/trinity glm "..."` dispatch has completed, run
+in a terminal at the project root:
+
+```
+trinity session-path glm
+```
+
+**Expected route:**
+`cmd_session_path` normalizes the lookup key (`glm` ≡ `glm:default`) → reads
+`sessions.glm.session_id` from `.claude/trinity.json` → validates the id format
+→ dispatches to the glm resolver → prints the resolved transcript path.
+
+**Pass criteria:**
+
+- [ ] `.claude/trinity.json` `sessions.glm` contains a non-empty `session_id`
+- [ ] `trinity session-path glm` exits 0 and prints a single absolute path to a
+      file that exists on disk
+- [ ] `trinity session-path glm:default` prints the same path (suffix
+      normalization)
+- [ ] `trinity session-path nonexistent` exits non-zero with
+      `no session pointer for 'nonexistent'` on stderr (no traceback)

--- a/samples/regression-prompts.md
+++ b/samples/regression-prompts.md
@@ -332,10 +332,12 @@ through the `trinity session-path` CLI subcommand, not through dispatch or
 heartbeat. Exercise it directly.
 
 **Prompt:** after at least one `/trinity glm "..."` dispatch has completed, run
-in a terminal at the project root:
+in a terminal **at the repo checkout of the branch under review** (invoking the
+branch script directly — the installed `trinity` wrapper comes from
+`make install-codex` and may be missing or stale in a Claude-only setup):
 
 ```
-trinity session-path glm
+python3 scripts/codex.py session-path glm
 ```
 
 **Expected route:**
@@ -346,9 +348,9 @@ trinity session-path glm
 **Pass criteria:**
 
 - [ ] `.claude/trinity.json` `sessions.glm` contains a non-empty `session_id`
-- [ ] `trinity session-path glm` exits 0 and prints a single absolute path to a
+- [ ] `python3 scripts/codex.py session-path glm` exits 0 and prints a single absolute path to a
       file that exists on disk
-- [ ] `trinity session-path glm:default` prints the same path (suffix
+- [ ] `... session-path glm:default` prints the same path (suffix
       normalization)
-- [ ] `trinity session-path nonexistent` exits non-zero with
+- [ ] `... session-path nonexistent` exits non-zero with
       `no session pointer for 'nonexistent'` on stderr (no traceback)

--- a/samples/regression-prompts.md
+++ b/samples/regression-prompts.md
@@ -26,7 +26,10 @@ for in the response. A prompt "passes" when the observed output matches the
 pass criteria for every item listed.
 
 Before the first run, ensure:
-- `make install` has been run from a clean `main` checkout so scripts are current
+- `make install` has been run **from the branch/commit under review** so the
+  candidate `SKILL.md` and scripts are what gets exercised — installing from a
+  clean `main` checkout would smoke-test the baseline skill instead of the
+  PR's changed dispatcher
 - At least one provider is installed (`/trinity install glm` or equivalent)
 - The project directory has a `.claude/trinity.json` with at least one session
   entry for resume tests (run a dispatch first, e.g. `/trinity glm "hello"`)
@@ -128,8 +131,11 @@ skipped.
 
 - [ ] Launch summary shows dispatch to every **required** provider that is usable,
       e.g. `GLM → review auth 代码 (background)`, `DeepSeek → review auth 代码 (background)`
-- [ ] If `gemini` has no agent file → output shows `⚠️ gemini (optional): missing agent file`
-      and continues (does not abort)
+- [ ] If `gemini` (a **required** provider) has no agent file → the preset
+      expansion reports it as a required-provider failure (not an optional
+      warning); the run must not silently continue as if the set were complete
+- [ ] If `codex`/`claude-code` (optional) are missing → output shows an
+      `⚠️ (optional)` warning and dispatch continues with the required set
 - [ ] If `codex`/`claude-code` are present → they appear in the dispatch list
 - [ ] Each dispatched entry gets the **same task text**
 - [ ] `.claude/trinity.json` records a `task_type: "review"` for each dispatched agent


### PR DESCRIPTION
## Summary

Supersedes #216 (same Assembly commit plus codex-review fixes). Adds the manual regression prompt set for Claude Code SKILL.md dispatch paths per issue #211.

Closes #211

## Why a replacement PR

codex review on #216 raised 3 findings (1 P1 + 2 duplicate P2s), all valid; the Assembly branch lives on `frankyxhl/trinity` which `ryosaeba1985` cannot push to (same constraint as #215 superseding #214). This PR carries Assembly's commit (`d8dd475`, authorship preserved) plus one fix commit:

- **P1** — setup instructions installed the skill from a clean `main` checkout, which would smoke-test the *baseline* SKILL.md instead of the PR's candidate change; now installs from the branch under review
- **P2 ×2** — the review-preset pass criterion treated a missing `gemini` agent file as an optional warning, contradicting the preset definition (gemini is REQUIRED); now a required-provider failure, with the optional-warning path pointed at `codex`/`claude-code`

## Validation

- `af validate --root .` — 148 documents, 0 issues
- Docs-only change; CI test legs skip via paths filter as designed

@frankyxhl: please close #216 in favour of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
